### PR TITLE
prunes endpoint data models

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/Exam.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/Exam.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.reporting.exam;
 
-import com.google.common.base.MoreObjects;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.time.Instant;
@@ -16,12 +15,11 @@ public class Exam {
     private Long assessmentId;
     private String sessionId;
     private Instant dateTime;
+    private Integer schoolYear;
+    private int gradeId;
     private Student student;
     private StudentContext studentContext;
-    private Long opportunity;
-    private int administrativeConditionId;
     private String administrativeConditionCode;
-    private int completenessId;
     private String completenessCode;
     private ScaleScore scaleScore;
     private List<ScaleScore> claimScaleScores;
@@ -58,10 +56,17 @@ public class Exam {
     }
 
     /**
-     * @return the student's attempt number on the assessment
+     * @return the school year in which the exam was taken
      */
-    public Long getOpportunity() {
-        return opportunity;
+    public Integer getSchoolYear() {
+        return schoolYear;
+    }
+
+    /**
+     * @return the grade entity ID of the student at the time of the exam
+     */
+    public int getGradeId() {
+        return gradeId;
     }
 
     /**
@@ -86,28 +91,10 @@ public class Exam {
     }
 
     /**
-     * @deprecated use {@link #getCompletenessCode()} instead.
-     * @return the completeness of the exam (partial, complete)
-     */
-    @Deprecated
-    public int getCompletenessId() {
-        return completenessId;
-    }
-
-    /**
      * @return the completeness of the exam
      */
     public String getCompletenessCode() {
         return completenessCode;
-    }
-
-    /**
-     * @deprecated use {@link #getAdministrativeConditionCode()} instead.
-     * @return the condition in which the exam was administered (valid, invalid, standard, non standard)
-     */
-    @Deprecated
-    public int getAdministrativeConditionId() {
-        return administrativeConditionId;
     }
 
     /**
@@ -143,13 +130,12 @@ public class Exam {
         private Long assessmentId;
         private String sessionId;
         private Instant dateTime;
-        private Long opportunity;
+        private Integer schoolYear;
+        private int gradeId;
         private Student student;
         private StudentContext studentContext;
         private ScaleScore scaleScore;
-        private int completenessId;
         private String completenessCode;
-        private int administrativeConditionId;
         private String administrativeConditionCode;
         private List<ScaleScore> claimScaleScores;
 
@@ -173,8 +159,13 @@ public class Exam {
             return this;
         }
 
-        public Builder opportunity(final Long opportunity) {
-            this.opportunity = opportunity;
+        public Builder schoolYear(final Integer schoolYear) {
+            this.schoolYear = schoolYear;
+            return this;
+        }
+
+        public Builder gradeId(final int gradeId) {
+            this.gradeId = gradeId;
             return this;
         }
 
@@ -193,18 +184,8 @@ public class Exam {
             return this;
         }
 
-        public Builder completenessId(final int completenessId) {
-            this.completenessId = completenessId;
-            return this;
-        }
-
         public Builder completenessCode(final String completenessCode) {
             this.completenessCode = completenessCode;
-            return this;
-        }
-
-        public Builder administrativeConditionId(final int administrativeConditionId) {
-            this.administrativeConditionId = administrativeConditionId;
             return this;
         }
 
@@ -224,13 +205,12 @@ public class Exam {
             exam.assessmentId = assessmentId;
             exam.sessionId = sessionId;
             exam.dateTime = dateTime;
-            exam.opportunity = opportunity;
+            exam.schoolYear = schoolYear;
+            exam.gradeId = gradeId;
             exam.student = student;
             exam.studentContext = studentContext;
             exam.scaleScore = scaleScore;
-            exam.completenessId = completenessId;
             exam.completenessCode = completenessCode;
-            exam.administrativeConditionId = administrativeConditionId;
             exam.administrativeConditionCode = administrativeConditionCode;
             exam.claimScaleScores = claimScaleScores != null ? Collections.unmodifiableList(claimScaleScores) : null;
             return exam;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/Student.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/Student.java
@@ -13,7 +13,6 @@ public class Student {
     private String ssid;
     private String firstName;
     private String lastName;
-    private long genderId;
     private String genderCode;
     private Set<String> ethnicityCodes;
 
@@ -53,15 +52,6 @@ public class Student {
     }
 
     /**
-     * @deprecated @deprecated use {@link #getGenderCode()} instead.
-     * @return the student's gender entity ID
-     */
-    @Deprecated
-    public long getGenderId() {
-        return genderId;
-    }
-
-    /**
      * @return the student's gender code
      */
     public String getGenderCode() {
@@ -81,7 +71,6 @@ public class Student {
         private String ssid;
         private String firstName;
         private String lastName;
-        private long genderId;
         private String genderCode;
         private Set<String> ethnicityCodes;
 
@@ -105,11 +94,6 @@ public class Student {
             return this;
         }
 
-        public Builder genderId(final long genderId) {
-            this.genderId = genderId;
-            return this;
-        }
-
         public Builder genderCode(final String genderCode) {
             this.genderCode = genderCode;
             return this;
@@ -126,7 +110,6 @@ public class Student {
             student.ssid = ssid;
             student.firstName = firstName;
             student.lastName = lastName;
-            student.genderId = genderId;
             student.genderCode = genderCode;
             student.ethnicityCodes = ethnicityCodes != null ? ImmutableSet.copyOf(ethnicityCodes) : ImmutableSet.of();
             return student;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/StudentContext.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/exam/StudentContext.java
@@ -7,8 +7,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  */
 public class StudentContext {
 
-    // TODO: move schoolYear, gradeId to Exam
-    private int schoolYear;
+    // TODO: remove gradeId when client starts using Exam.gradeId
     private int gradeId;
     private boolean iep;
     private boolean lep;
@@ -21,13 +20,6 @@ public class StudentContext {
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    /**
-     * @return the school year in which the exam was taken
-     */
-    public int getSchoolYear() {
-        return schoolYear;
     }
 
     /**
@@ -79,18 +71,12 @@ public class StudentContext {
 
     public static class Builder {
 
-        private int schoolYear;
         private int gradeId;
         private boolean iep;
         private boolean lep;
         private boolean section504;
         private boolean economicDisadvantage;
         private Boolean migrantStatus;
-
-        public Builder schoolYear(final int schoolYear) {
-            this.schoolYear = schoolYear;
-            return this;
-        }
 
         public Builder gradeId(final int gradeId) {
             this.gradeId = gradeId;
@@ -124,7 +110,6 @@ public class StudentContext {
 
         public StudentContext build() {
             final StudentContext context = new StudentContext();
-            context.schoolYear = schoolYear;
             context.gradeId = gradeId;
             context.iep = iep;
             context.lep = lep;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractAssessmentRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractAssessmentRepository.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.search.exam;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
@@ -53,7 +54,15 @@ public abstract class AbstractAssessmentRepository<T extends AbstractAssessmentS
     }
 
     private Assessment buildAssessment(final ResultSet row, final int index) throws SQLException {
-        return Assessments.map(row, Assessment.builder()).build();
+        return Assessments.map(row, Assessment.builder())
+                .cutPoints(ImmutableList.of(
+                        row.getInt("min_score"),
+                        row.getInt("cut_point_1"),
+                        row.getInt("cut_point_2"),
+                        row.getInt("cut_point_3"),
+                        row.getInt("max_score")
+                ))
+                .build();
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamRepository.java
@@ -65,7 +65,6 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
 
             final Exam.Builder examBuilder = Exam.builder()
                     .studentContext(StudentContext.builder()
-                            .schoolYear(row.getInt("school_year"))
                             .gradeId(row.getInt("grade_id"))
                             .iep(row.getBoolean("iep"))
                             .lep(row.getBoolean("lep"))
@@ -90,7 +89,6 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
                     .id(studentId)
                     .firstName(row.getString("student_first_name"))
                     .lastName(row.getString("student_last_name"))
-                    .genderId(row.getLong("student_gender_id"))
                     .genderCode(row.getString("student_gender_code"))
                     .ethnicityCodes(ethnicityCodes)
                     .build()

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Assessments.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Assessments.java
@@ -29,14 +29,7 @@ public final class Assessments {
                 .gradeId(row.getInt("grade_id"))
                 .type(type)
                 .subject(Subject.valueOf(row.getInt("subject_id")))
-                .schoolYear(row.getInt("school_year"))
-                .cutPoints(ImmutableList.of(
-                        row.getInt("min_score"),
-                        row.getInt("cut_point_1"),
-                        row.getInt("cut_point_2"),
-                        row.getInt("cut_point_3"),
-                        row.getInt("max_score")
-                ));
+                .schoolYear(row.getInt("school_year"));
 
         // IABs do not have claims
         if (type != AssessmentType.IAB) {

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Exams.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Exams.java
@@ -37,10 +37,8 @@ public final class Exams {
         builder.id(row.getLong("id"))
                 .sessionId(row.getString("session_id"))
                 .dateTime(row.getTimestamp("completed_at").toInstant())
-                .opportunity(getNullable(row, row.getLong("opportunity")))
-                .completenessId(row.getInt("completeness_id"))
+                .gradeId(row.getInt("grade_id"))
                 .completenessCode(row.getString("completeness_code"))
-                .administrativeConditionId(row.getInt("administration_condition_id"))
                 .administrativeConditionCode(row.getString("administration_condition_code"))
                 .scaleScore(scaleScore);
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
@@ -38,8 +38,8 @@ class JdbcStudentExamRepository implements StudentExamRepository {
                         .build(),
                 (row, index) -> Exams.map(row, Exam.builder())
                         .assessmentId(row.getLong("asmt_id"))
+                        .schoolYear(row.getInt("school_year"))
                         .studentContext(StudentContext.builder()
-                                .schoolYear(row.getInt("school_year"))
                                 .gradeId(row.getInt("grade_id"))
                                 .build()
                         )

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -5,10 +5,7 @@ sql:
         e.type_id,
         e.grade_id,
         e.school_year,
-        e.opportunity,
-        e.completeness_id,
         e.completeness_code,
-        e.administration_condition_id,
         e.administration_condition_code,
         e.session_id,
         e.completed_at,
@@ -75,12 +72,11 @@ sql:
           join exam e on e.asmt_id = a.id
           join student_group_membership sgm on e.student_id=sgm.student_id
           join school s on e.school_id=s.id
-          where
-              e.school_year=:school_year
-              and sgm.student_group_id=:group_id
-              and (0=:group_subject_id or a.subject_id=:group_subject_id)
-              and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
-              and a.id = e.asmt_id
+          where e.school_year=:school_year
+          and sgm.student_group_id=:group_id
+          and (0=:group_subject_id or a.subject_id=:group_subject_id)
+          and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+          and a.id = e.asmt_id
 
     exam:
       findLatest: >-
@@ -120,11 +116,7 @@ sql:
             e.section504,
             e.economic_disadvantage,
             e.migrant_status,
-            e.school_year,
-            e.opportunity,
-            e.completeness_id,
             e.completeness_code,
-            e.administration_condition_id,
             e.administration_condition_code,
             e.session_id,
             e.completed_at,
@@ -150,7 +142,6 @@ sql:
             st.id as student_id,
             st.last_or_surname as student_last_name,
             st.first_name as student_first_name,
-            st.gender_id as student_gender_id,
             st.gender_code as student_gender_code
           from exam e
             join student_group_membership sgm on e.student_id=sgm.student_id
@@ -248,11 +239,7 @@ sql:
           e.section504,
           e.economic_disadvantage,
           e.migrant_status,
-          e.school_year,
-          e.opportunity,
-          e.completeness_id,
           e.completeness_code,
-          e.administration_condition_id,
           e.administration_condition_code,
           e.session_id,
           e.completed_at,
@@ -278,7 +265,6 @@ sql:
           st.id as student_id,
           st.last_or_surname as student_last_name,
           st.first_name as student_first_name,
-          st.gender_id as student_gender_id,
           st.gender_code as student_gender_code
         from exam e
           join student st on e.student_id=st.id
@@ -309,23 +295,18 @@ sql:
 
   assessment:
     findAllByIds: >-
-      select a.id,
-        a.label,
-        a.grade_id,
-        a.type_id,
-        a.subject_id,
-        a.school_year,
-        a.claim1_score_code,
-        a.claim2_score_code,
-        a.claim3_score_code,
-        a.claim4_score_code,
-        a.min_score,
-        a.max_score,
-        a.cut_point_1,
-        a.cut_point_2,
-        a.cut_point_3
-      from asmt a
-      where a.id in (:assessment_ids)
+      select id,
+        label,
+        grade_id,
+        type_id,
+        subject_id,
+        school_year,
+        claim1_score_code,
+        claim2_score_code,
+        claim3_score_code,
+        claim4_score_code
+      from asmt
+      where id in (:assessment_ids)
 
     grade:
       findAllForSchool: >-

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
@@ -2,12 +2,14 @@ package org.opentestsystem.rdw.reporting;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;
 import org.opentestsystem.rdw.reporting.exam.ScaleScore;
+import org.opentestsystem.rdw.reporting.exam.Student;
 import org.opentestsystem.rdw.reporting.exam.StudentContext;
 
 import java.time.Instant;
@@ -19,213 +21,219 @@ import static com.google.common.collect.Lists.newArrayList;
 
 public final class TestData {
 
-    public static final List<Assessment> ASSESSMENTS = ImmutableList.of(
-            Assessment.builder()
-                    .id(-1L)
-                    .type(AssessmentType.ICA)
-                    .name("ica1")
-                    .gradeId(-1)
-                    .schoolYear(2017)
-                    .subject(Subject.MATH)
-                    .cutPoints(newArrayList(100, 200, 300, 400, 500))
-                    .claimCodes(newArrayList("ica_claim1", "ica_claim2", "ica_claim3", "ica_claim4"))
-                    .build(),
-            Assessment.builder()
-                    .id(-2L)
-                    .type(AssessmentType.IAB)
-                    .name("iab1")
-                    .gradeId(-1)
-                    .schoolYear(2017)
-                    .subject(Subject.MATH)
-                    .cutPoints(newArrayList(1, 0, 2, 0, 3))
-                    .claimCodes(null)
-                    .build(),
-            Assessment.builder()
-                    .id(-3L)
-                    .type(AssessmentType.SUMMATIVE)
-                    .name("sum1")
-                    .gradeId(-1)
-                    .schoolYear(2017)
-                    .subject(Subject.MATH)
-                    .cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000))
-                    .claimCodes(newArrayList("sum_claim1", "sum_claim2", "sum_claim3"))
-                    .build()
+    public static final List<Assessment> STUDENT_ASSESSMENTS = ImmutableList.of(
+            assessmentBuilder1().build(),
+            assessmentBuilder2().build(),
+            assessmentBuilder3().build()
     );
-
+    public static final List<Assessment> ASSESSMENTS = ImmutableList.of(
+            assessmentBuilder1().cutPoints(newArrayList(100, 200, 300, 400, 500)).build(),
+            assessmentBuilder2().cutPoints(newArrayList(1, 0, 2, 0, 3)).build(),
+            assessmentBuilder3().cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build()
+    );
+    public static final List<Exam> STUDENT_EXAMS = ImmutableList.of(
+            exam1().assessmentId(-1L).schoolYear(2017).build(),
+            exam2().assessmentId(-2L).schoolYear(2017).build(),
+            exam3().assessmentId(-3L).schoolYear(2017).build(),
+            exam4().assessmentId(-3L).schoolYear(2017).build(),
+            exam5().assessmentId(-3L).schoolYear(2017).build(),
+            exam6().assessmentId(-3L).schoolYear(2017).build()
+    );
     public static final List<Exam> EXAMS = ImmutableList.of(
-            Exam.builder()
-                    .id(-1)
-                    .assessmentId(-1L)
-                    .sessionId("session1")
-                    .dateTime(instant("2017-01-01"))
-                    .opportunity(0L)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-1)
-                            .iep(false)
-                            .lep(false)
-                            .section504(false)
-                            .economicDisadvantage(false)
-                            .migrantStatus(null)
-                            .build()
-                    )
-                    .administrativeConditionId(1)
-                    .administrativeConditionCode("Valid")
-                    .completenessId(2)
-                    .completenessCode("Complete")
-                    .scaleScore(
-                            ScaleScore.builder().level(1).value(2000).standardError(20).build()
-                    )
-                    .claimScaleScores(newArrayList(
-                            ScaleScore.builder().level(1).value(100).standardError(10).build(),
-                            ScaleScore.builder().level(2).value(200).standardError(20).build(),
-                            ScaleScore.builder().level(3).value(300).standardError(30).build(),
-                            ScaleScore.builder().level(4).value(400).standardError(40).build()
-                    ))
+            exam1()
+                    .student(student().build())
+                    .studentContext(studentContext().build())
                     .build(),
-            Exam.builder()
-                    .id(-2)
-                    .assessmentId(-2L)
-                    .sessionId("session2")
-                    .dateTime(instant("2017-01-01"))
-                    .opportunity(1L)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-2)
-                            .iep(false)
-                            .lep(false)
-                            .section504(false)
-                            .economicDisadvantage(false)
-                            .migrantStatus(null)
-                            .build()
-                    )
-                    .administrativeConditionId(1)
-                    .administrativeConditionCode("Valid")
-                    .completenessId(2)
-                    .completenessCode("Complete")
-                    .scaleScore(
-                            ScaleScore.builder().level(2).value(2100).standardError(21).build()
-                    )
-                    .claimScaleScores(null)
+            exam2()
+                    .student(student().build())
+                    .studentContext(studentContext().gradeId(-2).build())
                     .build(),
-            Exam.builder()
-                    .id(-3)
-                    .assessmentId(-3L)
-                    .sessionId("session3")
-                    .dateTime(instant("2017-01-01"))
-                    .opportunity(2L)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-3)
-                            .iep(false)
-                            .lep(false)
-                            .section504(false)
-                            .economicDisadvantage(false)
-                            .migrantStatus(null)
-                            .build()
-                    )
-                    .administrativeConditionId(1)
-                    .administrativeConditionCode("Valid")
-                    .completenessId(2)
-                    .completenessCode("Complete")
-                    .scaleScore(
-                            ScaleScore.builder().level(3).value(2200).standardError(22).build()
-                    )
-                    .claimScaleScores(newArrayList(
-                            ScaleScore.builder().level(1).value(1000).standardError(100).build(),
-                            ScaleScore.builder().level(2).value(2000).standardError(200).build(),
-                            ScaleScore.builder().level(3).value(3000).standardError(300).build()
-                    ))
+            exam3()
+                    .student(student().build())
+                    .studentContext(studentContext().gradeId(-3).build())
                     .build(),
-            Exam.builder()
-                    .id(-4)
-                    .assessmentId(-3L)
-                    .sessionId("session4")
-                    .dateTime(instant("2017-01-02"))
-                    .opportunity(3L)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-1)
-                            .iep(false)
-                            .lep(false)
-                            .section504(false)
-                            .economicDisadvantage(false)
-                            .migrantStatus(null)
-                            .build()
-                    )
-                    .administrativeConditionId(1)
-                    .administrativeConditionCode("Valid")
-                    .completenessId(2)
-                    .completenessCode("Complete")
-                    .scaleScore(
-                            ScaleScore.builder().level(1).value(2300).standardError(23).build()
-                    )
-                    .claimScaleScores(newArrayList(
-                            ScaleScore.builder().level(1).value(1100).standardError(110).build(),
-                            ScaleScore.builder().level(2).value(2100).standardError(210).build(),
-                            ScaleScore.builder().level(3).value(3100).standardError(310).build()
-                    ))
+            exam4()
+                    .student(student().build())
+                    .studentContext(studentContext().build())
                     .build(),
-            Exam.builder()
-                    .id(-5)
-                    .assessmentId(-3L)
-                    .sessionId("session5")
-                    .dateTime(instant("2017-01-05"))
-                    .opportunity(4L)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-1)
-                            .iep(false)
-                            .lep(false)
-                            .section504(false)
-                            .economicDisadvantage(false)
-                            .migrantStatus(null)
-                            .build()
-                    )
-                    .administrativeConditionId(1)
-                    .administrativeConditionCode("Valid")
-                    .completenessId(2)
-                    .completenessCode("Complete")
-                    .scaleScore(
-                            ScaleScore.builder().level(2).value(2400).standardError(24).build()
-                    )
-                    .claimScaleScores(newArrayList(
-                            ScaleScore.builder().level(1).value(1200).standardError(120).build(),
-                            ScaleScore.builder().level(2).value(2200).standardError(220).build(),
-                            ScaleScore.builder().level(3).value(3200).standardError(320).build()
-                    ))
+            exam5()
+                    .student(student().build())
+                    .studentContext(studentContext().build())
                     .build(),
-            Exam.builder()
-                    .id(-6)
-                    .assessmentId(-3L)
-                    .sessionId("session6")
-                    .dateTime(instant("2017-01-03"))
-                    .opportunity(null)
-                    .studentContext(StudentContext.builder()
-                            .schoolYear(2017)
-                            .gradeId(-1)
+            exam6()
+                    .student(student().build())
+                    .studentContext(studentContext()
                             .iep(true)
                             .lep(true)
                             .section504(true)
                             .economicDisadvantage(true)
-                            .migrantStatus(null)
                             .build()
                     )
-                    .administrativeConditionId(2)
-                    .administrativeConditionCode("Standardized")
-                    .completenessId(1)
-                    .completenessCode("Partial")
-                    .scaleScore(null)
-                    .claimScaleScores(newArrayList(null, null, null))
                     .build()
     );
-
+    public static final ImmutableMap<Long, Assessment> STUDENT_ASSESSMENTS_BY_ID = Maps.uniqueIndex(STUDENT_ASSESSMENTS, Assessment::getId);
     public static final ImmutableMap<Long, Assessment> ASSESSMENTS_BY_ID = Maps.uniqueIndex(ASSESSMENTS, Assessment::getId);
+    public static final ImmutableMap<Long, Exam> STUDENT_EXAMS_BY_ID = Maps.uniqueIndex(STUDENT_EXAMS, Exam::getId);
     public static final ImmutableMap<Long, Exam> EXAMS_BY_ID = Maps.uniqueIndex(EXAMS, Exam::getId);
 
-    private static Instant instant(final String value) {
-        return LocalDate.parse(value).atStartOfDay().toInstant(ZoneOffset.ofHours(-8));
+    private static Student.Builder student() {
+        return Student.builder()
+                .id(-1)
+                .firstName("student1_firstName")
+                .lastName("student1_lastName")
+                .genderCode("g1")
+                .ethnicityCodes(ImmutableSet.of());
     }
 
+    private static StudentContext.Builder studentContext() {
+        return StudentContext.builder()
+                .gradeId(-1)
+                .iep(false)
+                .lep(false)
+                .section504(false)
+                .economicDisadvantage(false)
+                .migrantStatus(null);
+    }
+
+    private static Instant instant(final String value) {
+        return LocalDate.parse(value).atStartOfDay().toInstant(ZoneOffset.ofHours(0));
+    }
+
+    public static Assessment.Builder assessmentBuilder1() {
+        return Assessment.builder()
+                .id(-1L)
+                .type(AssessmentType.ICA)
+                .name("ica1")
+                .gradeId(-1)
+                .schoolYear(2017)
+                .subject(Subject.MATH)
+                .claimCodes(newArrayList("ica_claim1", "ica_claim2", "ica_claim3", "ica_claim4"));
+    }
+
+    public static Assessment.Builder assessmentBuilder2() {
+        return Assessment.builder()
+                .id(-2L)
+                .type(AssessmentType.IAB)
+                .name("iab1")
+                .gradeId(-1)
+                .schoolYear(2017)
+                .subject(Subject.MATH)
+                .claimCodes(null);
+    }
+
+    public static Assessment.Builder assessmentBuilder3() {
+        return Assessment.builder()
+                .id(-3L)
+                .type(AssessmentType.SUMMATIVE)
+                .name("sum1")
+                .gradeId(-1)
+                .schoolYear(2017)
+                .subject(Subject.MATH)
+                .claimCodes(newArrayList("sum_claim1", "sum_claim2", "sum_claim3"));
+    }
+
+    public static Exam.Builder exam() {
+        return Exam.builder()
+                .gradeId(-1)
+                .administrativeConditionCode("Valid")
+                .completenessCode("Complete");
+    }
+
+    public static Exam.Builder exam1() {
+        return exam()
+                .id(-1)
+                .sessionId("session1")
+                .dateTime(instant("2017-01-01"))
+                .studentContext(studentContext().build())
+                .scaleScore(
+                        ScaleScore.builder().level(1).value(2000).standardError(20).build()
+                )
+                .claimScaleScores(newArrayList(
+                        ScaleScore.builder().level(1).value(100).standardError(10).build(),
+                        ScaleScore.builder().level(2).value(200).standardError(20).build(),
+                        ScaleScore.builder().level(3).value(300).standardError(30).build(),
+                        ScaleScore.builder().level(4).value(400).standardError(40).build()
+                ));
+    }
+
+    public static Exam.Builder exam2() {
+        return exam()
+                .id(-2)
+                .sessionId("session2")
+                .dateTime(instant("2017-01-01"))
+                .gradeId(-2)
+                .studentContext(studentContext()
+                        .gradeId(-2)
+                        .build()
+                )
+                .scaleScore(
+                        ScaleScore.builder().level(2).value(2100).standardError(21).build()
+                )
+                .claimScaleScores(null);
+    }
+
+    public static Exam.Builder exam3() {
+        return exam()
+                .id(-3)
+                .sessionId("session3")
+                .dateTime(instant("2017-01-01"))
+                .gradeId(-3)
+                .studentContext(studentContext()
+                        .gradeId(-3)
+                        .build()
+                )
+                .scaleScore(
+                        ScaleScore.builder().level(3).value(2200).standardError(22).build()
+                )
+                .claimScaleScores(newArrayList(
+                        ScaleScore.builder().level(1).value(1000).standardError(100).build(),
+                        ScaleScore.builder().level(2).value(2000).standardError(200).build(),
+                        ScaleScore.builder().level(3).value(3000).standardError(300).build()
+                ));
+    }
+
+    public static Exam.Builder exam4() {
+        return exam()
+                .id(-4)
+                .sessionId("session4")
+                .dateTime(instant("2017-01-02"))
+                .studentContext(studentContext().build())
+                .scaleScore(
+                        ScaleScore.builder().level(1).value(2300).standardError(23).build()
+                )
+                .claimScaleScores(newArrayList(
+                        ScaleScore.builder().level(1).value(1100).standardError(110).build(),
+                        ScaleScore.builder().level(2).value(2100).standardError(210).build(),
+                        ScaleScore.builder().level(3).value(3100).standardError(310).build()
+                ));
+    }
+
+    public static Exam.Builder exam5() {
+        return exam()
+                .id(-5)
+                .sessionId("session5")
+                .dateTime(instant("2017-01-05"))
+                .studentContext(studentContext().build())
+                .scaleScore(
+                        ScaleScore.builder().level(2).value(2400).standardError(24).build()
+                )
+                .claimScaleScores(newArrayList(
+                        ScaleScore.builder().level(1).value(1200).standardError(120).build(),
+                        ScaleScore.builder().level(2).value(2200).standardError(220).build(),
+                        ScaleScore.builder().level(3).value(3200).standardError(320).build()
+                ));
+    }
+
+    public static Exam.Builder exam6() {
+        return exam()
+                .id(-6)
+                .sessionId("session6")
+                .dateTime(instant("2017-01-03"))
+                .studentContext(studentContext().build())
+                .administrativeConditionCode("Standardized")
+                .completenessCode("Partial")
+                .scaleScore(null)
+                .claimScaleScores(newArrayList(null, null, null));
+    }
 
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
@@ -36,7 +36,7 @@ public class JdbcSchoolGradeExamRepositoryIT {
     @Test
     public void findAllForAssessmentShouldFindAll() throws Exception {
         assertThat(repository.findAllForAssessment(PermissionScope.STATEWIDE, search().build()))
-                .usingElementComparatorOnFields("id") // TODO: add full recursive field by field comparison
+                .usingRecursiveFieldByFieldElementComparator()
                 .containsExactlyInAnyOrder(TestData.EXAMS_BY_ID.get(-1L));
     }
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentAssessmentRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentAssessmentRepositoryIT.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.opentestsystem.rdw.reporting.TestData.ASSESSMENTS_BY_ID;
+import static org.opentestsystem.rdw.reporting.TestData.STUDENT_ASSESSMENTS_BY_ID;
 
 
 @RunWith(SpringRunner.class)
@@ -39,7 +39,7 @@ public class JdbcStudentAssessmentRepositoryIT {
     public void findAllByIdsShouldFindAllForExistingIds() throws Exception {
         assertThat(repository.findAllByIds(ImmutableSet.of(-3L, -2L, 0L)))
                 .usingFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(ASSESSMENTS_BY_ID.get(-2L), ASSESSMENTS_BY_ID.get(-3L));
+                .containsExactlyInAnyOrder(STUDENT_ASSESSMENTS_BY_ID.get(-2L), STUDENT_ASSESSMENTS_BY_ID.get(-3L));
     }
 
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
@@ -34,8 +34,8 @@ public class JdbcStudentExamRepositoryIT {
     @Test
     public void findAllForStudentShouldReturnAllExamsForExistingStudent() throws Exception {
         assertThat(repository.findAllForStudent(PermissionScope.STATEWIDE, -1L))
-                .usingElementComparatorOnFields("id") // TODO: add full recursive field by field comparison
-                .containsOnlyElementsOf(TestData.EXAMS);
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnlyElementsOf(TestData.STUDENT_EXAMS);
     }
 
 }


### PR DESCRIPTION
1. Removes unused Exam.opportunity, Exam.completenessId, Exam.administrationConditionId, StudentContext.schoolYear, Assessment.cutPoints, Student.genderId
2. Adds Exam.schoolYear, Exam.gradeId (moved from StudentContext)

TODO:
1. Move client to use exam.gradeId instead of exam.studentContext.gradeId