### PR TITLE
Feature/permission scope union

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/AuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/AuthorizationService.java
@@ -29,7 +29,7 @@ public interface AuthorizationService {
      * @param grants the grants for which to compute the permissions
      * @return immutable set of permissions
      */
-    Set<Permission> getPermissions(Collection<? extends Grant> grants);
+    Set<Permission> getPermissions(Collection<Grant> grants);
 
     /**
      * Computes authorities from grants. This is for integrating with spring security
@@ -37,7 +37,7 @@ public interface AuthorizationService {
      * @param grants the grants for which to compute the authorities
      * @return immutable set of authorities
      */
-    Set<GrantedAuthority> getAuthorities(Collection<? extends Grant> grants);
+    Set<GrantedAuthority> getAuthorities(Collection<Grant> grants);
 
     /**
      * Gets the group memberships for the given user
@@ -46,6 +46,6 @@ public interface AuthorizationService {
      * @param username The name of the user to lookup the group memberships for
      * @return immutable set of group memberships
      */
-    Set<GroupGrant> getGroups(Collection<? extends Permission> permissions, String username);
+    Set<GroupGrant> getGroups(Collection<Permission> permissions, String username);
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -131,7 +131,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         return permissionScopeBuildersByPermissionId.entrySet().stream()
                 // missing IDs in the natural ID to entity ID map can result in an invalid permission scope builder
-                // that is neither statewide containing any has schools and districts
+                // that is neither statewide nor containing any schools and districts so this will filter those out
                 .filter(entry -> entry.getValue().isValid())
                 .map(entry -> new Permission(entry.getKey(), entry.getValue().build()))
                 .collect(toImmutableSet());
@@ -204,12 +204,13 @@ public class DefaultAuthorizationService implements AuthorizationService {
             return this;
         }
 
+        /**
+         * @return <code>true</code> if the permission scope is statewide or has any districts or schools
+         */
         public boolean isValid() {
-            return statewide || (
-                    (districtIds != null ? districtIds.size() : 0)
-                            + (schoolIds != null ? schoolIds.size() : 0)
-                            > 0
-            );
+            return statewide
+                    || (districtIds != null && !districtIds.isEmpty())
+                    || (schoolIds != null && !schoolIds.isEmpty());
         }
 
         public PermissionScope build() {

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newLinkedHashSet;
 import static java.util.stream.Collectors.toSet;
 
@@ -58,14 +59,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
                 grants.add(grant);
             }
         }
-        return ImmutableSet.copyOf(sanitizeGrants(grants));
-    }
-
-    // TODO decide strategy for resolving case where users are assigned roles with colliding permission sets
-    private Collection<Grant> sanitizeGrants(final Collection<Grant> grants) {
-        return grants.stream().anyMatch(grant -> "PII".equals(grant.getRole()))
-                ? grants.stream().filter(grant -> !"PII_GROUP".equals(grant.getRole())).collect(toSet())
-                : grants;
+        return ImmutableSet.copyOf(grants);
     }
 
     public Set<Permission> getPermissions(final Collection<? extends Grant> grants) {
@@ -89,7 +83,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
         final Map<String, Long> districtIds = districtRepository.findAllIds(districtNaturalIds);
         final Map<String, Long> institutionIds = institutionRepository.findAllIds(institutionNaturalIds);
 
-        final Set<Permission> permissions = newLinkedHashSet();
+        final Map<String, Permission> permissionsById = newHashMap();
 
         // Identify and store the permissions associated with the role
         for (String role : grantsByRole.keySet()) {
@@ -99,16 +93,21 @@ public class DefaultAuthorizationService implements AuthorizationService {
             // User may have roles not registered to this application in the permission service.
             if (permissionIds != null) {
                 for (String permissionId : permissionIds) {
-                    permissions.add(
-                            new Permission(
-                                    permissionId,
-                                    createScope(grantsByRole.get(role), districtIds, institutionIds)
-                            )
+                    final Permission existingPermission = permissionsById.get(permissionId);
+                    final Permission permission = new Permission(
+                            permissionId,
+                            createScope(grantsByRole.get(role), districtIds, institutionIds)
                     );
+                    if (existingPermission == null) {
+                        permissionsById.put(permissionId, permission);
+                    } else {
+                        // TODO document
+                        permissionsById.put(permissionId, union(existingPermission, permission));
+                    }
                 }
             }
         }
-        return ImmutableSet.copyOf(permissions);
+        return ImmutableSet.copyOf(permissionsById.values());
     }
 
     public Set<GrantedAuthority> getAuthorities(final Collection<? extends Grant> grants) {
@@ -196,4 +195,27 @@ public class DefaultAuthorizationService implements AuthorizationService {
         );
 
     }
+
+    private Permission union(final Permission a, final Permission b) {
+        if (a.getScope().isStatewide()) {
+            return a;
+        }
+        if (b.getScope().isStatewide()) {
+            return b;
+        }
+        return new Permission(
+                a.getId(),
+                new PermissionScope(
+                        ImmutableSet.<Long>builder()
+                                .addAll(a.getScope().getDistrictIds())
+                                .addAll(b.getScope().getDistrictIds())
+                                .build(),
+                        ImmutableSet.<Long>builder()
+                                .addAll(a.getScope().getInstitutionIds())
+                                .addAll(b.getScope().getInstitutionIds())
+                                .build()
+                )
+        );
+    }
+
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -59,26 +59,33 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public Set<Grant> getGrants(final String[] encodedGrants) {
-        final Set<Grant> grants = newLinkedHashSet();
+        final ImmutableSet.Builder<Grant> grants = ImmutableSet.builder();
         for (String encodedGrant : encodedGrants) {
             final Grant grant = Grants.from(encodedGrant);
 
-            // Do not add do not belong to the application instance's state
+            // Only add grants for the application's configured state
             if (stateId.equals(grant.getStateId())) {
                 grants.add(grant);
             }
         }
-        return ImmutableSet.copyOf(grants);
+        return grants.build();
     }
 
+    // A Grant is a role granted for a state or organization identified by its natural id.
+    // A Permission is a permission and collection of organizations identified by their internal ids.
+    // This method maps the grant roles to the associated permissions, collects and dedups the
+    // organizations that share that permission, and resolves natural ids to internal ids.
     @Override
-    public Set<Permission> getPermissions(final Collection<? extends Grant> grants) {
+    public Set<Permission> getPermissions(final Collection<Grant> grants) {
 
         // Groups grants by role to later combine their districts and institutions into a single scope
         // This is to cover the case of multiple non-intersecting grants being given
         // (e.g. roleA,stateA,districtA and roleA,stateA,districtB)
-        final Multimap<String, Grant> grantsByRole = Multimaps.index((Iterable<Grant>) grants, Grant::getRole);
+        final Multimap<String, Grant> grantsByRole = Multimaps.index(grants, Grant::getRole);
         final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
+
+        // TODO: consider deferring lookup and resolution of organization IDs since statewide permission scope
+        // can override other organization level scopes and make this lookup unnecessary
 
         // prepare natural ID to entity ID maps
         final Set<String> districtNaturalIds = newLinkedHashSet();
@@ -97,34 +104,24 @@ public class DefaultAuthorizationService implements AuthorizationService {
         final Map<String, PermissionScopeBuilder> permissionScopeBuildersByPermissionId = newHashMap();
         for (Map.Entry<String, Grant> entry : grantsByRole.entries()) {
 
-            final String role = entry.getKey();
+            final Collection<String> permissionIds = permissionsByRole.get(entry.getKey());
+
+            // The user may be granted roles that are not registered to this application in the permission configuration.
+            // These roles should be ignored as they do not apply to our application
+            if (permissionIds == null) continue;
+
             final Grant grant = entry.getValue();
-            final Collection<String> permissionIds = permissionsByRole.get(role);
+            for (String permissionId : permissionIds) {
 
-            // User may have roles not registered to this application in the permission service.
-            if (permissionIds != null) {
-                for (String permissionId : permissionIds) {
+                final PermissionScopeBuilder permissionScopeBuilder = permissionScopeBuildersByPermissionId
+                        .computeIfAbsent(permissionId, (key) -> new PermissionScopeBuilder());
 
-                    final PermissionScopeBuilder permissionScopeBuilder = permissionScopeBuildersByPermissionId
-                            .computeIfAbsent(permissionId, (key) -> new PermissionScopeBuilder());
-
-                    if (grant.getEntityLevel() == STATE) {
-                        permissionScopeBuilder.statewide(true);
-                    } else if (grant.getEntityLevel() == DISTRICT) {
-                        final Long id = districtIdsByNaturalId.get(grant.getEntityId());
-                        if (id != null) {
-                            permissionScopeBuilder.addDistrictId(id);
-                        } else {
-                            logger.warn("grant district with natural ID \"{}\" not found.", grant.getEntityId());
-                        }
-                    } else if (grant.getEntityLevel() == INSTITUTION) {
-                        final Long id = schoolIdsByNaturalId.get(grant.getEntityId());
-                        if (id != null) {
-                            permissionScopeBuilder.addSchoolId(id);
-                        } else {
-                            logger.warn("grant school with natural ID \"{}\" not found", grant.getEntityId());
-                        }
-                    }
+                if (grant.getEntityLevel() == STATE) {
+                    permissionScopeBuilder.statewide(true);
+                } else if (grant.getEntityLevel() == DISTRICT) {
+                    addDistrict(permissionScopeBuilder, grant.getEntityId(), districtIdsByNaturalId);
+                } else if (grant.getEntityLevel() == INSTITUTION) {
+                    addSchool(permissionScopeBuilder, grant.getEntityId(), schoolIdsByNaturalId);
                 }
             }
         }
@@ -138,7 +135,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
     }
 
     @Override
-    public Set<GrantedAuthority> getAuthorities(final Collection<? extends Grant> grants) {
+    public Set<GrantedAuthority> getAuthorities(final Collection<Grant> grants) {
         final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
         final ImmutableSet.Builder<GrantedAuthority> authorities = ImmutableSet.builder();
         for (Grant grant : grants) {
@@ -158,7 +155,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
     }
 
     @Override
-    public Set<GroupGrant> getGroups(final Collection<? extends Permission> permissions, final String username) {
+    public Set<GroupGrant> getGroups(final Collection<Permission> permissions, final String username) {
         // only lookup groups for those with the group PII permission
         if (permissions.stream().noneMatch(permission -> permission.getId().equals("GROUP_PII_READ"))) {
             return ImmutableSet.of();
@@ -171,6 +168,24 @@ public class DefaultAuthorizationService implements AuthorizationService {
             return permissionService.getPermissionsByRole();
         } catch (PermissionServiceException exception) {
             throw new RuntimeException("Failed to get permissions", exception);
+        }
+    }
+
+    private void addDistrict(final PermissionScopeBuilder builder, final String entityId, final Map<String, Long> idsByNaturalId) {
+        final Long id = idsByNaturalId.get(entityId);
+        if (id != null) {
+            builder.addDistrictId(id);
+        } else {
+            logger.warn("grant district with natural ID \"{}\" not found", entityId);
+        }
+    }
+
+    private void addSchool(final PermissionScopeBuilder builder, final String entityId, final Map<String, Long> idsByNaturalId) {
+        final Long id = idsByNaturalId.get(entityId);
+        if (id != null) {
+            builder.addSchoolId(id);
+        } else {
+            logger.warn("grant school with natural ID \"{}\" not found", entityId);
         }
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -11,6 +11,8 @@ import org.opentestsystem.rdw.security.Grant;
 import org.opentestsystem.rdw.security.service.PermissionService;
 import org.opentestsystem.rdw.security.service.PermissionServiceException;
 import org.opentestsystem.rdw.security.support.Grants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,16 +21,22 @@ import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newLinkedHashSet;
-import static java.util.stream.Collectors.toSet;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.DISTRICT;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.INSTITUTION;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.STATE;
 
 @Service
 public class DefaultAuthorizationService implements AuthorizationService {
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final String stateId;
     private final PermissionService permissionService;
     private final DistrictRepository districtRepository;
@@ -49,6 +57,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
         this.groupMembershipRepository = groupMembershipRepository;
     }
 
+    @Override
     public Set<Grant> getGrants(final String[] encodedGrants) {
         final Set<Grant> grants = newLinkedHashSet();
         for (String encodedGrant : encodedGrants) {
@@ -62,6 +71,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
         return ImmutableSet.copyOf(grants);
     }
 
+    @Override
     public Set<Permission> getPermissions(final Collection<? extends Grant> grants) {
 
         // Groups grants by role to later combine their districts and institutions into a single scope
@@ -70,51 +80,69 @@ public class DefaultAuthorizationService implements AuthorizationService {
         final Multimap<String, Grant> grantsByRole = Multimaps.index((Iterable<Grant>) grants, Grant::getRole);
         final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
 
-
+        // prepare natural ID to entity ID maps
         final Set<String> districtNaturalIds = newLinkedHashSet();
         final Set<String> institutionNaturalIds = newLinkedHashSet();
         for (Grant grant : grants) {
-            if (grant.getEntityLevel() == Grant.EntityLevel.DISTRICT) {
+            if (grant.getEntityLevel() == DISTRICT) {
                 districtNaturalIds.add(grant.getEntityId());
-            } else {
+            } else if (grant.getEntityLevel() == INSTITUTION) {
                 institutionNaturalIds.add(grant.getEntityId());
             }
         }
-        final Map<String, Long> districtIds = districtRepository.findAllIds(districtNaturalIds);
-        final Map<String, Long> institutionIds = institutionRepository.findAllIds(institutionNaturalIds);
-
-        final Map<String, Permission> permissionsById = newHashMap();
+        final Map<String, Long> districtIdsByNaturalId = districtRepository.findAllIds(districtNaturalIds);
+        final Map<String, Long> schoolIdsByNaturalId = institutionRepository.findAllIds(institutionNaturalIds);
 
         // Identify and store the permissions associated with the role
-        for (String role : grantsByRole.keySet()) {
+        final Map<String, PermissionScopeBuilder> permissionScopeBuildersByPermissionId = newHashMap();
+        for (Map.Entry<String, Grant> entry : grantsByRole.entries()) {
 
+            final String role = entry.getKey();
+            final Grant grant = entry.getValue();
             final Collection<String> permissionIds = permissionsByRole.get(role);
 
             // User may have roles not registered to this application in the permission service.
             if (permissionIds != null) {
                 for (String permissionId : permissionIds) {
-                    final Permission existingPermission = permissionsById.get(permissionId);
-                    final Permission permission = new Permission(
-                            permissionId,
-                            createScope(grantsByRole.get(role), districtIds, institutionIds)
-                    );
-                    if (existingPermission == null) {
-                        permissionsById.put(permissionId, permission);
-                    } else {
-                        // TODO document
-                        permissionsById.put(permissionId, union(existingPermission, permission));
+
+                    final PermissionScopeBuilder permissionScopeBuilder = permissionScopeBuildersByPermissionId
+                            .computeIfAbsent(permissionId, (key) -> new PermissionScopeBuilder());
+
+                    if (grant.getEntityLevel() == STATE) {
+                        permissionScopeBuilder.statewide(true);
+                    } else if (grant.getEntityLevel() == DISTRICT) {
+                        final Long id = districtIdsByNaturalId.get(grant.getEntityId());
+                        if (id != null) {
+                            permissionScopeBuilder.addDistrictId(id);
+                        } else {
+                            logger.warn("grant district with natural ID \"{}\" not found.", grant.getEntityId());
+                        }
+                    } else if (grant.getEntityLevel() == INSTITUTION) {
+                        final Long id = schoolIdsByNaturalId.get(grant.getEntityId());
+                        if (id != null) {
+                            permissionScopeBuilder.addSchoolId(id);
+                        } else {
+                            logger.warn("grant district with natural ID \"{}\" not found", grant.getEntityId());
+                        }
                     }
                 }
             }
         }
-        return ImmutableSet.copyOf(permissionsById.values());
+
+        return permissionScopeBuildersByPermissionId.entrySet().stream()
+                // missing IDs in the natural ID to entity ID map can result in an invalid permission scope builder
+                // that is neither statewide containing any has schools and districts
+                .filter(entry -> entry.getValue().isValid())
+                .map(entry -> new Permission(entry.getKey(), entry.getValue().build()))
+                .collect(toImmutableSet());
     }
 
+    @Override
     public Set<GrantedAuthority> getAuthorities(final Collection<? extends Grant> grants) {
         final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
         final ImmutableSet.Builder<GrantedAuthority> authorities = ImmutableSet.builder();
         for (Grant grant : grants) {
-            if (grant.getEntityLevel() == Grant.EntityLevel.STATE) {
+            if (grant.getEntityLevel() == STATE) {
                 if (permissionsByRole.containsKey(grant.getRole())) {
                     authorities.add(Authorities.createRole(grant.getRole()));
                     final Collection<String> permissionIds = permissionsByRole.get(grant.getRole());
@@ -129,6 +157,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
         return authorities.build();
     }
 
+    @Override
     public Set<GroupGrant> getGroups(final Collection<? extends Permission> permissions, final String username) {
         // only lookup groups for those with the group PII permission
         if (permissions.stream().noneMatch(permission -> permission.getId().equals("GROUP_PII_READ"))) {
@@ -145,77 +174,51 @@ public class DefaultAuthorizationService implements AuthorizationService {
         }
     }
 
-    private PermissionScope createScope(
-            final Collection<Grant> grantsWithSameRole,
-            final Map<String, Long> districtIdByNaturalId,
-            final Map<String, Long> institutionIdByNaturalId) {
+    private static class PermissionScopeBuilder {
 
-        if (grantsWithSameRole.size() == 1) {
-            return createScope(
-                    grantsWithSameRole.iterator().next(),
-                    districtIdByNaturalId,
-                    institutionIdByNaturalId
-            );
+        private boolean statewide;
+        private List<Long> districtIds;
+        private List<Long> schoolIds;
+
+        private PermissionScopeBuilder() {
         }
 
-        // Below implementation assumes if there was a state-level role,
-        // all other scopes for the same role are contained in that role and therefore already filtered out
-        // and there should only be one scope left for this role
-        final ImmutableSet.Builder<Long> districtIds = ImmutableSet.builder();
-        final ImmutableSet.Builder<Long> institutionIds = ImmutableSet.builder();
+        public PermissionScopeBuilder statewide(final boolean statewide) {
+            this.statewide = statewide;
+            return this;
+        }
 
-        for (Grant grant : grantsWithSameRole) {
-            if (grant.getEntityLevel() == Grant.EntityLevel.DISTRICT) {
-                districtIds.add(districtIdByNaturalId.get(grant.getEntityId()));
-            } else {
-                institutionIds.add(institutionIdByNaturalId.get(grant.getEntityId()));
+        public PermissionScopeBuilder addDistrictId(final long id) {
+            if (this.districtIds == null) {
+                this.districtIds = newArrayList();
             }
+            this.districtIds.add(id);
+            return this;
         }
 
-        return new PermissionScope(districtIds.build(), institutionIds.build());
-    }
-
-    private PermissionScope createScope(
-            final Grant grant,
-            final Map<String, Long> districtIdByNaturalId,
-            final Map<String, Long> institutionIdByNaturalId) {
-
-        if (grant.getEntityLevel() == Grant.EntityLevel.STATE) {
-            return PermissionScope.STATEWIDE;
+        public PermissionScopeBuilder addSchoolId(final long id) {
+            if (this.schoolIds == null) {
+                this.schoolIds = newArrayList();
+            }
+            this.schoolIds.add(id);
+            return this;
         }
-        if (grant.getEntityLevel() == Grant.EntityLevel.DISTRICT) {
-            return new PermissionScope(
-                    ImmutableSet.of(districtIdByNaturalId.get(grant.getEntityId())),
-                    ImmutableSet.of()
+
+        public boolean isValid() {
+            return statewide || (
+                    (districtIds != null ? districtIds.size() : 0)
+                            + (schoolIds != null ? schoolIds.size() : 0)
+                            > 0
             );
         }
-        return new PermissionScope(
-                ImmutableSet.of(),
-                ImmutableSet.of(institutionIdByNaturalId.get(grant.getEntityId()))
-        );
 
-    }
+        public PermissionScope build() {
+            if (statewide) {
+                return PermissionScope.STATEWIDE;
+            }
+            return new PermissionScope(districtIds, schoolIds);
+        }
 
-    private Permission union(final Permission a, final Permission b) {
-        if (a.getScope().isStatewide()) {
-            return a;
-        }
-        if (b.getScope().isStatewide()) {
-            return b;
-        }
-        return new Permission(
-                a.getId(),
-                new PermissionScope(
-                        ImmutableSet.<Long>builder()
-                                .addAll(a.getScope().getDistrictIds())
-                                .addAll(b.getScope().getDistrictIds())
-                                .build(),
-                        ImmutableSet.<Long>builder()
-                                .addAll(a.getScope().getInstitutionIds())
-                                .addAll(b.getScope().getInstitutionIds())
-                                .build()
-                )
-        );
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -122,7 +122,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
                         if (id != null) {
                             permissionScopeBuilder.addSchoolId(id);
                         } else {
-                            logger.warn("grant district with natural ID \"{}\" not found", grant.getEntityId());
+                            logger.warn("grant school with natural ID \"{}\" not found", grant.getEntityId());
                         }
                     }
                 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationServiceTest.java
@@ -5,36 +5,54 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.security.GroupGrant;
 import org.opentestsystem.rdw.reporting.security.Permission;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
 import org.opentestsystem.rdw.security.Grant;
 import org.opentestsystem.rdw.security.service.PermissionService;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.DISTRICT;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.INSTITUTION;
+import static org.opentestsystem.rdw.security.Grant.EntityLevel.STATE;
 
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
 public class DefaultAuthorizationServiceTest {
 
-    private final String stateA = "stateA";
-    private final String stateB = "stateB";
+    private static final String stateA = "stateA";
+
+    @MockBean
     private PermissionService permissionService;
+
+    @MockBean
     private DistrictRepository districtRepository;
+
+    @MockBean
     private InstitutionRepository institutionRepository;
+
+    @MockBean
     private GroupGrantRepository groupMembershipRepository;
+
     private DefaultAuthorizationService authorizationService;
 
     @Before
     public void before() throws Exception {
-        permissionService = mock(PermissionService.class);
-        districtRepository = mock(DistrictRepository.class);
-        institutionRepository = mock(InstitutionRepository.class);
-        groupMembershipRepository = mock(GroupGrantRepository.class);
-        authorizationService = new DefaultAuthorizationService(stateA, permissionService, districtRepository, institutionRepository, groupMembershipRepository);
+        authorizationService = new DefaultAuthorizationService(
+                stateA,
+                permissionService,
+                districtRepository,
+                institutionRepository,
+                groupMembershipRepository
+        );
 
         when(permissionService.getPermissionsByRole()).thenReturn(ImmutableMap.of(
                 "a", ImmutableSet.of("a"),
@@ -53,18 +71,18 @@ public class DefaultAuthorizationServiceTest {
         final String[] encodedGrants = {"|stateA|roleA|STATE|||||stateA||||||||||", "|stateB|roleA|STATE|||||stateB||||||||||"};
         assertThat(authorizationService.getGrants(encodedGrants))
                 .containsExactlyInAnyOrder(
-                        Grant.builder().entityId(stateA).role("roleA").entityLevel(Grant.EntityLevel.STATE).stateId(stateA).build()
+                        Grant.builder().entityId(stateA).role("roleA").entityLevel(STATE).stateId(stateA).build()
                 );
     }
 
     @Test
     public void getPermissionsShouldCorrectlyDerivePermissionsFromGrants() throws Exception {
         final List<Grant> grants = ImmutableList.of(
-                Grant.builder().entityId("a").role("a").entityLevel(Grant.EntityLevel.STATE).stateId("a").build(),
-                Grant.builder().entityId("a").role("b").entityLevel(Grant.EntityLevel.DISTRICT).stateId("a").districtId("a").build(),
-                Grant.builder().entityId("a").role("c").entityLevel(Grant.EntityLevel.INSTITUTION).stateId("a").districtId("a").institutionId("a").build(),
-                Grant.builder().entityId("a").role("d").entityLevel(Grant.EntityLevel.DISTRICT).stateId("a").districtId("a").build(),
-                Grant.builder().entityId("a").role("d").entityLevel(Grant.EntityLevel.INSTITUTION).stateId("a").districtId("a").institutionId("a").build()
+                Grant.builder().entityId("a").role("a").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("b").entityLevel(DISTRICT).stateId("a").districtId("a").build(),
+                Grant.builder().entityId("a").role("c").entityLevel(INSTITUTION).stateId("a").districtId("a").institutionId("a").build(),
+                Grant.builder().entityId("a").role("d").entityLevel(DISTRICT).stateId("a").districtId("a").build(),
+                Grant.builder().entityId("a").role("d").entityLevel(INSTITUTION).stateId("a").districtId("a").institutionId("a").build()
         );
 
         assertThat(authorizationService.getPermissions(grants))
@@ -79,11 +97,68 @@ public class DefaultAuthorizationServiceTest {
     }
 
     @Test
+    public void getPermissionsShouldIgnoreOrganizationsForWhichThereIsNoEntityID() throws Exception {
+        final List<Grant> grants = ImmutableList.of(
+                Grant.builder().entityId("missing_school").role("a").entityLevel(INSTITUTION).stateId("a").districtId("2").institutionId("missing_school").build(),
+                Grant.builder().entityId("missing_district").role("a").entityLevel(DISTRICT).stateId("a").districtId("missing_district").build()
+        );
+
+        assertThat(authorizationService.getPermissions(grants)).isEmpty();
+    }
+
+    @Test
+    public void getPermissionsShouldAllowButIgnoreOrganizationsForWhichThereIsNoEntityID() throws Exception {
+        final List<Grant> grants = ImmutableList.of(
+                Grant.builder().entityId("a").role("a").entityLevel(INSTITUTION).stateId("a").districtId("2").institutionId("a").build(),
+                Grant.builder().entityId("missing_district").role("a").entityLevel(DISTRICT).stateId("a").districtId("missing_district").build()
+        );
+
+        assertThat(authorizationService.getPermissions(grants))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        new Permission("a", new PermissionScope(null, ImmutableSet.of(1L)))
+                );
+    }
+
+    @Test
+    public void getPermissionsShouldUnionPermissionScopesOfRepeatingPermissions() throws Exception {
+
+        when(districtRepository.findAllIds(ImmutableSet.of("2", "4"))).thenReturn(ImmutableMap.of("2", 2L, "4", 4L));
+        when(institutionRepository.findAllIds(ImmutableSet.of("1", "3"))).thenReturn(ImmutableMap.of("1", 1L, "3", 3L));
+
+        final List<Grant> grants = ImmutableList.of(
+                Grant.builder().entityId("1").role("a").entityLevel(INSTITUTION).stateId("a").districtId("2").institutionId("1").build(),
+                Grant.builder().entityId("2").role("a").entityLevel(DISTRICT).stateId("a").districtId("2").build(),
+                Grant.builder().entityId("3").role("a").entityLevel(INSTITUTION).stateId("a").districtId("4").institutionId("3").build(),
+                Grant.builder().entityId("4").role("a").entityLevel(DISTRICT).stateId("a").districtId("4").build()
+        );
+
+        assertThat(authorizationService.getPermissions(grants))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        new Permission("a", new PermissionScope(ImmutableSet.of(2L, 4L), ImmutableSet.of(1L, 3L)))
+                );
+    }
+
+    @Test
+    public void getPermissionsShouldProduceStateLevelPermissionScopeForUnionWithStateLevel() throws Exception {
+
+        final List<Grant> grants = ImmutableList.of(
+                Grant.builder().entityId("a").role("a").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("a").entityLevel(DISTRICT).stateId("a").districtId("a").build()
+        );
+
+        assertThat(authorizationService.getPermissions(grants))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(new Permission("a", PermissionScope.STATEWIDE));
+    }
+
+    @Test
     public void getAuthoritiesShouldOnlyReturnStateLevelRolesAndPermissions() throws Exception {
         assertThat(authorizationService.getAuthorities(ImmutableList.of(
-                Grant.builder().entityId("a").role("a").entityLevel(Grant.EntityLevel.STATE).stateId("a").build(),
-                Grant.builder().entityId("a").role("b").entityLevel(Grant.EntityLevel.DISTRICT).stateId("a").districtId("a").build(),
-                Grant.builder().entityId("a").role("c").entityLevel(Grant.EntityLevel.INSTITUTION).stateId("a").districtId("a").institutionId("a").build()
+                Grant.builder().entityId("a").role("a").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("b").entityLevel(DISTRICT).stateId("a").districtId("a").build(),
+                Grant.builder().entityId("a").role("c").entityLevel(INSTITUTION).stateId("a").districtId("a").institutionId("a").build()
         ))).containsExactlyInAnyOrder(
                 new SimpleGrantedAuthority("ROLE_A"),
                 new SimpleGrantedAuthority("PERM_A")
@@ -93,14 +168,14 @@ public class DefaultAuthorizationServiceTest {
     @Test
     public void getAuthoritiesShouldIgnoreRolesNotProvidedByThePermissionService() throws Exception {
         assertThat(authorizationService.getAuthorities(ImmutableList.of(
-                Grant.builder().entityId("a").role("z").entityLevel(Grant.EntityLevel.STATE).stateId("a").build()
+                Grant.builder().entityId("a").role("z").entityLevel(STATE).stateId("a").build()
         ))).isEmpty();
     }
 
     @Test
     public void getAuthoritiesShouldNotFailIfThereAreNoPermissionsForAGivenRole() throws Exception {
         assertThat(authorizationService.getAuthorities(ImmutableList.of(
-                Grant.builder().entityId("a").role("e").entityLevel(Grant.EntityLevel.STATE).stateId("a").build()
+                Grant.builder().entityId("a").role("e").entityLevel(STATE).stateId("a").build()
         ))).containsExactlyInAnyOrder(
                 new SimpleGrantedAuthority("ROLE_E")
         );
@@ -109,10 +184,10 @@ public class DefaultAuthorizationServiceTest {
     @Test
     public void getAuthoritiesShouldReturnAllStateLevelRolesAndPermissions() throws Exception {
         assertThat(authorizationService.getAuthorities(ImmutableList.of(
-                Grant.builder().entityId("a").role("a").entityLevel(Grant.EntityLevel.STATE).stateId("a").build(),
-                Grant.builder().entityId("a").role("b").entityLevel(Grant.EntityLevel.STATE).stateId("a").build(),
-                Grant.builder().entityId("a").role("c").entityLevel(Grant.EntityLevel.STATE).stateId("a").build(),
-                Grant.builder().entityId("a").role("d").entityLevel(Grant.EntityLevel.STATE).stateId("a").build()
+                Grant.builder().entityId("a").role("a").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("b").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("c").entityLevel(STATE).stateId("a").build(),
+                Grant.builder().entityId("a").role("d").entityLevel(STATE).stateId("a").build()
         ))).containsExactlyInAnyOrder(
                 new SimpleGrantedAuthority("ROLE_A"),
                 new SimpleGrantedAuthority("PERM_A"),


### PR DESCRIPTION
Auth service now resolves the case of different tenancy chain role grants have overlapping permission sets with different access levels associated to them (state, district, school).
The solution implemented makes a union of the organizations associated with the permission. 

Example:

Tenancy chain:
PII|{districtA, schoolA}
PII_GROUP|{schoolB}

With permission mapping:
PII -> INDIVIDUAL_PII_READ, GROUP_PII_READ, GROUP_READ
PII_GROUP -> GROUP_PII_READ, GROUP_READ

will result in permissions:
INDIVIDUAL_PII_READ|{districtA, schoolA}
GROUP_PII_READ|{districtA, schoolA, schoolB}
GROUP_READ|{districtA, schoolA, schoolB}

