### PR TITLE
Remove session options from School/Grade results page

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -105,6 +105,7 @@
   <assessment-results [assessmentExam]="assessment"
                       [showValuesAsPercent]="showValuesAsPercent"
                       [filterBy]="clientFilterBy"
+                      [useSessions]="useSessions"
                       [loadAssessmentItems]="boundLoadAssessmentItems"></assessment-results>
 </div>
 <!-- No Results Error -->

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
@@ -41,6 +41,13 @@ export class AssessmentsComponent implements OnInit {
   @Input()
   assessmentProvider: AssessmentProvider;
 
+  /**
+   * If true, the session toggles will be display with the most recent selected
+   * by default.  Otherwise, they won't be displayed and all results will be shown.
+   */
+  @Input()
+  useSessions: boolean = true;
+
   showValuesAsPercent: boolean = true;
   filterDisplayOptions: any = {
     expanded: true

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -22,6 +22,7 @@
     <div class="row">
         <!-- Sessions -->
         <div class="col-md-7">
+          <div *ngIf="useSessions">
             <p><strong>{{'labels.groups.results.assessment.sessions-title' | translate}}</strong><br />
             {{'labels.groups.results.assessment.sessions-instruct' | translate}}</p>
             <div class="flex-children">
@@ -34,6 +35,7 @@
                     <span class="icon"><i class="fa" [ngClass]="{'fa-minus':session.filter, 'fa-plus': !session.filter }"></i></span>
                 </a>
             </div>
+          </div>
         </div>
 
         <!-- TODO: Add labels to translations -->

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -56,10 +56,14 @@ export class AssessmentResultsComponent implements OnInit {
   @Input()
   set assessmentExam(assessment: AssessmentExam) {
     this._assessmentExam = assessment;
-    this.sessions = this.getDistinctExamSessions(assessment.exams);
 
-    if (this.sessions.length > 0) {
-      this.toggleSession(this.sessions[ 0 ]);
+    // if we aren't going to display the sessions, don't waste resources computing them
+    if (this.useSessions) {
+      this.sessions = this.getDistinctExamSessions(assessment.exams);
+
+      if (this.sessions.length > 0) {
+        this.toggleSession(this.sessions[0]);
+      }
     }
   }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -70,6 +70,13 @@ export class AssessmentResultsComponent implements OnInit {
   @Input()
   showValuesAsPercent: boolean;
 
+  /**
+   * If true, the session toggles will be display with the most recent selected
+   * by default.  Otherwise, they won't be displayed and all results will be shown.
+   */
+  @Input()
+  useSessions: boolean = true;
+
   @Input()
   displayState: any = {
     showClaim: ScoreViewState.OVERALL
@@ -238,9 +245,15 @@ export class AssessmentResultsComponent implements OnInit {
   }
 
   private filterExams() {
-    return this.examFilterService
-      .filterExams(this._assessmentExam, this._filterBy)
-      .filter(x => this.sessions.some(y => y.filter && y.id == x.session));
+    let exams: Exam[] = this.examFilterService
+      .filterExams(this._assessmentExam, this._filterBy);
+
+    // only filter by sessions if this is my groups, otherwise return all regardless of session
+    if (this.useSessions) {
+      return exams.filter(x => this.sessions.some(y => y.filter && y.id == x.session));
+    }
+
+    return exams;
   }
 
   private filterAssessmentItems(assessmentItems: AssessmentItem[]) {

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -3,7 +3,7 @@
   {{'labels.groups.name' | translate}}
 </h2>
 
-<assessments [assessmentExams]="assessmentExams" [assessmentProvider]="assessmentProvider">
+<assessments [assessmentExams]="assessmentExams" [assessmentProvider]="assessmentProvider" [useSessions]="true">
   <!-- Group Select -->
   <div class="col-md-3">
     <label for="select-group">{{'labels.groups.results.select-group' | translate}}</label>

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -5,7 +5,7 @@
   </span>
 </h2>
 
-<assessments [assessmentExams]="assessmentExams" [assessmentProvider]="assessmentProvider">
+<assessments [assessmentExams]="assessmentExams" [assessmentProvider]="assessmentProvider" [useSessions]="false">
   <!-- School Select -->
   <div class="col-md-4">
     <label>{{'labels.school-grade.results.basic-filters.school' | translate}}</label>


### PR DESCRIPTION
Do not display session toggles for School/Grade, always show all results since sessions don't make sense at that level according to SBAC.  Since this is a shared component for Groups and School/Grade, each sets an input boolean to represent whether to use session filters or not.