### PR TITLE
dockerize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ open http://localhost:8080
 The artifact is a Spring Boot executable jar so you can just run it. Just as when running from the IDE the default
 is to run without a configuration server so the configuration must be specified on the command line:
 ```bash
-java -jar build/libs/rdw-reporting-ui*.jar --spring.config.location=/opt/rdw-reporting/config/application.yml
+java -jar build/libs/rdw-reporting*.jar --spring.config.location=/opt/rdw-reporting/config/application.yml
 open http://localhost:8080
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ configuration, either:
 * In the Run/Debug Configurations dialog, hit ^N (ctrl-n) and select Spring Boot
 	* For the new configuration, name it as you wish
 	* Main class: org.opentestsystem.rdw.reporting.Application
-	* Program arguments: --spring.config.location=/opt/rdw-reporting/application.yml
+	* Program arguments: --spring.config.location=/opt/rdw-reporting/config/application.yml
 	* Use classpath of module: rdw-reporting-service_main
 	
 OR
@@ -44,18 +44,18 @@ OR
 	* For the new configuration, name it as you wish
 	* In Gradle Project: Select RDW_Reporting
 	* In Tasks: Enter bootRun as the Task
-	* In Script Parameters: -PjvmArgs="-Dspring.config.location=/opt/rdw-reporting/application.yml"
+	* In Script Parameters: -PjvmArgs="-Dspring.config.location=/opt/rdw-reporting/config/application.yml"
 
 #### Running Using Gradle
-```
-gradle bootRun -PjvmArgs="-Dspring.config.location=/opt/rdw-reporting/application.yml"
+```bash
+gradle bootRun -PjvmArgs="-Dspring.config.location=/opt/rdw-reporting/config/application.yml"
 open http://localhost:8080
 ```
 #### Running Standalone
 The artifact is a Spring Boot executable jar so you can just run it. Just as when running from the IDE the default
 is to run without a configuration server so the configuration must be specified on the command line:
-```
-java -jar build/libs/rdw-reporting-ui*.jar --spring.config.location=/opt/rdw-reporting/application.yml
+```bash
+java -jar build/libs/rdw-reporting-ui*.jar --spring.config.location=/opt/rdw-reporting/config/application.yml
 open http://localhost:8080
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ store file, and the credentials to read it must be provided in a spring configur
 will contain entries similar to (passwords redacted):
 ```text
 saml:
-  key-store-file: file:/opt/rdw-reporting-ui/config/saml.jks
+  key-store-file: file:/opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
   key-store-password: [redacted]
   private-key-entry-alias: rdw-reporting-ui-sp
   private-key-entry-password: [redacted]
@@ -30,9 +30,9 @@ mkdir -p /opt/rdw-reporting-ui/config
 
 # download the application.yml and saml.jks made for your local environment into this directory
 curl <application_properties_url> > /opt/rdw-reporting-ui/config/application.yml
-curl <saml_jks_url> > /opt/rdw-reporting-ui/config/saml.jks
+curl <saml_jks_url> > /opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
 ```
-_There is nothing magical about the location of the files, but being consistent will make things easier._ 
+_There is nothing magical about the location and names of the files, but being consistent will make things easier._ 
 
 #### MySQL
 MySQL is required for building (integration tests) and running this application. To better match production, MySQL
@@ -63,7 +63,7 @@ mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
 mysql> exit
 ```
 
-The applications depend on the database being configured properly. This is done using RDW_Schema.
+The service depends on the database being configured properly. This is done using RDW_Schema.
 ```bash
 git clone https://github.com/SmarterApp/RDW_Schema
 cd RDW_Schema
@@ -92,8 +92,46 @@ gradle build
 
 Code coverage reports can be found under `./build/reports/jacoco/test/html/index.html` 
 
-TODO - building docker images
+You must explicitly build the docker images:
+```bash
+$ gradle buildImage
+$ docker images
+REPOSITORY                              TAG                 IMAGE ID            CREATED             SIZE
+fwsbac/rdw-reporting-service            latest              da5207b421c0        30 seconds ago      150 MB
+fwsbac/configuration-service            latest              1b41406534c7        2 weeks ago         221 MB
+java                                    8-jre-alpine        d85b17c6762e        6 weeks ago         108 MB
+```
+
+After cycling through some builds you will end up with a number of dangling images, e.g.:
+```bash
+$ docker images
+REPOSITORY                          TAG                 IMAGE ID            CREATED             SIZE
+fwsbac/rdw-reporting-service        latest              da5207b421c0        30 seconds ago      150 MB
+<none>                              <none>              13b96a973d59        About an hour ago   140 MB
+<none>                              <none>              cb5063cbcc56        2 hours ago         140 MB
+<none>                              <none>              2236259b73f0        3 hours ago         140 MB
+```
+These can be quickly cleaned up:
+```bash
+$ docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
+$ docker images
+REPOSITORY                          TAG                 IMAGE ID            CREATED             SIZE
+fwsbac/rdw-reporting-service        latest              da5207b421c0        30 seconds ago      150 MB
+```
 
 ### Running
 The apps are wrapped in docker containers and should be built and run that way. There is a docker-compose spec
-to make it easy: TODO
+to make it easier: it runs the configuration server and the reporting service with the correct profile. Please 
+read the comments in the docker-compose script for setting required environment variables. You must place the 
+development SAML key store file in the config folder (as described above; note the localapplication.yml file is 
+not needed), then invoke docker-compose, e.g.:
+```bash
+# copy development SAML key store file
+mkdir -p /opt/rdw-reporting-ui/config
+curl <saml_jks_url> > /opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
+# use docker-compose to launch service
+cd docker
+docker-compose up -d
+docker logs -f docker_reporting-service_1
+```
+You may now navigate to `http://localhost:8080` in a browser. You'll need ART credentials.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ store file, and the credentials to read it must be provided in a spring configur
 will contain entries similar to (passwords redacted):
 ```text
 saml:
-  key-store-file: file:/opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
+  key-store-file: file:/opt/rdw-reporting/config/saml.jks
   key-store-password: [redacted]
   private-key-entry-alias: rdw-reporting-ui-sp
   private-key-entry-password: [redacted]
@@ -26,11 +26,11 @@ saml:
 For developers with access to internal resources there is a keystore and yml file available to download:
 ```bash
 # create a local application data folder
-mkdir -p /opt/rdw-reporting-ui/config
+mkdir -p /opt/rdw-reporting-/config
 
 # download the application.yml and saml.jks made for your local environment into this directory
-curl <application_properties_url> > /opt/rdw-reporting-ui/config/application.yml
-curl <saml_jks_url> > /opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
+curl <application_properties_url> > /opt/rdw-reporting-/config/application.yml
+curl <saml_jks_url> > /opt/rdw-reporting/config/saml.jks
 ```
 _There is nothing magical about the location and names of the files, but being consistent will make things easier._ 
 
@@ -127,8 +127,8 @@ development SAML key store file in the config folder (as described above; note t
 not needed), then invoke docker-compose, e.g.:
 ```bash
 # copy development SAML key store file
-mkdir -p /opt/rdw-reporting-ui/config
-curl <saml_jks_url> > /opt/rdw-reporting-ui/config/rdw-reporting-ui.jks
+mkdir -p /opt/rdw-reporting/config
+curl <saml_jks_url> > /opt/rdw-reporting/config/saml.jks
 # use docker-compose to launch service
 cd docker
 docker-compose up -d

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ task createDockerfile(type: Dockerfile) {
     destFile = project.file('build/docker/Dockerfile')
     from('java:8-jre-alpine')
     volume('/tmp')
-    volume('/opt/rdw-reporting-ui/config')
+    volume('/opt/rdw-reporting/config')
     label([maintainer: 'Fairway Technologies'])
     copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
     exposePort(8080)

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,15 @@ buildscript {
         maven { url 'http://repo.spring.io/plugins-release' }
     }
     dependencies {
+        classpath("com.bmuschko:gradle-docker-plugin:3.0.5")
         classpath('org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE')
         classpath('org.springframework.build.gradle:propdeps-plugin:0.0.7')
     }
 }
+
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
 plugins {
     id "com.moowork.node" version "1.1.1"
@@ -25,6 +30,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'jacoco'
 apply plugin: 'net.ltgt.apt'
+apply plugin: 'com.bmuschko.docker-remote-api'
 
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.springframework.boot'
@@ -117,3 +123,45 @@ task buildFe(type: NpmTask) {
 // In order to get the front end resources in to the final jar, the front end needs to be built
 // before all of the other resources are processed in order to get the static resouces in the right place
 processResources.dependsOn buildFe
+
+// task to generate build-info.properties with build.version, build.timestamp
+// using this approach instead of resource filtering to avoid modifying source
+task createBuildInfoFile(dependsOn: processResources) {
+    doLast {
+        def buildInfoFile = new File("${buildDir}/resources/main/build-info.properties")
+        buildInfoFile.parentFile.mkdirs()
+        Properties props = new Properties()
+        props.setProperty('build.version', project.version.toString())
+        props.store(buildInfoFile.newWriter(), null)
+    }
+}
+
+// trigger creation of build-info.properties
+classes.dependsOn(createBuildInfoFile)
+
+
+// task to create Dockerfile
+// (http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html)
+task createDockerfile(type: Dockerfile) {
+    destFile = project.file('build/docker/Dockerfile')
+    from('java:8-jre-alpine')
+    volume('/tmp')
+    volume('/opt/rdw-reporting-ui/config')
+    label([maintainer: 'Fairway Technologies'])
+    copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
+    exposePort(8080)
+    entryPoint("java", "-jar", "${jar.archivePath.name}")
+}
+
+// task to build the docker image
+task buildImage(type:DockerBuildImage, dependsOn:[build, createDockerfile]) {
+    dockerFile = createDockerfile.destFile
+    inputDir = project.file('build/docker/')
+    tag = "fwsbac/${project.name}"
+    doFirst {
+        copy {
+            from jar
+            into inputDir
+        }
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,8 @@
 # GIT_PASSWORD - password for GIT_USER
 #
 # This configuration maps the config folder as outlined in CONTRIBUTING.md and the application.yml file from the config
-# server local-docker profile points to that folder so developers should be able to reuse the rdw-reporting-ui.jks file
-# (NOTE: developers may have to explicitly share the folder in Docker, Preferences, File Sharing)
+# server local-docker profile points to that folder so developers should be able to reuse the saml.jks file
+# (NOTE: developers may have to explicitly share the /opt folder in Docker, Preferences, File Sharing)
 
 version: '2'
 services:
@@ -34,7 +34,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - /opt/rdw-reporting-ui/config:/opt/rdw-reporting-ui/config
+      - /opt/rdw-reporting/config:/opt/rdw-reporting/config
     depends_on:
       - config-server
     links:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,47 @@
+# docker-compose specs for rdw reporting service with the configuration server
+# running in a container and MySQL running natively (outside the containers).
+#
+# The following environment variables MUST be set before running this spec:
+#
+# DATAWAREHOUSE_HOST - host running mysql with rdw reporting schema initialized
+# For mac developers running mysql natively, something like:
+#   $ export DATAWAREHOUSE_HOST=$(ipconfig getifaddr en0)
+# This value may have to be reset when you change networks.
+#
+# CONFIG_SERVICE_REPO - git repo url, e.g. https://gitlab.com/fairwaytech/sbac-config-repo.git
+# GIT_USER - user with rights to access CONFIG_SERVICE_REPO
+# GIT_PASSWORD - password for GIT_USER
+#
+# This configuration maps the config folder as outlined in CONTRIBUTING.md and the application.yml file from the config
+# server local-docker profile points to that folder so developers should be able to reuse the rdw-reporting-ui.jks file
+# (NOTE: developers may have to explicitly share the folder in Docker, Preferences, File Sharing)
+
+version: '2'
+services:
+  config-server:
+    image: fwsbac/configuration-service:latest
+    container_name: config-server
+    ports:
+      - 8888:8888
+    environment:
+      - CONFIG_SERVICE_REPO
+      - ENCRYPT_KEY
+      - GIT_USER
+      - GIT_PASSWORD
+
+  reporting-service:
+    image: fwsbac/rdw-reporting-service
+    ports:
+      - 8080:8080
+    volumes:
+      - /opt/rdw-reporting-ui/config:/opt/rdw-reporting-ui/config
+    depends_on:
+      - config-server
+    links:
+      - config-server
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"

--- a/src/main/webapp/README.md
+++ b/src/main/webapp/README.md
@@ -11,7 +11,7 @@ ng test
 ### Run ###
 ```
 #!bash
-ng serve --proxy-config /opt/rdw-reporting-ui/config/proxy.conf.json
+ng serve --proxy-config /opt/rdw-reporting/config/proxy.conf.json
 ```
 To run in standalone mode with static data, add the below arguments:
 ```


### PR DESCRIPTION
This adds docker-compose capability at least for local-docker (i didn't put the pushImage stuff in yet).

Everybody please note that i've tried to make the naming and location of the keystore consistent. To make it easy to reuse you should have: `/opt/rdw-reporting-ui/config/rdw-reporting-ui.jks`. The local external application.yml can be wherever you want but it should point to that exact JKS file. Otherwise you'll have to have a different copy when running from docker.
