### PR TITLE
add base url for saml

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlSettings.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlSettings.java
@@ -49,7 +49,7 @@ public class SamlSettings {
     }
 
     /**
-     * @return Private kel alias password. May be same as JKS file password.
+     * @return Private key alias password. May be same as JKS file password.
      */
     public String getPrivateKeyEntryPassword() {
         return privateKeyEntryPassword;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlSettings.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlSettings.java
@@ -13,9 +13,10 @@ public class SamlSettings {
     private String privateKeyEntryPassword;
     private String idpMetadataUrl;
     private String spEntityId;
+    private String spEntityBaseUrl;
 
     /**
-     * The full file path to the Java KeyStore (JKS) file.
+     * @return The full file path to the Java KeyStore (JKS) file.
      */
     public String getKeyStoreFile() {
         return keyStoreFile;
@@ -26,7 +27,7 @@ public class SamlSettings {
     }
 
     /**
-     * Password for the JKS File.
+     * @return Password for the JKS File.
      */
     public String getKeyStorePassword() {
         return keyStorePassword;
@@ -37,7 +38,7 @@ public class SamlSettings {
     }
 
     /**
-     * Private key alias in JKS used for SAML signing.
+     * @return Private key alias in JKS used for SAML signing.
      */
     public String getPrivateKeyEntryAlias() {
         return privateKeyEntryAlias;
@@ -48,7 +49,7 @@ public class SamlSettings {
     }
 
     /**
-     * Private kel alias password. May be same as JKS file password.
+     * @return Private kel alias password. May be same as JKS file password.
      */
     public String getPrivateKeyEntryPassword() {
         return privateKeyEntryPassword;
@@ -59,7 +60,7 @@ public class SamlSettings {
     }
 
     /**
-     * Identity provider metadata URL.
+     * @return Identity provider metadata URL.
      */
     public String getIdpMetadataUrl() {
         return idpMetadataUrl;
@@ -70,7 +71,7 @@ public class SamlSettings {
     }
 
     /**
-     * Service Provider entity id as registered in the IDP circle of trust.
+     * @return Service Provider entity id as registered in the IDP circle of trust.
      */
     public String getSpEntityId() {
         return spEntityId;
@@ -78,5 +79,16 @@ public class SamlSettings {
 
     public void setSpEntityId(final String spEntityId) {
         this.spEntityId = spEntityId;
+    }
+
+    /**
+     * @return Service Provider entity base URL; used to build SAML request metadata
+     */
+    public String getSpEntityBaseUrl() {
+        return spEntityBaseUrl;
+    }
+
+    public void setSpEntityBaseUrl(final String spEntityBaseUrl) {
+        this.spEntityBaseUrl = spEntityBaseUrl;
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -87,14 +87,18 @@ import java.util.Timer;
 @EnableWebSecurity
 public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    private SamlSettings samlSettings;
+    private final SamlSettings samlSettings;
+    private final SamlUserDetailsService samlUserDetailsService;
+    private final ResourceLoader resourceLoader;
 
     @Autowired
-    private SamlUserDetailsService samlUserDetailsService;
-
-    @Autowired
-    private ResourceLoader resourceLoader;
+    public SamlWebSecurityConfiguration(final SamlSettings samlSettings,
+                                        final SamlUserDetailsService samlUserDetailsService,
+                                        final ResourceLoader resourceLoader) {
+        this.samlSettings = samlSettings;
+        this.samlUserDetailsService = samlUserDetailsService;
+        this.resourceLoader = resourceLoader;
+    }
 
     // Initialization of OpenSAML library
     @Bean
@@ -288,6 +292,7 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     public MetadataGenerator metadataGenerator() {
         MetadataGenerator metadataGenerator = new MetadataGenerator();
         metadataGenerator.setEntityId(samlSettings.getSpEntityId());
+        metadataGenerator.setEntityBaseURL(samlSettings.getSpEntityBaseUrl());
         metadataGenerator.setExtendedMetadata(extendedMetadata());
         metadataGenerator.setIncludeDiscoveryExtension(false);
         metadataGenerator.setKeyManager(keyManager());


### PR DESCRIPTION
The app needs to provide the callback service URL in the SAML2 request. The framework handles it but there is a setting that needs to be configured. This is the same thing that IAT had to do.

If the sp-entity-base-url is not set, it will continue to use the default which is the base url of the first request to come in, typically localhost or the IP address. Note that you can confuse the system if the first request to come in is on the status/health port. From that point on it will use localhost:8008 instead of localhost:8080. I'm not too concerned with that at this time.