### PR TITLE
Explicitly set typescript version to 2.3.4 as 2.4 is not compiling wi…

### DIFF
--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -55,7 +55,7 @@
     "protractor": "4.0.9",
     "ts-node": "1.2.1",
     "tslint": "^4.0.0",
-    "typescript": "^2.2.1",
+    "typescript": "2.3.4",
     "webdriver-manager": "10.2.5"
   }
 }


### PR DESCRIPTION
…th rxjs.


Fixes broken build:  

https://github.com/Microsoft/TypeScript/issues/16593