### PR TITLE
DWR-436 Add a placeholder route for student exam responses.

### DIFF
--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -43,8 +43,8 @@ cloud:
   aws:
     credentials:
       #AWS credentials are necessary if reading assessment files from S3
-      accessKey: ${rdw.aws.access.key:""}
-      secretKey: ${rdw.aws.secret.key:""}
+      accessKey: ${rdw.aws.access.key:}
+      secretKey: ${rdw.aws.secret.key:}
       instance-profile: false
     region:
       auto: false

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -48,8 +48,7 @@ export const routes: Routes = [
         children: [ {
           path: '',
           pathMatch: 'full',
-          component: StudentResultsComponent,
-          canActivate: [ AuthorizeCanActivate ]
+          component: StudentResultsComponent
         }, {
           path: 'exams/:examId',
           pathMatch: 'full',
@@ -60,8 +59,7 @@ export const routes: Routes = [
             },
             permissions: ['INDIVIDUAL_PII_READ']
           },
-          component: StudentResponsesComponent,
-          canActivate: [ AuthorizeCanActivate ]
+          component: StudentResponsesComponent
         } ]
       }
     ]

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -9,6 +9,8 @@ import { SchoolResultsComponent } from "./school-grade/results/school-results.co
 import { CurrentSchoolResolve } from "./school-grade/results/current-school.resolve";
 import { StudentResultsComponent } from "./student/results/student-results.component";
 import { StudentExamHistoryResolve } from "./student/results/student-exam-history.resolve";
+import { StudentResponsesResolve } from "./student/responses/student-responses.resolve";
+import { StudentResponsesComponent } from "./student/responses/student-responses.component";
 
 export const routes: Routes = [
   {
@@ -34,7 +36,6 @@ export const routes: Routes = [
       },
       {
         path: 'students/:studentId',
-        pathMatch: 'full',
         resolve: { examHistory: StudentExamHistoryResolve },
         data: {
           breadcrumb: {
@@ -43,8 +44,25 @@ export const routes: Routes = [
           },
           permissions: ['INDIVIDUAL_PII_READ']
         },
-        component: StudentResultsComponent,
-        canActivate: [ AuthorizeCanActivate ]
+        canActivate: [ AuthorizeCanActivate ],
+        children: [ {
+          path: '',
+          pathMatch: 'full',
+          component: StudentResultsComponent,
+          canActivate: [ AuthorizeCanActivate ]
+        }, {
+          path: 'exams/:examId',
+          pathMatch: 'full',
+          resolve: { assessmentItems: StudentResponsesResolve },
+          data: {
+            breadcrumb: {
+              translate: 'labels.student.responses.crumb'
+            },
+            permissions: ['INDIVIDUAL_PII_READ']
+          },
+          component: StudentResponsesComponent,
+          canActivate: [ AuthorizeCanActivate ]
+        } ]
       }
     ]
   }

--- a/webapp/src/main/webapp/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/webapp/src/main/webapp/src/app/breadcrumbs/breadcrumbs.component.html
@@ -9,10 +9,10 @@
         </a>
       </li>
       <li *ngFor="let crumb of breadcrumbs; let last = last;" [ngClass]="{'active': last }">
-        <a *ngIf="!last" [routerLink]="[crumb.url, crumb.params]">
+        <a *ngIf="!last" [routerLink]="crumb.commands">
           {{ crumb.requiresTranslate? (crumb.label | translate:crumb.translateParams) : crumb.label }}
         </a>
-        <span *ngIf="last" [routerLink]="[crumb.url, crumb.params]">
+        <span *ngIf="last" [routerLink]="crumb.commands">
           {{ crumb.requiresTranslate? (crumb.label | translate:crumb.translateParams) : crumb.label }}
         </span>
       </li>

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -1,0 +1,1 @@
+<h3 class="blue mb-md">{{'labels.student.responses.title' | translate}}</h3>

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.spec.ts
@@ -1,0 +1,58 @@
+
+import { StudentResponsesComponent } from "./student-responses.component";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AssessmentsModule } from "../../assessments/assessments.module";
+import { ActivatedRoute } from "@angular/router";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import createSpy = jasmine.createSpy;
+import Spy = jasmine.Spy;
+import { TranslateModule } from "@ngx-translate/core";
+
+describe('StudentResponsesComponent', () => {
+  let component: StudentResponsesComponent;
+  let fixture: ComponentFixture<StudentResponsesComponent>;
+  let route: MockActivatedRoute;
+
+  beforeEach(() => {
+    route = new MockActivatedRoute();
+
+    let mockRouteSnapshot: any = {};
+    mockRouteSnapshot.data = {};
+    mockRouteSnapshot.params = {};
+    route.snapshotResult.and.returnValue(mockRouteSnapshot);
+
+
+    TestBed.configureTestingModule({
+      imports: [
+        AssessmentsModule,
+        TranslateModule.forRoot()
+      ],
+      declarations: [
+        StudentResponsesComponent
+      ],
+      providers: [ {
+        provide: ActivatedRoute,
+        useValue: route
+      } ],
+      schemas: [ NO_ERRORS_SCHEMA ]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(StudentResponsesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+});
+
+class MockActivatedRoute {
+  snapshotResult: Spy = createSpy("snapshot");
+
+  get snapshot(): any {
+    return this.snapshotResult();
+  }
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.spec.ts
@@ -21,7 +21,6 @@ describe('StudentResponsesComponent', () => {
     mockRouteSnapshot.params = {};
     route.snapshotResult.and.returnValue(mockRouteSnapshot);
 
-
     TestBed.configureTestingModule({
       imports: [
         AssessmentsModule,

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.ts
@@ -1,0 +1,25 @@
+
+import { OnInit, Component } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { AssessmentItem } from "../../assessments/model/assessment-item.model";
+
+/**
+ * This component is responsible for displaying a student's responses to a
+ * particular assessment for a single exam.
+ */
+@Component({
+  selector: 'student-responses',
+  templateUrl: './student-responses.component.html'
+})
+export class StudentResponsesComponent implements OnInit {
+
+  assessmentItems: AssessmentItem[];
+
+  constructor(private route: ActivatedRoute) {
+  }
+
+  ngOnInit(): void {
+    this.assessmentItems = this.route.snapshot.data[ "assessmentItems" ];
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.resolve.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.resolve.ts
@@ -1,0 +1,20 @@
+import { Observable } from "rxjs";
+import { RouterStateSnapshot, ActivatedRouteSnapshot, Resolve } from "@angular/router";
+import { Injectable } from "@angular/core";
+import { StudentResponsesService } from "./student-responses.service";
+import { AssessmentItem } from "../../assessments/model/assessment-item.model";
+
+/**
+ * This resolver is responsible for fetching assessment items for a student and exam.
+ */
+@Injectable()
+export class StudentResponsesResolve implements Resolve<AssessmentItem[]> {
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<AssessmentItem[]> {
+    return this.service.findItemsByStudentAndExam(route.params[ "studentId" ], route.params["examId"]);
+  }
+
+  constructor(private service: StudentResponsesService) {
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.service.spec.ts
@@ -1,0 +1,60 @@
+
+import { MockDataService } from "../../../test/mock.data.service";
+import Spy = jasmine.Spy;
+import createSpy = jasmine.createSpy;
+import { TestBed, inject } from "@angular/core/testing";
+import { StudentResponsesService } from "./student-responses.service";
+import { DataService } from "../../shared/data/data.service";
+import { AssessmentExamMapper } from "../../assessments/assessment-exam.mapper";
+import { AssessmentItem } from "../../assessments/model/assessment-item.model";
+import { Observable } from "rxjs";
+
+describe('StudentResponsesService', () => {
+  let dataService: MockDataService;
+  let mapper: MockAssessmentExamMapper;
+
+  beforeEach(() => {
+    dataService = new MockDataService();
+    mapper = new MockAssessmentExamMapper();
+
+    TestBed.configureTestingModule({
+      providers: [
+        StudentResponsesService, {
+          provide: DataService,
+          useValue: dataService
+        }, {
+          provide: AssessmentExamMapper,
+          useValue: mapper
+        }
+      ]
+    });
+  });
+
+  it("should find, map, and return assessment items",
+    inject([StudentResponsesService], (service: StudentResponsesService) => {
+
+    dataService.get.and.callFake((url) => {
+      expect(url).toBe('/students/123/exams/456/examitems');
+      return Observable.of({ id: 123 });
+    });
+
+    service.findItemsByStudentAndExam(123, 456).subscribe((response) => {
+      expect(response.length).toBe(1);
+      expect(response[0].id).toBe(123);
+    });
+
+  }));
+});
+
+class MockAssessmentExamMapper {
+  mapAssessmentItemsFromApi: Spy = createSpy("mapAssessmentItemsFromApi");
+
+  constructor() {
+    this.mapAssessmentItemsFromApi.and.callFake((apiModel: any) => {
+      let item = new AssessmentItem();
+      item.id = apiModel.id;
+      return [item];
+    });
+
+  }
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.service.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@angular/core";
+import { AssessmentExamMapper } from "../../assessments/assessment-exam.mapper";
+import { DataService } from "../../shared/data/data.service";
+import { Observable } from "rxjs";
+import { AssessmentItem } from "../../assessments/model/assessment-item.model";
+
+/**
+ * This service is responsible for providing student response information.
+ */
+@Injectable()
+export class StudentResponsesService {
+
+  constructor(
+    private dataService: DataService,
+    private assessmentMapper: AssessmentExamMapper) {}
+
+  /**
+   * Retrieve the exam responses for a given exam.
+   *
+   * @param studentId The student database id
+   * @param examId    The exam database id
+   * @returns {Observable<AssessmentItem[]>} The exam responses
+   */
+  findItemsByStudentAndExam(studentId: number, examId: number): Observable<AssessmentItem[]> {
+    return this.dataService.get(`/students/${studentId}/exams/${examId}/examitems`)
+      .map((apiExamItems) => {
+        if (!apiExamItems) return null;
+
+       return this.assessmentMapper.mapAssessmentItemsFromApi(apiExamItems);
+      });
+  }
+}

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.spec.ts
@@ -5,9 +5,8 @@ import { BrowserModule } from "@angular/platform-browser";
 import { CommonModule } from "../../shared/common.module";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { SharedModule } from "primeng/components/common/shared";
-import { Location } from "@angular/common";
 import { TranslateModule } from "@ngx-translate/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { StudentExamHistory } from "../model/student-exam-history.model";
 import { Student } from "../model/student.model";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
@@ -17,6 +16,7 @@ import { Assessment } from "../../assessments/model/assessment.model";
 import { AssessmentType } from "../../shared/enum/assessment-type.enum";
 import { ClaimScore } from "../../assessments/model/claim-score.model";
 import { School } from "../../user/model/school.model";
+import { MockRouter } from "../../../test/mock.router";
 import Spy = jasmine.Spy;
 import createSpy = jasmine.createSpy;
 import createSpyObj = jasmine.createSpyObj;
@@ -25,7 +25,7 @@ describe('StudentResultsComponent', () => {
   let component: StudentResultsComponent;
   let fixture: ComponentFixture<StudentResultsComponent>;
   let route: MockActivatedRoute;
-  let location: MockLocation;
+  let router: MockRouter;
 
   beforeEach(() => {
     route = new MockActivatedRoute();
@@ -33,10 +33,10 @@ describe('StudentResultsComponent', () => {
     let mockRouteSnapshot: any = {};
     mockRouteSnapshot.data = {};
     mockRouteSnapshot.data.examHistory = MockBuilder.history();
-    mockRouteSnapshot.queryParams = {};
+    mockRouteSnapshot.params = {};
     route.snapshotResult.and.returnValue(mockRouteSnapshot);
 
-    location = new MockLocation();
+    router = new MockRouter();
 
     TestBed.configureTestingModule({
       imports: [
@@ -55,8 +55,8 @@ describe('StudentResultsComponent', () => {
         provide: ActivatedRoute,
         useValue: route
       }, {
-        provide: Location,
-        useValue: location
+        provide: Router,
+        useValue: router
       }],
       schemas: [NO_ERRORS_SCHEMA]
     })
@@ -88,7 +88,7 @@ describe('StudentResultsComponent', () => {
   it('should filter by year on initialization', inject([ActivatedRoute], (route: MockActivatedRoute) => {
     // Filter to the single 2017 exam
     let snapshot = route.snapshot;
-    snapshot.queryParams['schoolYear'] = '2017';
+    snapshot.params['schoolYear'] = '2017';
 
     component.ngOnInit();
 
@@ -101,7 +101,7 @@ describe('StudentResultsComponent', () => {
 
   it('should filter by subject on initialization', inject([ActivatedRoute], (route: MockActivatedRoute) => {
     let snapshot = route.snapshot;
-    snapshot.queryParams['subject'] = 'MATH';
+    snapshot.params['subject'] = 'MATH';
 
     component.ngOnInit();
 
@@ -230,8 +230,4 @@ class MockActivatedRoute {
   get snapshot(): any {
     return this.snapshotResult();
   }
-}
-
-class MockLocation {
-  replaceState: Spy = createSpy("replaceState");
 }

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.ts
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.ts
@@ -1,8 +1,6 @@
 import { OnInit, Component } from "@angular/core";
-import { ActivatedRoute, Params } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 import { StudentExamHistory } from "../model/student-exam-history.model";
-import { Location } from "@angular/common";
-import { URLSearchParams } from "@angular/http";
 import { StudentResultsFilterState } from "./model/student-results-filter-state.model";
 import { StudentHistoryExamWrapper } from "../model/student-history-exam-wrapper.model";
 import { AssessmentType } from "../../shared/enum/assessment-type.enum";
@@ -31,7 +29,7 @@ export class StudentResultsComponent implements OnInit {
   }
 
   constructor(private route: ActivatedRoute,
-              private location: Location,
+              private router: Router,
               private examFilterService: ExamFilterService) {
   }
 
@@ -39,7 +37,7 @@ export class StudentResultsComponent implements OnInit {
     this.examHistory = this.route.snapshot.data[ "examHistory" ];
     this.initializeFilter(
       this.examHistory.exams,
-      this.route.snapshot.queryParams);
+      this.route.snapshot.params);
     this.applyFilter();
   }
 
@@ -128,29 +126,26 @@ export class StudentResultsComponent implements OnInit {
 
   /**
    * Update the current route based upon the current filter state.
-   * Do not re-load the page or re-fetch data.
+   * TODO Do not re-load the page or re-fetch data.
    */
   private updateRoute(): void {
-    let searchParams: URLSearchParams = new URLSearchParams();
+    let params: any = {};
     if (this.filterState.schoolYear > 0) {
-      searchParams.set("schoolYear", this.filterState.schoolYear.toString());
+      params.schoolYear = this.filterState.schoolYear.toString();
     }
     if (this.filterState.subject) {
-      searchParams.set("subject", this.filterState.subject);
+      params.subject = this.filterState.subject;
     }
 
-    //Update the current route without navigating
-    this.location.replaceState(
-      `/students/${this.examHistory.student.id}`,
-      searchParams.toString()
-    );
+    //Update the current route
+    this.router.navigate(['students', this.examHistory.student.id, params]);
   }
 
   /**
    * Initialize the current filter state from the initial request.
    *
    * @param exams       The available exams
-   * @param params      The route query params
+   * @param params      The route params
    */
   private initializeFilter(exams: StudentHistoryExamWrapper[], params: Params): void {
 

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.spec.ts
@@ -9,12 +9,19 @@ import { PopoverModule } from "ngx-bootstrap";
 import { ScaleScoreComponent } from "../../../assessments/results/scale-score.component";
 import { InformationLabelComponent } from "../../../assessments/results/information-label.component";
 import { PopupMenuComponent } from "../../../assessments/menu/popup-menu.component";
+import { MockRouter } from "../../../../test/mock.router";
+import { Router, ActivatedRoute } from "@angular/router";
 
 describe('StudentHistoryIABTableComponent', () => {
   let component: StudentHistoryIABTableComponent;
   let fixture: ComponentFixture<StudentHistoryIABTableComponent>;
+  let router: MockRouter;
+  let activatedRoute: ActivatedRoute;
 
   beforeEach(async(() => {
+    router = new MockRouter();
+    activatedRoute = new ActivatedRoute();
+
     TestBed.configureTestingModule({
       imports: [
         BrowserModule,
@@ -30,7 +37,13 @@ describe('StudentHistoryIABTableComponent', () => {
         ScaleScoreComponent,
         PopupMenuComponent
       ],
-      providers: []
+      providers: [{
+        provide: Router,
+        useValue: router
+      }, {
+        provide: ActivatedRoute,
+        useValue: activatedRoute
+      }]
     })
       .compileComponents();
   }));

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.ts
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.ts
@@ -3,6 +3,8 @@ import { StudentHistoryExamWrapper } from "../../model/student-history-exam-wrap
 import { TranslateService } from "@ngx-translate/core";
 import { Student } from "../../model/student.model";
 import { PopupMenuAction } from "../../../assessments/menu/popup-menu-action.model";
+import { Router, ActivatedRoute } from "@angular/router";
+import { exam } from "../../../standalone/data/exam";
 
 @Component({
   selector: 'student-history-iab-table',
@@ -18,7 +20,9 @@ export class StudentHistoryIABTableComponent implements OnInit {
 
   actions: PopupMenuAction[];
 
-  constructor(private translateService: TranslateService) {
+  constructor(private translateService: TranslateService,
+              private router: Router,
+              private route: ActivatedRoute) {
   }
 
   ngOnInit(): void {
@@ -37,8 +41,9 @@ export class StudentHistoryIABTableComponent implements OnInit {
     let responsesAction: PopupMenuAction = new PopupMenuAction();
     responsesAction.displayName = (() => responsesLabel);
     responsesAction.perform = ((wrapper) => {
-      console.log(`Show Responses: ${wrapper.assessment.name}`);
-    }).bind(this);
+      let examId: number = wrapper.exam.id;
+      this.router.navigate(['exams', examId], { relativeTo: this.route });
+    });
     actions.push(responsesAction);
 
     let resourcesLabel: string = this.translateService.instant('labels.menus.resources');

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.spec.ts
@@ -13,10 +13,14 @@ import { PopoverModule } from "ngx-bootstrap";
 import { ScaleScoreComponent } from "../../../assessments/results/scale-score.component";
 import { InformationLabelComponent } from "../../../assessments/results/information-label.component";
 import { PopupMenuComponent } from "../../../assessments/menu/popup-menu.component";
+import { ActivatedRoute, Router } from "@angular/router";
+import { MockRouter } from "../../../../test/mock.router";
 
 describe('StudentHistoryICASummitiveTableComponent', () => {
   let component: StudentHistoryICASummitiveTableComponent;
   let fixture: ComponentFixture<StudentHistoryICASummitiveTableComponent>;
+  let router: MockRouter;
+  let activatedRoute: ActivatedRoute;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -34,7 +38,13 @@ describe('StudentHistoryICASummitiveTableComponent', () => {
         ScaleScoreComponent,
         PopupMenuComponent
       ],
-      providers: []
+      providers: [{
+        provide: Router,
+        useValue: router
+      }, {
+        provide: ActivatedRoute,
+        useValue: activatedRoute
+      }]
     })
       .compileComponents();
   }));

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.ts
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.ts
@@ -3,6 +3,7 @@ import { StudentHistoryExamWrapper } from "../../model/student-history-exam-wrap
 import { Student } from "../../model/student.model";
 import { TranslateService } from "@ngx-translate/core";
 import { PopupMenuAction } from "../../../assessments/menu/popup-menu-action.model";
+import { ActivatedRoute, Router } from "@angular/router";
 
 @Component({
   selector: 'student-history-ica-summitive-table',
@@ -23,7 +24,9 @@ export class StudentHistoryICASummitiveTableComponent {
 
   actions: PopupMenuAction[];
 
-  constructor(private translateService: TranslateService) {
+  constructor(private translateService: TranslateService,
+              private router: Router,
+              private route: ActivatedRoute) {
   }
 
   ngOnInit(): void {
@@ -56,8 +59,9 @@ export class StudentHistoryICASummitiveTableComponent {
       let responsesAction: PopupMenuAction = new PopupMenuAction();
       responsesAction.displayName = (() => responsesLabel);
       responsesAction.perform = ((wrapper) => {
-        console.log(`Show Responses: ${wrapper.assessment.name}`);
-      }).bind(this);
+        let examId: number = wrapper.exam.id;
+        this.router.navigate(['exams', examId], { relativeTo: this.route });
+      });
       actions.push(responsesAction);
     }
 

--- a/webapp/src/main/webapp/src/app/student/student.module.ts
+++ b/webapp/src/main/webapp/src/app/student/student.module.ts
@@ -14,10 +14,14 @@ import { DataTableModule } from "primeng/components/datatable/datatable";
 import { StudentHistoryIABTableComponent } from "./results/tables/student-history-iab-table.component";
 import { StudentHistoryICASummitiveTableComponent } from "./results/tables/student-history-ica-summitive-table.component";
 import { PopoverModule } from "ngx-bootstrap";
+import { StudentResponsesComponent } from "./responses/student-responses.component";
+import { StudentResponsesService } from "./responses/student-responses.service";
+import { StudentResponsesResolve } from "./responses/student-responses.resolve";
 
 @NgModule({
   declarations: [
     StudentComponent,
+    StudentResponsesComponent,
     StudentResultsComponent,
     StudentResultsFilterComponent,
     StudentHistoryIABTableComponent,
@@ -34,10 +38,15 @@ import { PopoverModule } from "ngx-bootstrap";
     ReactiveFormsModule,
     SharedModule
   ],
-  exports: [ StudentComponent ],
+  exports: [
+    StudentComponent,
+    StudentResponsesComponent
+  ],
   providers: [
     StudentExamHistoryResolve,
-    StudentExamHistoryService
+    StudentExamHistoryService,
+    StudentResponsesResolve,
+    StudentResponsesService
   ]
 })
 export class StudentModule {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -254,6 +254,10 @@
       "messages": {
         "no-results": "Student does not exist or has no available exam results."
       },
+      "responses": {
+        "title": "Student Test History Report",
+        "crumb": "Student Responses"
+      },
       "results": {
         "title": "Student Test History Report",
         "crumb": "Student Id: {{ssid}}",


### PR DESCRIPTION
Add a resolver to fetch student exam responses.
Update student results table menu items to navigate to the selected student/exam responses.
Update breadcrumb component to build crumb links by navigation commands rather than url.

Since the code changes were starting to mount, I decided this was a good place to stop and file an interim PR.