### PR TITLE
Enable collapse-all functionality in the group-results component.

### DIFF
--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
@@ -4,7 +4,7 @@
         <!-- Top Right Buttons -->
         <div class="pull-right text-right">
             <a class="btn btn-default btn-xs"><i class="fa fa-list-alt"></i> {{'labels.assessment.instruct' | translate }}</a>
-            <button class="btn btn-default btn-sm icon-only" (click)="toggleCollapsed()">
+            <button class="btn btn-default btn-sm icon-only" (click)="collapsed = !collapsed;">
                 <i class="fa font-bold" [ngClass]="{'fa-angle-down':collapsed, 'fa-angle-up':!collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
             </button>
         </div>

--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
@@ -4,7 +4,7 @@
         <!-- Top Right Buttons -->
         <div class="pull-right text-right">
             <a class="btn btn-default btn-xs"><i class="fa fa-list-alt"></i> {{'labels.assessment.instruct' | translate }}</a>
-            <button class="btn btn-default btn-sm icon-only" (click)="collapsed = !collapsed;">
+            <button class="btn btn-default btn-sm icon-only" (click)="collapsed = !collapsed">
                 <i class="fa font-bold" [ngClass]="{'fa-angle-down':collapsed, 'fa-angle-up':!collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
             </button>
         </div>

--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
@@ -4,8 +4,8 @@
         <!-- Top Right Buttons -->
         <div class="pull-right text-right">
             <a class="btn btn-default btn-xs"><i class="fa fa-list-alt"></i> {{'labels.assessment.instruct' | translate }}</a>
-            <button class="btn btn-default btn-sm icon-only" (click)="collapsed = !collapsed">
-                <i class="fa font-bold" [ngClass]="{'fa-angle-down':collapsed, 'fa-angle-up':!collapsed}"></i> <span class="sr-only">Collapse</span>
+            <button class="btn btn-default btn-sm icon-only" (click)="toggleCollapsed()">
+                <i class="fa font-bold" [ngClass]="{'fa-angle-down':collapsed, 'fa-angle-up':!collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
             </button>
         </div>
         <!-- Assessment Title -->

--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.ts
@@ -1,9 +1,7 @@
-import { Component, OnInit, Input, OnChanges, SimpleChanges } from "@angular/core";
+import { Component, Input, Output, EventEmitter } from "@angular/core";
 import { trigger, transition, style, animate } from "@angular/animations";
 import { AssessmentExam } from "../model/assessment-exam.model";
 import { Exam } from "../model/exam.model";
-import { ExamResultLevel } from "../../../shared/enum/exam-result-level.enum";
-import { AssessmentType } from "../../../shared/enum/assessment-type.enum";
 import { ExamStatisticsCalculator } from "./exam-statistics-calculator";
 import { FilterBy } from "../model/filter-by.model";
 import { Subscription } from "rxjs";
@@ -43,12 +41,9 @@ export class AssessmentResultsComponent {
     this._assessmentExam = assessment;
     this.sessions = this.getDistinctExamSessions(assessment.exams);
 
-    if (this.sessions.length > 0)
+    if (this.sessions.length > 0) {
       this.toggleSession(this.sessions[ 0 ]);
-  }
-
-  get assessmentExam() {
-    return this._assessmentExam;
+    }
   }
 
   @Input()
@@ -60,26 +55,32 @@ export class AssessmentResultsComponent {
   set filterBy(value: FilterBy) {
     this._filterBy = value;
 
-    if (this._filterBySubscription)
+    if (this._filterBySubscription) {
       this._filterBySubscription.unsubscribe();
+    }
 
     if (this._filterBy) {
       this.updateExamSessions();
 
-      this._filterBySubscription = this._filterBy.onChanges.subscribe(x => {
+      this._filterBySubscription = this._filterBy.onChanges.subscribe(() => {
         this.updateExamSessions();
       });
     }
   }
 
-  private _filterBy: FilterBy;
-  private _assessmentExam: AssessmentExam;
-  private _showValuesAsPercent: boolean;
-  private _filterBySubscription: Subscription;
+  @Output()
+  onCollapsed: EventEmitter<boolean> = new EventEmitter();
 
-  constructor(public gradeService : GradeService,
-              private examCalculator: ExamStatisticsCalculator,
-              private examFilterService: ExamFilterService) {
+  get assessmentExam() {
+    return this._assessmentExam;
+  }
+
+  set collapsed(collapsed: boolean) {
+    this.assessmentExam.collapsed = collapsed;
+  }
+
+  get collapsed() {
+    return this.assessmentExam.collapsed;
   }
 
   get performance() {
@@ -102,6 +103,25 @@ export class AssessmentResultsComponent {
   get performanceLevelHeader() {
     return "labels.groups.results.exam-cols." +
       (this.isIab ? "iab" : "ica") + ".performance";
+  }
+
+  private _filterBy: FilterBy;
+  private _assessmentExam: AssessmentExam;
+  private _showValuesAsPercent: boolean;
+  private _filterBySubscription: Subscription;
+
+  constructor(public gradeService : GradeService,
+              private examCalculator: ExamStatisticsCalculator,
+              private examFilterService: ExamFilterService) {
+  }
+
+  /**
+   * Toggle the collapsed state of this result.
+   * Emit an onCollapsed event with the new collapsed state.
+   */
+  toggleCollapsed() {
+    this.collapsed = !this.collapsed;
+    this.onCollapsed.emit(this.collapsed);
   }
 
   toggleSession(session) {

--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.ts
@@ -68,9 +68,6 @@ export class AssessmentResultsComponent {
     }
   }
 
-  @Output()
-  onCollapsed: EventEmitter<boolean> = new EventEmitter();
-
   get assessmentExam() {
     return this._assessmentExam;
   }
@@ -113,15 +110,6 @@ export class AssessmentResultsComponent {
   constructor(public gradeService : GradeService,
               private examCalculator: ExamStatisticsCalculator,
               private examFilterService: ExamFilterService) {
-  }
-
-  /**
-   * Toggle the collapsed state of this result.
-   * Emit an onCollapsed event with the new collapsed state.
-   */
-  toggleCollapsed() {
-    this.collapsed = !this.collapsed;
-    this.onCollapsed.emit(this.collapsed);
   }
 
   toggleSession(session) {

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -131,14 +131,16 @@
               class="btn btn-default">{{'labels.groups.results.value-as-number' | translate}}
       </button>
     </div>
-    <a class="btn btn-default btn-xs pull-right">
-      Collapse Results <i class="fa fa-chevron-up"></i>
-    </a>
+    <button class="btn btn-default btn-xs pull-right" (click)="allCollapsed = !allCollapsed">
+      <span *ngIf="!allCollapsed">{{'labels.groups.results.collapse-all' | translate}} <i class="fa fa-angle-up"></i></span>
+      <span *ngIf="allCollapsed">{{'labels.groups.results.expand-all' | translate}} <i class="fa fa-angle-down"></i></span>
+    </button>
   </div>
 </h2>
 <!-- Results Container -->
-<div *ngFor="let assessment of assessmentExams" class="groups-results-wrapper">
-  <assessment-results [assessmentExam]="assessment" [showValuesAsPercent]="showValuesAsPercent"
+<div *ngFor="let assessment of assessmentExams; let i = index" class="groups-results-wrapper">
+  <assessment-results [assessmentExam]="assessment"
+                      [showValuesAsPercent]="showValuesAsPercent"
                       [filterBy]="clientFilterBy"></assessment-results>
 </div>
 <!-- No Results Error -->

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.spec.ts
@@ -130,6 +130,19 @@ describe('GroupResultsComponent', () => {
     expect(actual.length).toBe(0);
     expect(component.assessmentExams.length).toBe(0);
   });
+
+  it("should detect if all results are collapsed", () => {
+    let assessmentExamA = new AssessmentExam();
+    let assessmentExamB = new AssessmentExam();
+    component.assessmentExams = [ assessmentExamA, assessmentExamB ];
+    expect(component.allCollapsed).toBe(false);
+
+    assessmentExamA.collapsed = true;
+    expect(component.allCollapsed).toBe(false);
+
+    assessmentExamB.collapsed = true;
+    expect(component.allCollapsed).toBe(true);
+  });
 });
 
 

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
@@ -93,8 +93,8 @@ export class GroupResultsComponent implements OnInit {
    * @param allCollapsed True if all assessment exams should be collapsed
    */
   set allCollapsed(allCollapsed: boolean) {
-    for (let i = 0; i < this.assessmentExams.length; i++) {
-      this.assessmentExams[i].collapsed = allCollapsed;
+    for (let assessmentExam of this.assessmentExams) {
+      assessmentExam.collapsed = allCollapsed;
     }
   }
 
@@ -102,7 +102,7 @@ export class GroupResultsComponent implements OnInit {
    * @returns {boolean} True only if ALL assessment exams are collapsed
    */
   get allCollapsed(): boolean {
-    return this.assessmentExams.findIndex((assessmentExam) => !assessmentExam.collapsed) < 0;
+    return !this.assessmentExams.some((assessmentExam) => !assessmentExam.collapsed);
   }
 
   private _showAdvancedFilters: boolean = false;

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
@@ -15,7 +15,6 @@ import { GradeService } from "../../shared/grade.service";
 })
 export class GroupResultsComponent implements OnInit {
   groups;
-
   showValuesAsPercent: boolean = true;
   expandFilterOptions: boolean = false;
   clientFilterBy: FilterBy;
@@ -88,6 +87,24 @@ export class GroupResultsComponent implements OnInit {
     return [];
   }
 
+  /**
+   * When set, toggle the collapsed state of all assessment exams.
+   *
+   * @param allCollapsed True if all assessment exams should be collapsed
+   */
+  set allCollapsed(allCollapsed: boolean) {
+    for (let i = 0; i < this.assessmentExams.length; i++) {
+      this.assessmentExams[i].collapsed = allCollapsed;
+    }
+  }
+
+  /**
+   * @returns {boolean} True only if ALL assessment exams are collapsed
+   */
+  get allCollapsed(): boolean {
+    return this.assessmentExams.findIndex((assessmentExam) => !assessmentExam.collapsed) < 0;
+  }
+
   private _showAdvancedFilters: boolean = false;
   private _expandAssessments: boolean = false;
   private _showOnlyMostRecent: boolean = true;
@@ -141,8 +158,9 @@ export class GroupResultsComponent implements OnInit {
 
   updateAssessment(latestAssessment) {
     this.assessmentExams = [];
-    if (latestAssessment)
+    if (latestAssessment) {
       this.assessmentExams.push(latestAssessment);
+    }
   }
 
   updateRoute() {

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.ts
@@ -102,7 +102,7 @@ export class GroupResultsComponent implements OnInit {
    * @returns {boolean} True only if ALL assessment exams are collapsed
    */
   get allCollapsed(): boolean {
-    return !this.assessmentExams.some((assessmentExam) => !assessmentExam.collapsed);
+    return this.assessmentExams.every((assessmentExam) => assessmentExam.collapsed);
   }
 
   private _showAdvancedFilters: boolean = false;

--- a/webapp/src/main/webapp/src/app/groups/results/model/assessment-exam.model.ts
+++ b/webapp/src/main/webapp/src/app/groups/results/model/assessment-exam.model.ts
@@ -1,12 +1,17 @@
 import { Assessment } from "./assessment.model";
 import { Exam } from "./exam.model";
 
+/**
+ * This class represents a collection of Exams for a given Assessment.
+ */
 export class AssessmentExam {
   assessment: Assessment;
   exams: Exam[];
+  collapsed: boolean;
 
   constructor(){
     this.assessment = new Assessment();
     this.exams = [];
+    this.collapsed = false;
   }
 }

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -54,7 +54,8 @@
     "notApplicable": "-"
   },
   "prompt": {
-    "search": "Search"
+    "search": "Search",
+    "collapse": "Collapse"
   },
   "labels": {
     "aggregate": {
@@ -118,6 +119,8 @@
         "title": "Results",
         "select-group": "Group",
         "select-year": "School Year",
+        "collapse-all": "Collapse Results",
+        "expand-all": "Expand Results",
         "adv-filters" : {
           "label": "Advanced Filters",
           "subhead": "Click an items to remove it from the list",


### PR DESCRIPTION
Simple collapse-all functionality in the group results page.
If all items are collapsed, the button changes to "Expand Results"