### PR TITLE
DWR-306 Modify student history API to include Assessment and School i…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Assessments.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/Assessments.java
@@ -1,12 +1,15 @@
 package org.opentestsystem.rdw.reporting.search.exam;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
 import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
 
 public final class Assessments {
 
@@ -21,21 +24,25 @@ public final class Assessments {
     }
 
     public static <A extends Assessment.Builder> A map(final ResultSet row, final A builder) throws SQLException {
+        return map(row, builder, EMPTY);
+    }
 
-        final AssessmentType type = AssessmentType.valueOf(row.getInt("type_id"));
+    public static <A extends Assessment.Builder> A map(final ResultSet row, final A builder, final String prefix) throws SQLException {
 
-        builder.id(row.getLong("id"))
-                .name(row.getString("label"))
-                .gradeId(row.getInt("grade_id"))
+        final AssessmentType type = AssessmentType.valueOf(row.getInt(prefix + "type_id"));
+
+        builder.id(row.getLong(prefix + "id"))
+                .name(row.getString(prefix + "label"))
+                .gradeId(row.getInt(prefix + "grade_id"))
                 .type(type)
-                .subject(Subject.valueOf(row.getInt("subject_id")))
-                .schoolYear(row.getInt("school_year"));
+                .subject(Subject.valueOf(row.getInt(prefix + "subject_id")))
+                .schoolYear(row.getInt(prefix + "school_year"));
 
         // IABs do not have claims
         if (type != AssessmentType.IAB) {
             final ImmutableList.Builder<String> claimCodes = ImmutableList.builder();
             for (String claimCodeColumnName : CLAIM_CODE_COLUMN_NAMES) {
-                final String claimCode = row.getString(claimCodeColumnName);
+                final String claimCode = row.getString(prefix + claimCodeColumnName);
                 if (claimCode == null) {
                     break;
                 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
@@ -39,16 +39,12 @@ class DefaultStudentExamService implements StudentExamService {
             throw new NoSuchElementException(String.format("No student with SSID: %s", studentSsid));
         }
 
-        final List<Exam> exams = examRepository.findAllForStudent(
+        final List<StudentHistoryExamWrapper> exams = examRepository.findAllForStudent(
                 user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope(),
                 student.getId()
         );
 
-        final List<Assessment> assessments = exams.isEmpty()
-                ? ImmutableList.of()
-                : assessmentRepository.findAllByIds(exams.stream().map(Exam::getAssessmentId).collect(toImmutableList()));
-
-        return new StudentExamHistory(student, assessments, exams);
+        return new StudentExamHistory(student, exams);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
@@ -1,9 +1,12 @@
 package org.opentestsystem.rdw.reporting.search.exam.student;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.exam.Student;
 import org.opentestsystem.rdw.reporting.exam.StudentContext;
+import org.opentestsystem.rdw.reporting.search.exam.Assessments;
 import org.opentestsystem.rdw.reporting.search.exam.Exams;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,21 +37,40 @@ class JdbcStudentExamRepository implements StudentExamRepository {
     }
 
     @Override
-    public List<Exam> findAllForStudent(@NotNull final PermissionScope permissionScope, final long studentId) {
+    public List<StudentHistoryExamWrapper> findAllForStudent(@NotNull final PermissionScope permissionScope, final long studentId) {
         return template.query(
                 findAllByStudentIdQuery,
                 ImmutableMap.<String, Object>builder()
                         .putAll(getSecurityParameters(permissionScope))
                         .put("student_id", studentId)
                         .build(),
-                (row, index) -> Exams.map(row, Exam.builder())
-                        .assessmentId(row.getLong("asmt_id"))
-                        .schoolYear(row.getInt("school_year"))
-                        .studentContext(StudentContext.builder()
-                                .gradeId(row.getInt("grade_id"))
-                                .build()
-                        )
-                        .build()
+                (row, index) -> {
+                    //Parse the Exam
+                    final Exam exam = Exams.map(row, Exam.builder())
+                            .assessmentId(row.getLong("asmt_id"))
+                            .schoolYear(row.getInt("school_year"))
+                            .studentContext(StudentContext.builder()
+                                    .gradeId(row.getInt("grade_id"))
+                                    .build()
+                            )
+                            .build();
+
+                    //Parse the Assessment
+                    final Assessment assessment = Assessments.map(row, Assessment.builder(), "asmt_")
+                            .build();
+
+                    //Parse the School
+                    final Organization school = new Organization(
+                            row.getLong("school_id"),
+                            row.getString("school_name"));
+
+                    //Build the wrapper
+                    return new StudentHistoryExamWrapper.Builder()
+                            .withExam(exam)
+                            .withAssessment(assessment)
+                            .withSchool(school)
+                            .build();
+                }
         );
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
@@ -66,9 +66,9 @@ class JdbcStudentExamRepository implements StudentExamRepository {
 
                     //Build the wrapper
                     return new StudentHistoryExamWrapper.Builder()
-                            .withExam(exam)
-                            .withAssessment(assessment)
-                            .withSchool(school)
+                            .exam(exam)
+                            .assessment(assessment)
+                            .school(school)
                             .build();
                 }
         );

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamHistory.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamHistory.java
@@ -11,12 +11,10 @@ import java.util.Set;
 class StudentExamHistory {
 
     private final Student student;
-    private final Set<Assessment> assessments;
-    private final Set<Exam> exams;
+    private final Collection<StudentHistoryExamWrapper> exams;
 
-    StudentExamHistory(final Student student, final Collection<Assessment> assessments, final Collection<Exam> exams) {
+    StudentExamHistory(final Student student, final Collection<StudentHistoryExamWrapper> exams) {
         this.student = student;
-        this.assessments = assessments != null ? ImmutableSet.copyOf(assessments) : ImmutableSet.of();
         this.exams = exams != null ? ImmutableSet.copyOf(exams) : ImmutableSet.of();
     }
 
@@ -24,11 +22,7 @@ class StudentExamHistory {
         return student;
     }
 
-    public Set<Assessment> getAssessments() {
-        return assessments;
-    }
-
-    public Set<Exam> getExams() {
+    public Collection<StudentHistoryExamWrapper> getExams() {
         return exams;
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamRepository.java
@@ -9,7 +9,14 @@ import java.util.List;
 
 interface StudentExamRepository {
 
-    List<Exam> findAllForStudent(@NotNull PermissionScope scope, long studentId);
+    /**
+     * Find all of the exams with associated assessments and schools for the given user.
+     *
+     * @param scope     The authenticated user's permission scope
+     * @param studentId The student SSID
+     * @return  The student's exam history
+     */
+    List<StudentHistoryExamWrapper> findAllForStudent(@NotNull PermissionScope scope, long studentId);
 
     /**
      * Return the student if at least one exam exists.

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentHistoryExamWrapper.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentHistoryExamWrapper.java
@@ -24,10 +24,6 @@ public class StudentHistoryExamWrapper {
         return exam;
     }
 
-    void setExam(final Exam exam) {
-        this.exam = exam;
-    }
-
     /**
      * @return The exam's associated Assessment
      */
@@ -35,19 +31,11 @@ public class StudentHistoryExamWrapper {
         return assessment;
     }
 
-    void setAssessment(final Assessment assessment) {
-        this.assessment = assessment;
-    }
-
     /**
      * @return The exam's School
      */
     public Organization getSchool() {
         return school;
-    }
-
-    void setSchool(final Organization school) {
-        this.school = school;
     }
 
     public static class Builder {
@@ -58,24 +46,24 @@ public class StudentHistoryExamWrapper {
 
         public StudentHistoryExamWrapper build() {
             final StudentHistoryExamWrapper examWrapper = new StudentHistoryExamWrapper();
-            examWrapper.setExam(exam);
-            examWrapper.setAssessment(assessment);
-            examWrapper.setSchool(school);
+            examWrapper.exam = exam;
+            examWrapper.assessment = assessment;
+            examWrapper.school = school;
 
             return examWrapper;
         }
 
-        public Builder withExam(final Exam exam) {
+        public Builder exam(final Exam exam) {
             this.exam = exam;
             return this;
         }
 
-        public Builder withAssessment(final Assessment assessment) {
+        public Builder assessment(final Assessment assessment) {
             this.assessment = assessment;
             return this;
         }
 
-        public Builder withSchool(final Organization school) {
+        public Builder school(final Organization school) {
             this.school = school;
             return this;
         }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentHistoryExamWrapper.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentHistoryExamWrapper.java
@@ -1,0 +1,83 @@
+package org.opentestsystem.rdw.reporting.search.exam.student;
+
+import org.opentestsystem.rdw.reporting.exam.Assessment;
+import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.Organization;
+
+/**
+ * This model represents an Exam within the context of a student's history.
+ * It contains the Exam's associated Assessment and School information.
+ */
+public class StudentHistoryExamWrapper {
+
+    private Exam exam;
+    private Assessment assessment;
+    private Organization school;
+
+    private StudentHistoryExamWrapper() {
+    }
+
+    /**
+     * @return The student history exam
+     */
+    public Exam getExam() {
+        return exam;
+    }
+
+    void setExam(final Exam exam) {
+        this.exam = exam;
+    }
+
+    /**
+     * @return The exam's associated Assessment
+     */
+    public Assessment getAssessment() {
+        return assessment;
+    }
+
+    void setAssessment(final Assessment assessment) {
+        this.assessment = assessment;
+    }
+
+    /**
+     * @return The exam's School
+     */
+    public Organization getSchool() {
+        return school;
+    }
+
+    void setSchool(final Organization school) {
+        this.school = school;
+    }
+
+    public static class Builder {
+
+        private Exam exam;
+        private Assessment assessment;
+        private Organization school;
+
+        public StudentHistoryExamWrapper build() {
+            final StudentHistoryExamWrapper examWrapper = new StudentHistoryExamWrapper();
+            examWrapper.setExam(exam);
+            examWrapper.setAssessment(assessment);
+            examWrapper.setSchool(school);
+
+            return examWrapper;
+        }
+
+        public Builder withExam(final Exam exam) {
+            this.exam = exam;
+            return this;
+        }
+
+        public Builder withAssessment(final Assessment assessment) {
+            this.assessment = assessment;
+            return this;
+        }
+
+        public Builder withSchool(final Organization school) {
+            this.school = school;
+            return this;
+        }
+    }
+}

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -1,39 +1,56 @@
 sql:
   exam:
     findAllByStudentId: >-
-      select e.id,
-        e.type_id,
-        e.grade_id,
-        e.school_year,
-        e.completeness_code,
-        e.administration_condition_code,
-        e.session_id,
-        e.completed_at,
-        e.scale_score,
-        e.scale_score_std_err,
-        e.performance_level,
-        a.claim1_score_code,
-        e.claim1_category,
-        e.claim1_scale_score,
-        e.claim1_scale_score_std_err,
-        a.claim2_score_code,
-        e.claim2_category,
-        e.claim2_scale_score,
-        e.claim2_scale_score_std_err,
-        a.claim3_score_code,
-        e.claim3_category,
-        e.claim3_scale_score,
-        e.claim3_scale_score_std_err,
-        a.claim4_score_code,
-        e.claim4_category,
-        e.claim4_scale_score,
-        e.claim4_scale_score_std_err,
-        e.asmt_id
-      from exam e
-        join asmt a on e.asmt_id=a.id
-        join school s on e.school_id=s.id
-      where e.student_id=:student_id
-        and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+      select exam.id,
+        exam.type_id,
+        exam.grade_id,
+        exam.school_year,
+        exam.completeness_code,
+        exam.administration_condition_code,
+        exam.session_id,
+        exam.completed_at,
+        exam.scale_score,
+        exam.scale_score_std_err,
+        exam.performance_level,
+        exam.claim1_category,
+        exam.claim1_scale_score,
+        exam.claim1_scale_score_std_err,
+        exam.claim2_category,
+        exam.claim2_scale_score,
+        exam.claim2_scale_score_std_err,
+        exam.claim3_category,
+        exam.claim3_scale_score,
+        exam.claim3_scale_score_std_err,
+        exam.claim4_category,
+        exam.claim4_scale_score,
+        exam.claim4_scale_score_std_err,
+        exam.asmt_id,
+        asmt.claim1_score_code,
+        asmt.claim2_score_code,
+        asmt.claim3_score_code,
+        asmt.claim4_score_code,
+        asmt.id as asmt_id,
+        asmt.label as asmt_label,
+        asmt.grade_id as asmt_grade_id,
+        asmt.type_id as asmt_type_id,
+        asmt.subject_id as asmt_subject_id,
+        asmt.school_year as asmt_school_year,
+        asmt.claim1_score_code as asmt_claim1_score_code,
+        asmt.claim2_score_code as asmt_claim2_score_code,
+        asmt.claim3_score_code as asmt_claim3_score_code,
+        asmt.claim4_score_code as asmt_claim4_score_code,
+        asmt.min_score as asmt_min_score,
+        asmt.max_score as asmt_max_score,
+        asmt.cut_point_1 as asmt_cut_point_1,
+        asmt.cut_point_2 as asmt_cut_point_2,
+        asmt.cut_point_3 as asmt_cut_point_3,
+        school.id as school_id,
+        school.name as school_name
+      from exam
+        join asmt on exam.asmt_id=asmt.id
+        join school on exam.school_id=school.id
+      where exam.student_id=:student_id
+        and (1=:statewide or school.district_id in (:district_ids) or exam.school_id in (:school_ids))
 
     existsForStudentId: >-
       select stu.id,

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.exam.Student;
 import org.opentestsystem.rdw.reporting.security.Permission;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
@@ -19,8 +20,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -67,7 +66,6 @@ public class DefaultStudentExamServiceTest {
                 .isEqualToComparingFieldByFieldRecursively(
                         new StudentExamHistory(
                                 Student.builder().id(1).build(),
-                                ImmutableList.of(),
                                 ImmutableList.of()
                         )
                 );
@@ -77,27 +75,30 @@ public class DefaultStudentExamServiceTest {
     public void getExamsShouldReturnHistoryWhenStudentFoundWithExams() throws Exception {
 
         final Student student = Student.builder().id(1).build();
+        final StudentHistoryExamWrapper wrapper1 = new StudentHistoryExamWrapper.Builder()
+                .withAssessment(Assessment.builder().id(1).build())
+                .withExam(Exam.builder().id(2).assessmentId(1L).build())
+                .withSchool(new Organization(3, "School A"))
+                .build();
+        final StudentHistoryExamWrapper wrapper2 = new StudentHistoryExamWrapper.Builder()
+                .withAssessment(Assessment.builder().id(4).build())
+                .withExam(Exam.builder().id(5).assessmentId(4L).build())
+                .withSchool(new Organization(6, "School B"))
+                .build();
 
-        final List<Exam> exams = ImmutableList.of(
-                Exam.builder().id(1).assessmentId(1L).build(),
-                Exam.builder().id(2).assessmentId(2L).build()
-        );
-
-        final List<Assessment> assessments = ImmutableList.of(
-                Assessment.builder().id(1).build(),
-                Assessment.builder().id(2).build()
-        );
+        final List<StudentHistoryExamWrapper> exams = ImmutableList.of(wrapper1, wrapper2);
 
         when(studentRepository.findOneBySsid("a")).thenReturn(student);
         when(examRepository.findAllForStudent(PermissionScope.STATEWIDE, 1)).thenReturn(exams);
-        when(assessmentRepository.findAllByIds(any())).thenReturn(assessments);
 
         final StudentExamHistory actual = service.getExams(user, "a");
 
         assertThat(actual).isNotNull();
         assertThat(actual.getStudent()).isEqualToComparingFieldByFieldRecursively(student);
-        assertThat(actual.getExams()).usingRecursiveFieldByFieldElementComparator().containsOnlyElementsOf(exams);
-        assertThat(actual.getAssessments()).usingRecursiveFieldByFieldElementComparator().containsOnlyElementsOf(assessments);
+        assertThat(actual.getExams().stream().map(wrapper -> wrapper.getExam().getId()))
+                .containsOnly(2L, 5L);
+        assertThat(actual.getExams().stream().map(wrapper -> wrapper.getAssessment().getId()))
+                .containsOnly(1L, 4L);
 
     }
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
@@ -76,14 +76,14 @@ public class DefaultStudentExamServiceTest {
 
         final Student student = Student.builder().id(1).build();
         final StudentHistoryExamWrapper wrapper1 = new StudentHistoryExamWrapper.Builder()
-                .withAssessment(Assessment.builder().id(1).build())
-                .withExam(Exam.builder().id(2).assessmentId(1L).build())
-                .withSchool(new Organization(3, "School A"))
+                .assessment(Assessment.builder().id(1).build())
+                .exam(Exam.builder().id(2).assessmentId(1L).build())
+                .school(new Organization(3, "School A"))
                 .build();
         final StudentHistoryExamWrapper wrapper2 = new StudentHistoryExamWrapper.Builder()
-                .withAssessment(Assessment.builder().id(4).build())
-                .withExam(Exam.builder().id(5).assessmentId(4L).build())
-                .withSchool(new Organization(6, "School B"))
+                .assessment(Assessment.builder().id(4).build())
+                .exam(Exam.builder().id(5).assessmentId(4L).build())
+                .school(new Organization(6, "School B"))
                 .build();
 
         final List<StudentHistoryExamWrapper> exams = ImmutableList.of(wrapper1, wrapper2);

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
@@ -5,6 +5,9 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
+import org.opentestsystem.rdw.reporting.exam.Assessment;
+import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.exam.Student;
 import org.opentestsystem.rdw.reporting.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +17,9 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Collections;
+import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -36,9 +41,25 @@ public class JdbcStudentExamRepositoryIT {
 
     @Test
     public void findAllForStudentShouldReturnAllExamsForExistingStudent() throws Exception {
-        assertThat(repository.findAllForStudent(PermissionScope.STATEWIDE, -1L))
+
+        final List<StudentHistoryExamWrapper> wrappers = repository.findAllForStudent(PermissionScope.STATEWIDE, -1L);
+        final List<Exam> exams = newArrayList();
+        final List<Assessment> assessments = newArrayList();
+        final List<Organization> schools = newArrayList();
+        wrappers.forEach(wrapper -> {
+            exams.add(wrapper.getExam());
+            assessments.add(wrapper.getAssessment());
+            schools.add(wrapper.getSchool());
+        });
+
+        assertThat(exams)
+                .isNotEmpty()
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT_EXAMS);
+        assertThat(assessments)
+                .isNotEmpty()
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnlyElementsOf(TestData.STUDENT_ASSESSMENTS);
     }
 
     @Test

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamControllerIT.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.exam.Assessment;
 import org.opentestsystem.rdw.reporting.exam.Exam;
+import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.exam.Student;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,26 +45,33 @@ public class StudentExamControllerIT {
     @Test
     public void getStudentExamsShouldReturnHistoryWhenFound() throws Exception {
         final Student student = Student.builder().id(1).build();
-        final Assessment assessment1 = Assessment.builder().id(1).build();
-        final Assessment assessment2 = Assessment.builder().id(2).build();
-        final Exam exam1 = Exam.builder().id(1).assessmentId(1L).build();
-        final Exam exam2 = Exam.builder().id(2).assessmentId(2L).build();
+        final StudentHistoryExamWrapper wrapper1 = new StudentHistoryExamWrapper.Builder()
+                .withAssessment(Assessment.builder().id(1).build())
+                .withExam(Exam.builder().id(1).assessmentId(1L).build())
+                .withSchool(new Organization(1, "School A"))
+                .build();
+        final StudentHistoryExamWrapper wrapper2 = new StudentHistoryExamWrapper.Builder()
+                .withAssessment(Assessment.builder().id(2).build())
+                .withExam(Exam.builder().id(2).assessmentId(2L).build())
+                .withSchool(new Organization(2, "School B"))
+                .build();
 
         when(service.getExams(any(User.class), eq("a"))).thenReturn(
                 new StudentExamHistory(
                         student,
-                        ImmutableSet.of(assessment1, assessment2),
-                        ImmutableSet.of(exam1, exam2)
+                        ImmutableSet.of(wrapper1, wrapper2)
                 )
         );
 
         mvc.perform(get("/api/students/a/exams"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.student.id").value((int) student.getId()))
-                .andExpect(jsonPath("$.assessments[?(@.id==1)].id").value((int) assessment1.getId()))
-                .andExpect(jsonPath("$.assessments[?(@.id==2)].id").value((int) assessment2.getId()))
-                .andExpect(jsonPath("$.exams[?(@.id==1)].id").value((int) exam1.getId()))
-                .andExpect(jsonPath("$.exams[?(@.id==2)].id").value((int) exam2.getId()));
+                .andExpect(jsonPath("$.exams.[*].assessment[?(@.id==1)].id").exists())
+                .andExpect(jsonPath("$.exams.[*].assessment[?(@.id==2)].id").exists())
+                .andExpect(jsonPath("$.exams.[*].exam[?(@.id==1)].id").exists())
+                .andExpect(jsonPath("$.exams.[*].exam[?(@.id==2)].id").exists())
+                .andExpect(jsonPath("$.exams.[*].school[?(@.id==1)].id").exists())
+                .andExpect(jsonPath("$.exams.[*].school[?(@.id==2)].id").exists());
     }
 
     @Test

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/StudentExamControllerIT.java
@@ -46,14 +46,14 @@ public class StudentExamControllerIT {
     public void getStudentExamsShouldReturnHistoryWhenFound() throws Exception {
         final Student student = Student.builder().id(1).build();
         final StudentHistoryExamWrapper wrapper1 = new StudentHistoryExamWrapper.Builder()
-                .withAssessment(Assessment.builder().id(1).build())
-                .withExam(Exam.builder().id(1).assessmentId(1L).build())
-                .withSchool(new Organization(1, "School A"))
+                .assessment(Assessment.builder().id(1).build())
+                .exam(Exam.builder().id(1).assessmentId(1L).build())
+                .school(new Organization(1, "School A"))
                 .build();
         final StudentHistoryExamWrapper wrapper2 = new StudentHistoryExamWrapper.Builder()
-                .withAssessment(Assessment.builder().id(2).build())
-                .withExam(Exam.builder().id(2).assessmentId(2L).build())
-                .withSchool(new Organization(2, "School B"))
+                .assessment(Assessment.builder().id(2).build())
+                .exam(Exam.builder().id(2).assessmentId(2L).build())
+                .school(new Organization(2, "School B"))
                 .build();
 
         when(service.getExams(any(User.class), eq("a"))).thenReturn(


### PR DESCRIPTION
…nformation for each Exam.

After reading through the Student Results table specs, we were missing some data from the student history exam payload.  This PR modifies the response payload from two disconnected collections of Exam and Assessment instances into a single collection of wrapper models, each containing an Exam, Assessment, and School.