### PR TITLE
Updated homepage

### DIFF
--- a/webapp/src/main/webapp/src/app/groups/groups.component.html
+++ b/webapp/src/main/webapp/src/app/groups/groups.component.html
@@ -2,6 +2,7 @@
 
   <div class="flex-child grow">
     <label>{{'labels.groups.search-label' | translate }}</label>
+  </div>
 
   <!-- My Groups Search Input -->
   <div *ngIf="groups.length > 2" class="gray-lightest pt-sm pr-sm pb-sm pl-sm my-groups-search-form-container">

--- a/webapp/src/main/webapp/src/app/groups/groups.component.html
+++ b/webapp/src/main/webapp/src/app/groups/groups.component.html
@@ -1,5 +1,8 @@
 <div *ngIf="groups" class="home-view">
 
+  <div class="flex-child grow">
+    <label>{{'labels.groups.search-label' | translate }}</label>
+
   <!-- My Groups Search Input -->
   <div *ngIf="groups.length > 2" class="gray-lightest pt-sm pr-sm pb-sm pl-sm my-groups-search-form-container">
     <label for="search" class="sr-only">Search My Groups</label>

--- a/webapp/src/main/webapp/src/app/home/home.component.html
+++ b/webapp/src/main/webapp/src/app/home/home.component.html
@@ -4,20 +4,20 @@
 
     <!-- Left Column Content Area -->
     <div class="col-md-9">
-      <h1 class="sr-only">Reporting System Dashboard</h1>
+      <h1 class="sr-only">{{'labels.homepage.title' | translate}}</h1>
 
       <!-- Student ID Search -->
-      <h2 class="blue-dark h3 mb-md">Search by Student ID</h2>
+      <h1 class="blue-dark h3 mb-md">{{'labels.homepage.title' | translate}}</h1>
       <div class="student-id-search-container well">
         <form>
           <div class="form-group">
             <div class="flex-children">
               <div class="flex-child grow">
-                <label for="student-id-input">Statewide Student Identifier (SSID)</label>
-                <input type="text" class="form-control" id="student-id-input" placeholder="Enter the Statewide Student Identifier (SSID)">
+                <label for="student-id-input">{{'labels.homepage.search-student-id.label' | translate}}</label>
+                <input type="text" class="form-control" id="student-id-input" placeholder="{{'labels.homepage.search-student-id.placeholder' | translate}}">
               </div>
               <div class="flex-child">
-                <button type="submit" class="btn btn-primary">Search</button>
+                <button type="submit" class="btn btn-primary">{{'buttons.search' | translate}}</button>
               </div>
             </div>
           </div>
@@ -25,17 +25,16 @@
       </div>
 
       <!-- School & Grade Search -->
-      <h2 class="blue-dark h3 mb-md">Search by School &amp; Grade</h2>
       <div class="school-and-grade-search-container well">
         <form>
           <div class="form-group">
             <div class="flex-children">
               <div class="flex-child grow">
-                <label for="school-name-input">Search by School Name</label>
-                <input type="text" class="form-control" id="school-name-input" placeholder="Start typing the school name">
+                <label for="school-name-input">{{'labels.homepage.search-school-grade.school-label' | translate}}</label>
+                <input type="text" class="form-control" id="school-name-input" placeholder="{{'labels.homepage.search-school-grade.school-placeholder' | translate }}">
               </div>
               <div class="flex-child">
-                <label for="grade-select">Grade</label>
+                <label for="grade-select">{{'labels.homepage.search-school-grade.grade-label' | translate}}</label>
                 <select name="grade-select" id="grade-select" class="form-control">
                   <option value="3">3</option>
                   <option value="4">4</option>
@@ -47,7 +46,7 @@
                 </select>
               </div>
               <div class="flex-child">
-                <button type="submit" class="btn btn-primary mt-md">Search</button>
+                <button type="submit" class="btn btn-primary mt-md">{{'buttons.search' | translate}}</button>
               </div>
             </div>
           </div>
@@ -55,7 +54,6 @@
       </div>
 
       <!-- My Groups Search -->
-      <h2 class="blue-dark h3 mb-md">My Groups</h2>
       <div class="my-groups-search-container well">
         <div *sbAuthorize="['GROUP_PII_READ','INDIVIDUAL_PII_READ']">
           <!--TODO:  Implement authorize of PII or PII Group role. -->
@@ -68,14 +66,16 @@
     <div class="col-md-3 pt-md">
       <!-- Student Groups Admin Link -->
       <p class="text-right">
-        <a href="#" class="btn btn-xs btn-info"><i class="fa fa-gear"></i> Student Groups Admin</a>
+        <a href="#" class="btn btn-xs btn-info"><i class="fa fa-gear"></i> {{'labels.groups.manage-group' | translate}}</a>
       </p>
 
       <!-- Welcome Content -->
       <div class="welcome-container well">
-        <p class="lead">Welcome! Get the most from the Reporting System:</p>
-        <p><a href="#" class="btn btn-primary">User Guide</a></p>
-        <p><a href="#" class="btn btn-success">Interpretive Guide</a></p>
+        <p class="lead">{{'labels.homepage.welcome.title' | translate}}</p>
+        <p>{{'labels.homepage.welcome.sub-title' | translate}}</p>
+        <p><a href="#" class="btn btn-primary">{{'labels.user-guide' | translate}}</a></p>
+        <p>{{'labels.homepage.welcome.interpret-instructions' | translate}}</p>
+        <p><a href="#" class="btn btn-success">{{'labels.interpretive-guide' | translate}}</a></p>
       </div>
 
       <!-- Summary Reports Content -->

--- a/webapp/src/main/webapp/src/app/home/home.component.html
+++ b/webapp/src/main/webapp/src/app/home/home.component.html
@@ -7,7 +7,7 @@
       <h1 class="sr-only">{{'labels.homepage.title' | translate}}</h1>
 
       <!-- Student ID Search -->
-      <h1 class="blue-dark h3 mb-md">{{'labels.homepage.title' | translate}}</h1>
+      <h1 class="blue-dark h1 mb-md">{{'labels.homepage.title' | translate}}</h1>
       <div class="student-id-search-container well">
         <form>
           <div class="form-group">

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -11,10 +11,29 @@
     "notApplicable": "-"
   },
   "labels": {
+    "homepage": {
+      "title": "Access Assessment Results",
+      "search-student-id": {
+        "label": "Search by Student",
+        "placeholder": "Enter the Statewide Student Identifier (SSID)"
+      },
+      "search-school-grade": {
+        "school-label": "Search by School Name",
+        "school-placeholder": "Start typing the school name",
+        "grade-label": "Grade"
+      },
+      "welcome": {
+        "title": "Welcome!",
+        "sub-title": "Get the most from the Reporting System:",
+        "interpret-instructions": "Learn how to interpret the scores in this reporting tool:"
+      }
+    },
     "groups": {
       "name": "My Groups",
       "filter": "Search by Group Name",
       "empty-message": "Contact your building administrator for access to group-level test results",
+      "manage-group": "Manage Student Groups",
+      "search-label": "Search by My Groups",
       "cols": {
         "group" : "Group Name",
         "school" : "School",
@@ -104,8 +123,9 @@
           }
         }
       }
-    }
-
+    },
+    "user-guide": "User Guide",
+    "interpretive-guide": "Interpretive Guide"
   },
   "buttons": {
     "all": "All",
@@ -116,7 +136,8 @@
     "collapsible": {
       "expand": "Expand",
       "collapse": "Collapse"
-    }
+    },
+    "search": "Search"
   },
   "enum" : {
     "administrative-condition" : {


### PR DESCRIPTION
- use translate instead of static text
- minor structure updates based on latest mockup

Please check the en.json hierarchy to see if it fits with what you had in mind as far as structure.  I went back and forth on whether the search widget content should be under homepage as a section or their own like groups is.