### PR TITLE
moves exam/* components into feature specific packages

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/AssessmentItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/AssessmentItemRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam;
 
 import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/JdbcAssessmentItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/JdbcAssessmentItemRepository.java
@@ -1,8 +1,6 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam;
 
 import com.google.common.collect.ImmutableList;
-import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
-import org.opentestsystem.rdw.reporting.exam.AssessmentItemDifficultyRange;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/DefaultEthnicityService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/DefaultEthnicityService.java
@@ -1,7 +1,6 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import com.google.common.collect.ImmutableSet;
-import org.opentestsystem.rdw.reporting.exam.repository.EthnicityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/DefaultExamFilterOptionService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/DefaultExamFilterOptionService.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/EthnicityRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/EthnicityRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import java.util.List;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/EthnicityService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/EthnicityService.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import java.util.Set;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptionController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptionController.java
@@ -1,7 +1,7 @@
-package org.opentestsystem.rdw.reporting.web;
+package org.opentestsystem.rdw.reporting.exam.search;
 
-import org.opentestsystem.rdw.reporting.exam.ExamFilterOptionService;
-import org.opentestsystem.rdw.reporting.exam.ExamFilterOptions;
+import org.opentestsystem.rdw.reporting.exam.search.ExamFilterOptionService;
+import org.opentestsystem.rdw.reporting.exam.search.ExamFilterOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptionService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptionService.java
@@ -1,4 +1,6 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
+
+import org.opentestsystem.rdw.reporting.exam.search.ExamFilterOptions;
 
 /**
  * Responsible for managing exam filter options

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptions.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/ExamFilterOptions.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import com.google.common.collect.ImmutableSet;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/JdbcEthnicityRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/JdbcEthnicityRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/SchoolYearService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/SchoolYearService.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import java.util.Set;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/StubSchoolYearService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/StubSchoolYearService.java
@@ -1,6 +1,7 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search;
 
 import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.reporting.exam.search.SchoolYearService;
 import org.springframework.stereotype.Service;
 
 import java.util.Set;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/DefaultGroupExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/DefaultGroupExamItemService.java
@@ -1,7 +1,8 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
-import org.opentestsystem.rdw.reporting.exam.repository.AssessmentItemRepository;
-import org.opentestsystem.rdw.reporting.exam.repository.GroupExamItemRepository;
+import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
+import org.opentestsystem.rdw.reporting.exam.AssessmentItemRepository;
+import org.opentestsystem.rdw.reporting.exam.ExamItemScore;
 import org.opentestsystem.rdw.reporting.security.GroupSecurityContext;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/DefaultGroupExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/DefaultGroupExamService.java
@@ -1,7 +1,9 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import com.google.common.collect.ImmutableList;
-import org.opentestsystem.rdw.reporting.exam.repository.GroupExamRepository;
+import org.opentestsystem.rdw.reporting.exam.Assessment;
+import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.GroupExam;
 import org.opentestsystem.rdw.reporting.security.GroupSecurityContext;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamController.java
@@ -1,7 +1,7 @@
-package org.opentestsystem.rdw.reporting.web;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import org.opentestsystem.rdw.reporting.exam.Assessment;
-import org.opentestsystem.rdw.reporting.exam.GroupExamService;
+import org.opentestsystem.rdw.reporting.exam.search.group.GroupExamService;
 import org.opentestsystem.rdw.reporting.exam.Exam;
 import org.opentestsystem.rdw.reporting.exam.GroupExam;
 import org.opentestsystem.rdw.reporting.security.User;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemController.java
@@ -1,7 +1,7 @@
-package org.opentestsystem.rdw.reporting.web;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
-import org.opentestsystem.rdw.reporting.exam.GroupExamItemScores;
-import org.opentestsystem.rdw.reporting.exam.GroupExamItemService;
+import org.opentestsystem.rdw.reporting.exam.search.group.GroupExamItemScores;
+import org.opentestsystem.rdw.reporting.exam.search.group.GroupExamItemService;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import org.opentestsystem.rdw.reporting.exam.ExamItemScore;
 import org.opentestsystem.rdw.reporting.security.GroupSecurityContext;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemScores.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemScores.java
@@ -1,4 +1,7 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search.group;
+
+import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
+import org.opentestsystem.rdw.reporting.exam.ExamItemScore;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamItemService.java
@@ -1,5 +1,6 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
+import org.opentestsystem.rdw.reporting.exam.search.group.GroupExamItemScores;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.security.access.prepost.PreAuthorize;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/GroupExamService.java
@@ -1,5 +1,6 @@
-package org.opentestsystem.rdw.reporting.exam;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
+import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;
 import org.opentestsystem.rdw.reporting.exam.GroupExam;
 import org.opentestsystem.rdw.reporting.security.User;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamItemRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.exam.ExamItemScore;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamRepository.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/SchoolYearController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/SchoolYearController.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.web;
 
-import org.opentestsystem.rdw.reporting.exam.SchoolYearService;
+import org.opentestsystem.rdw.reporting.exam.search.ExamFilterOptionController;
+import org.opentestsystem.rdw.reporting.exam.search.SchoolYearService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -159,11 +159,38 @@ sql:
       from district
       where natural_id in (:naturalIds)
 
+    findAll: >-
+      select id, name
+      from district
+      where 1=:statewide
+      or id in (:district_ids)
+      or id=(
+        select district_id
+        from school s
+        where s.id in (:school_ids)
+      );
+
   school:
     findAllIds: >-
       select natural_id, id
       from school
       where natural_id in (:naturalIds)
+
+    findAllForDistrict: >-
+      select id, name
+      from school
+      where district_id=:district_id
+      and (
+        1=:statewide
+        or district_id in (:district_ids)
+        or id in (:school_ids)
+      );
+
+  grade:
+    # TODO: make this return only grades for which there are exam results for a given school_id
+    findAllForSchool: >-
+      select id, code
+      from grade
 
   ethnicity:
     findAll: >-

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/JdbcAssessmentItemRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/JdbcAssessmentItemRepositoryIT.java
@@ -1,11 +1,9 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.RepositoryIT;
-import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
-import org.opentestsystem.rdw.reporting.exam.AssessmentItemDifficulty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/JdbcEthnicityRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/JdbcEthnicityRepositoryIT.java
@@ -1,8 +1,5 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.ITDataSourceConfiguration;
@@ -12,10 +9,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamItemRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamItemRepositoryIT.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/exam/search/group/JdbcGroupExamRepositoryIT.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.reporting.exam.repository;
+package org.opentestsystem.rdw.reporting.exam.search.group;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -20,7 +20,7 @@ import static org.opentestsystem.rdw.reporting.security.GroupSecurityContexts.st
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
-@ContextConfiguration(classes = {ITDataSourceConfiguration.class, JdbcGroupExamRepository.class, JdbcEthnicityRepository.class})
+@ContextConfiguration(classes = {ITDataSourceConfiguration.class, JdbcGroupExamRepository.class})
 @Sql(statements = {
         "INSERT INTO gender (id, code) VALUES (-1, 'g1');\n",
         "INSERT INTO district (id, natural_id, name) VALUES (-1, 'district1', 'district1');\n",


### PR DESCRIPTION
Changing package structures.

Moved components from reporting.exam into:
...reporting.exam.search (will house general search related components)
...reporting.exam.search.group (intended to house my group page components)

This is to make way for a
...reporting.exam.search.grade
package which will house search by school grade components