### PR TITLE
Fixed Bug 555

### DIFF
--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 import { UserService } from "./user/user.service";
-import { RdwTranslateLoader } from "./shared/rdw-translate-loader";
 
 @Component({
   selector: 'app-component',
@@ -10,13 +9,12 @@ import { RdwTranslateLoader } from "./shared/rdw-translate-loader";
 export class AppComponent {
 
   private _user;
-  public loadingTranslations: boolean = true;
 
   get user() {
     return this._user;
   }
 
-  constructor(public translate: TranslateService, private _userService: UserService, private translateLoader: RdwTranslateLoader) {
+  constructor(public translate: TranslateService, private _userService: UserService) {
 
     let languages = [ 'en', 'ja' ];
     let defaultLanguage = languages[ 0 ];

--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 import { UserService } from "./user/user.service";
+import { RdwTranslateLoader } from "./shared/rdw-translate-loader";
 
 @Component({
   selector: 'app-component',
@@ -9,12 +10,13 @@ import { UserService } from "./user/user.service";
 export class AppComponent {
 
   private _user;
+  public loadingTranslations: boolean = true;
 
   get user() {
     return this._user;
   }
 
-  constructor(public translate: TranslateService, private _userService: UserService) {
+  constructor(public translate: TranslateService, private _userService: UserService, private translateLoader: RdwTranslateLoader) {
 
     let languages = [ 'en', 'ja' ];
     let defaultLanguage = languages[ 0 ];

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { routes } from "./app.routes";
 import { RouterModule } from "@angular/router";
 import { SchoolGradeModule } from "./school-grade/school-grade.module";
 import { PopoverModule } from "ngx-bootstrap/popover";
+import { TranslateResolve } from "./home/translate.resolve";
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import { PopoverModule } from "ngx-bootstrap/popover";
     PopoverModule.forRoot()
   ],
   providers: [
+    TranslateResolve,
     ...(environment.standalone ? standaloneProviders : [])
   ],
   bootstrap: [ AppComponent ]

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -11,11 +11,12 @@ import { StudentResultsComponent } from "./student/results/student-results.compo
 import { StudentExamHistoryResolve } from "./student/results/student-exam-history.resolve";
 import { StudentResponsesResolve } from "./student/responses/student-responses.resolve";
 import { StudentResponsesComponent } from "./student/responses/student-responses.component";
+import { TranslateResolve } from "./home/translate.resolve";
 
 export const routes: Routes = [
   {
     path: '',
-    resolve: { user: UserResolve },
+    resolve: { user: UserResolve, translateComplete: TranslateResolve },
     children: [
       { path: '', pathMatch: 'full', component: HomeComponent },
       {

--- a/webapp/src/main/webapp/src/app/home/translate.resolve.ts
+++ b/webapp/src/main/webapp/src/app/home/translate.resolve.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from "@angular/router";
+import { Observable } from "rxjs";
+import { RdwTranslateLoader } from "../shared/rdw-translate-loader";
+
+/**
+ * Resolver that only resolves once the translate getTranslation is complete.
+ */
+@Injectable()
+export class TranslateResolve implements Resolve<string> {
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any>|Promise<any>|any {
+    return this.service.observable;
+  }
+
+  constructor(private service: RdwTranslateLoader) {
+  }
+}

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -18,10 +18,6 @@ import { GradeDisplayPipe } from "./grade-display.pipe";
 import { RdwTranslateLoader } from "./rdw-translate-loader";
 import { AssessmentTypePipe } from "./assessment-type.pipe";
 
-export function createTranslateLoader(http: Http) {
-  return new RdwTranslateLoader(http);
-}
-
 @NgModule({
   declarations: [
     AssessmentTypePipe,
@@ -41,8 +37,7 @@ export function createTranslateLoader(http: Http) {
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
-        useFactory: createTranslateLoader,
-        deps: [ Http ]
+        useClass: RdwTranslateLoader
       }
     })
   ],
@@ -62,7 +57,8 @@ export function createTranslateLoader(http: Http) {
   providers: [
     DataService,
     CachingDataService,
-    GradeService
+    GradeService,
+    RdwTranslateLoader
   ]
 })
 export class CommonModule {

--- a/webapp/src/main/webapp/src/app/shared/rdw-translate-loader.ts
+++ b/webapp/src/main/webapp/src/app/shared/rdw-translate-loader.ts
@@ -1,25 +1,42 @@
-import { Observable } from "rxjs";
+import { Observable, Observer } from "rxjs";
 import { JsonUnFlat } from "json-unflat";
 import { TranslateHttpLoader } from "@ngx-translate/http-loader";
 import { Http } from "@angular/http";
 import * as _ from "lodash";
+import { Injectable } from "@angular/core";
 
+@Injectable()
 export class RdwTranslateLoader {
-  constructor(private http: Http){
+  /**
+   * @returns The observable for the getTranslation request.
+   */
+  public get observable() {
+    return this._observable;
+  };
+
+  constructor(private http: Http) {
   }
 
   private apiLoader = new TranslateHttpLoader(this.http, '/api/translations/', '');
   private uiLoader = new TranslateHttpLoader(this.http, '/assets/i18n/', '.json');
+  private _observable: Observable<any>;
 
   getTranslation(lang: string) {
-    return this.uiLoader
-      .getTranslation(lang)
-      .mergeMap(uiTranslation => this.apiLoader
-        .getTranslation(lang)
-        .mergeMap(apiTranslation => {
-          // TODO: Should the API unflatten the JSON before returning?
-          let merged = _.merge(uiTranslation, JsonUnFlat.unflat(apiTranslation));
-          return Observable.of(merged);
-        }));
+    let uiObservable = this.uiLoader.getTranslation(lang);
+    let apiObservable = this.apiLoader.getTranslation(lang);
+
+    let translateObserver: Observer<any>;
+    this._observable = new Observable<any>(observer => translateObserver = observer).share();
+
+    Observable
+      .forkJoin([uiObservable, apiObservable])
+      .share()
+      .subscribe(responses => {
+        let merged = _.merge(responses[0], JsonUnFlat.unflat(responses[1]));
+        translateObserver.next(merged);
+        translateObserver.complete();
+      });
+
+    return this._observable;
   };
 }


### PR DESCRIPTION
This broke because the translate was now taking longer to resolve now that we are merging ui / api translations.  When the primeng dropdown was being initialized, a placeholder (from translate) hadn't finished resolving so the primeng was selecting the first item in the dropdown rather than using it's placeholder.  Primeng never updated itself once the translation completed.

So now optimized the translate loader by parallelizing the api / ui translation requests and added a translate resolve so that the HomeComponent won't load until translate is complete.