### PR TITLE
Feature/group assessments

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/Assessment.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/Assessment.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.reporting.assessment;
 
+import java.util.Objects;
+
 /**
  * Represents an assessment taken by an individual or group
  */
@@ -10,6 +12,7 @@ public class Assessment {
     private long gradeId;
     private long typeId;
     private long subjectId;
+    private long schoolYear;
 
     /**
      * @return the assessment entity ID
@@ -46,6 +49,35 @@ public class Assessment {
         return subjectId;
     }
 
+    /**
+     * @return the school year the assessment was designed for
+     */
+    public long getSchoolYear() {
+        return schoolYear;
+    }
+
+    /**
+     * This allows IAB and ICA/Summative exam's to not collide in {@link java.util.Set}s
+     *
+     * @param o the object to compare
+     * @return <code>true</code> if the given object is an Assessment and has the same entity ID and type ID
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final Assessment that = (Assessment) o;
+        return id == that.id && typeId == that.typeId;
+    }
+
+    /**
+     * @return hash code based on the Assessment's entity ID and type ID
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, typeId);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -57,6 +89,7 @@ public class Assessment {
         private long gradeId;
         private long typeId;
         private long subjectId;
+        private long schoolYear;
 
         public Builder id(final long id) {
             this.id = id;
@@ -83,6 +116,11 @@ public class Assessment {
             return this;
         }
 
+        public Builder schoolYear(final long schoolYear) {
+            this.schoolYear = schoolYear;
+            return this;
+        }
+
         public Assessment build() {
             final Assessment assessment = new Assessment();
             assessment.id = id;
@@ -90,6 +128,7 @@ public class Assessment {
             assessment.gradeId = gradeId;
             assessment.typeId = typeId;
             assessment.subjectId = subjectId;
+            assessment.schoolYear = schoolYear;
             return assessment;
         }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/DefaultGroupAssessmentService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/DefaultGroupAssessmentService.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.assessment;
 
+import com.google.common.collect.ImmutableList;
 import org.opentestsystem.rdw.reporting.exam.GroupExam;
 import org.opentestsystem.rdw.reporting.exam.repository.GroupIcaSummativeExamRepository;
 import org.opentestsystem.rdw.reporting.exam.repository.GroupIabExamRepository;
@@ -33,7 +34,7 @@ public class DefaultGroupAssessmentService implements GroupAssessmentService {
         this.groupIcaSummativeExamRepository = groupIcaSummativeExamRepository;
     }
 
-    public Optional<Assessment> getLatest(@NotNull final User user, final long groupId, final long schoolYear) {
+    public Optional<Assessment> getLatestAssessment(@NotNull final User user, final long groupId, final long schoolYear) {
 
         // assured not null by spring security annotation
         final GroupGrant groupGrant = user.getGroupsById().get(groupId);
@@ -56,6 +57,24 @@ public class DefaultGroupAssessmentService implements GroupAssessmentService {
         exams.sort(groupExamCompletedDateTimeComparator);
 
         return Optional.of(exams.get(0).getAssessment());
+    }
+
+    @Override
+    public List<Assessment> getAllAssessments(@NotNull final User user, final long groupId, final long schoolYear) {
+
+        // assured not null by spring security annotation
+        final GroupGrant groupGrant = user.getGroupsById().get(groupId);
+        final PermissionScope permissionScope = user.getPermissionsById().get("GROUP_PII_READ").getScope();
+
+        final ImmutableList.Builder<Assessment> assessments = ImmutableList.builder();
+
+        assessments.addAll(groupIabExamRepository
+                .findAll(groupGrant.getId(), groupGrant.getSubjectId(), schoolYear, permissionScope));
+
+        assessments.addAll(groupIcaSummativeExamRepository
+                .findAll(groupGrant.getId(), groupGrant.getSubjectId(), schoolYear, permissionScope));
+
+        return assessments.build();
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/GroupAssessmentService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/GroupAssessmentService.java
@@ -4,6 +4,7 @@ import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -21,6 +22,9 @@ public interface GroupAssessmentService {
      * @return the most recent assessment or an empty optional if there is no assessment found
      */
     @PreAuthorize("hasAuthority('PERM_GROUP_PII_READ') and #user.getGroupsById().containsKey(#groupId)")
-    Optional<Assessment> getLatest(@NotNull User user, long groupId, long schoolYear);
+    Optional<Assessment> getLatestAssessment(@NotNull User user, long groupId, long schoolYear);
+
+    @PreAuthorize("hasAuthority('PERM_GROUP_PII_READ') and #user.getGroupsById().containsKey(#groupId)")
+    List<Assessment> getAllAssessments(@NotNull User user, long groupId, long schoolYear);
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/GroupAssessmentService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/assessment/GroupAssessmentService.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface GroupAssessmentService {
 
     /**
-     * Gets the most recent assessment taken by a group for a given group and year.
+     * Gets the most recent assessment taken by a group for a given school year.
      * This can be an IAB, ICA or Summative assessment.
      *
      * @param user the user accessing the group's assessment
@@ -24,6 +24,15 @@ public interface GroupAssessmentService {
     @PreAuthorize("hasAuthority('PERM_GROUP_PII_READ') and #user.getGroupsById().containsKey(#groupId)")
     Optional<Assessment> getLatestAssessment(@NotNull User user, long groupId, long schoolYear);
 
+    /**
+     * Gets all assessments taken by a group for a given school year.
+     * This can be a list containing IAB, ICA and Summative assessments.
+     *
+     * @param user the user accessing the group information
+     * @param groupId the group for which the assessments will be searched
+     * @param schoolYear the academic year for which the assessments will be searched
+     * @return all assessments taken by the given group for the given school year
+     */
     @PreAuthorize("hasAuthority('PERM_GROUP_PII_READ') and #user.getGroupsById().containsKey(#groupId)")
     List<Assessment> getAllAssessments(@NotNull User user, long groupId, long schoolYear);
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/AbstractJdbcGroupExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/AbstractJdbcGroupExamRepository.java
@@ -10,16 +10,19 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 
-public abstract class AbstractJdbcGroupExamRepository implements GroupExamRepository {
+abstract class AbstractJdbcGroupExamRepository implements GroupExamRepository {
 
     private final NamedParameterJdbcTemplate template;
     private final String findLatestQuery;
+    private final String findAllQuery;
 
     AbstractJdbcGroupExamRepository(
             @NotNull final NamedParameterJdbcTemplate template,
-            @NotNull final String findLatestQuery) {
+            @NotNull final String findLatestQuery,
+            @NotNull final String findAllQuery) {
         this.template = template;
         this.findLatestQuery = findLatestQuery;
+        this.findAllQuery = findAllQuery;
     }
 
     @Override
@@ -54,6 +57,34 @@ public abstract class AbstractJdbcGroupExamRepository implements GroupExamReposi
         return assessments.isEmpty()
                 ? Optional.empty()
                 : Optional.of(assessments.get(0));
+    }
+
+    @Override
+    public List<Assessment> findAll(
+            final long groupId,
+            final long groupSubjectId,
+            final long schoolYear,
+            @NotNull final PermissionScope permissionScope) {
+
+        return template.query(
+                findAllQuery,
+                ImmutableMap.<String, Object>builder()
+                        .put("school_year", schoolYear)
+                        .put("group_id", groupId)
+                        .put("group_subject_id", groupSubjectId)
+                        .put("statewide", permissionScope.isStatewide())
+                        .put("district_ids", permissionScope.getDistrictIds().isEmpty() ? -1 : permissionScope.getDistrictIds())
+                        .put("school_ids", permissionScope.getInstitutionIds().isEmpty() ? -1 : permissionScope.getDistrictIds())
+                        .build(),
+                (row, index) -> Assessment.builder()
+                        .id(row.getLong("id"))
+                        .name(row.getString("name"))
+                        .gradeId(row.getLong("grade_id"))
+                        .typeId(row.getLong("type_id"))
+                        .subjectId(row.getLong("subject_id"))
+                        .schoolYear(row.getLong("school_year"))
+                        .build()
+        );
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/GroupExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/GroupExamRepository.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.reporting.exam.repository;
 
+import org.opentestsystem.rdw.reporting.assessment.Assessment;
 import org.opentestsystem.rdw.reporting.exam.GroupExam;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,6 +13,16 @@ import java.util.Optional;
  */
 public interface GroupExamRepository {
 
-    Optional<GroupExam> findLatest(long groupId, long groupSubjectId, long schoolYear, @NotNull PermissionScope permissionScope);
+    Optional<GroupExam> findLatest(
+            long groupId,
+            long groupSubjectId,
+            long schoolYear,
+            @NotNull PermissionScope permissionScope);
+
+    List<Assessment> findAll(
+            long groupId,
+            long groupSubjectId,
+            long schoolYear,
+            @NotNull PermissionScope permissionScope);
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/JdbcGroupIabExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/JdbcGroupIabExamRepository.java
@@ -11,8 +11,9 @@ public class JdbcGroupIabExamRepository extends AbstractJdbcGroupExamRepository 
 
     public JdbcGroupIabExamRepository(
             @NotNull final NamedParameterJdbcTemplate template,
-            @Value("${sql.group.exam.iab.findLatest}") final String findLatestQuery) {
-        super(template, findLatestQuery);
+            @Value("${sql.group.exam.iab.findLatest}") final String findLatestQuery,
+            @Value("${sql.group.assessment.iab.findAll}") final String findAllQuery) {
+        super(template, findLatestQuery, findAllQuery);
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/JdbcGroupIcaSummativeExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/repository/JdbcGroupIcaSummativeExamRepository.java
@@ -11,8 +11,9 @@ public class JdbcGroupIcaSummativeExamRepository extends AbstractJdbcGroupExamRe
 
     public JdbcGroupIcaSummativeExamRepository(
             @NotNull final NamedParameterJdbcTemplate template,
-            @Value("${sql.group.exam.findLatest}") final String findLatestQuery) {
-        super(template, findLatestQuery);
+            @Value("${sql.group.exam.findLatest}") final String findLatestQuery,
+            @Value("${sql.group.assessment.findAll}") final String findAllQuery) {
+        super(template, findLatestQuery, findAllQuery);
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/GroupAssessmentController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/GroupAssessmentController.java
@@ -1,7 +1,5 @@
 package org.opentestsystem.rdw.reporting.web;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import org.opentestsystem.rdw.reporting.assessment.Assessment;
 import org.opentestsystem.rdw.reporting.assessment.GroupAssessmentService;
 import org.opentestsystem.rdw.reporting.security.User;
@@ -9,9 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -26,21 +24,23 @@ public class GroupAssessmentController {
         this.service = service;
     }
 
-    @GetMapping("/api/groups/{groupId}/schoolYears/{schoolYear}/assessments")
+    @GetMapping("/api/groups/{groupId}/latestassessment")
+    public Assessment getLatestGroupAssessment(
+            @AuthenticationPrincipal final User user,
+            @PathVariable final long groupId,
+            @RequestParam("schoolYear") final long schoolYear) {
+
+        return service.getLatestAssessment(user, groupId, schoolYear)
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    @GetMapping("/api/groups/{groupId}/assessments")
     public List<Assessment> getGroupAssessments(
             @AuthenticationPrincipal final User user,
             @PathVariable final long groupId,
-            @PathVariable final long schoolYear,
-            final HttpServletRequest request) {
+            @RequestParam("schoolYear") final long schoolYear) {
 
-        if (Strings.isNullOrEmpty(request.getQueryString())) {
-            return ImmutableList.of(
-                    service.getLatest(user, groupId, schoolYear)
-                            .orElseThrow(NoSuchElementException::new));
-        }
-
-        // TODO: implement assessment search
-        throw new UnsupportedOperationException("group assessment search is not supported yet");
+        return service.getAllAssessments(user, groupId, schoolYear);
     }
 
 }

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -14,6 +14,42 @@ sql:
             join student_group sg on sg.id = usg.student_group_id
           where user_login=:user_login
 
+    assessment:
+      findAll: >-
+        select
+            distinct a.id,
+            a.name,
+            a.grade_id,
+            a.type_id,
+            a.subject_id,
+            a.school_year
+          from exam e
+            join student_group_membership sgm on e.student_id=sgm.student_id
+            join asmt a on e.asmt_id=a.id
+            join school s on e.school_id=s.id
+          where e.school_year=:school_year
+          and sgm.student_group_id=:group_id
+          and (0=:group_subject_id or a.subject_id=:group_subject_id)
+          and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+
+      iab:
+        findAll: >-
+          select
+              distinct a.id,
+              a.name,
+              a.grade_id,
+              a.type_id,
+              a.subject_id,
+              a.school_year
+            from iab_exam e
+              join student_group_membership sgm on e.student_id=sgm.student_id
+              join asmt a on e.asmt_id=a.id
+              join school s on e.school_id=s.id
+            where e.school_year=:school_year
+            and sgm.student_group_id=:group_id
+            and (0=:group_subject_id or a.subject_id=:group_subject_id)
+            and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+
     exam:
       findLatest: >-
         select


### PR DESCRIPTION
1. Adds API endpoint for getting all assessments for a given group in a given school year
2. Simplifies existing "get latest group assessment" API endpoint by not accommodating broader assessment search in the same method

(!) new endpoints are as follows:
/api/groups/{groupId}/assessments?schoolYear={schoolYear}
/api/groups/{groupId}/latestassessment?schoolYear={schoolYear}