### PR TITLE
Sorting by array property in datatable doesn't work, fixed by creatin…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
@@ -17,4 +17,20 @@ export class Exam {
   limitedEnglishProficiency: boolean;
   ethnicities: string[];
   claimLevels: number[];
+
+  get claimLevel0() {
+    return this.claimLevels[0];
+  }
+
+  get claimLevel1() {
+    return this.claimLevels[1];
+  }
+
+  get claimLevel2() {
+    return this.claimLevels[2];
+  }
+
+  get claimLevel3() {
+    return this.claimLevels[3];
+  }
 }

--- a/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
@@ -17,20 +17,4 @@ export class Exam {
   limitedEnglishProficiency: boolean;
   ethnicities: string[];
   claimLevels: number[];
-
-  get claimLevel0() {
-    return this.claimLevels[0];
-  }
-
-  get claimLevel1() {
-    return this.claimLevels[1];
-  }
-
-  get claimLevel2() {
-    return this.claimLevels[2];
-  }
-
-  get claimLevel3() {
-    return this.claimLevels[3];
-  }
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -147,7 +147,7 @@
           <!-- Claim Score columns -->
           <p-column *ngFor="let claim of claimCodes; let idx = index"
                     header="{{'enum.claim-code.' + claim | translate}}"
-                    field="{{'claimLevel' + idx}}"
+                    field="{{'claimLevels.' + idx}}"
                     sortable="true"
                     [hidden]="!isClaimScoreSelected">
             <ng-template let-exam="rowData" pTemplate="body">

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -147,7 +147,7 @@
           <!-- Claim Score columns -->
           <p-column *ngFor="let claim of claimCodes; let idx = index"
                     header="{{'enum.claim-code.' + claim | translate}}"
-                    field="{{'exam.claimLevels[' + idx + ']'}}"
+                    field="{{'claimLevel' + idx}}"
                     sortable="true"
                     [hidden]="!isClaimScoreSelected">
             <ng-template let-exam="rowData" pTemplate="body">


### PR DESCRIPTION
…g property names for each

This feels weird and only works because we know that there can only be up to 4 claims so we can create denormalized properties.

I might be missing something so want people's thoughts on this.  @wtritch are you having this issue on your student test history results page as well?