### PR TITLE
Feature/item by points grid headers

### DIFF
--- a/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/assessment/assessment-results.component.html
@@ -162,7 +162,11 @@
           <p-column field="fullCredit" [sortable]="true">
             <ng-template pTemplate="header">
               {{'labels.groups.results.assessment.items.cols.full-credit' | translate}}
-              <span class="icon"><i class="fa fa-info-circle"></i></span>
+              <span class="icon"
+                    popover="{{'labels.groups.results.assessment.items.cols.full-credit-info' | translate}}"
+                    popoverTitle="{{'labels.groups.results.assessment.items.cols.full-credit' | translate}}"
+                    triggers="click:mouseleave"
+              ><i class="fa fa-info-circle"></i></span>
             </ng-template>
             <ng-template let-item="rowData" pTemplate="body">
                 <span [hidden]="showValuesAsPercent">{{ item.fullCredit }}</span>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -122,7 +122,8 @@
               "difficulty": "Item Difficulty",
               "standard": "Standard",
               "full-credit": "Full Credit",
-              "x-points": "{{id}} Points"
+              "full-credit-info": "The full credit column represents ... need real data here",
+              "x-points": "{{id}}"
             },
             "target": "Target {{target}}"
           }


### PR DESCRIPTION
updated items by points earned header to match latest mockup
- points columns are 0, 1, 2 instead of 0 points, 1 point, etc.
- added popover for info on Full Credit column