### PR TITLE
Feature/notification system

### DIFF
--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -33,6 +33,7 @@
     "json-unflat": "^1.0.1",
     "lodash": "^4.17.4",
     "ngx-bootstrap": "^1.6.6",
+    "ngx-cookie": "^1.0.0",
     "primeng": "^4.1.0",
     "rxjs": "^5.4.2",
     "sbac-ui-kit": "git+https://github.com/SmarterApp/SBAC-Global-UI-Kit.git#v0.0.7",

--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -1,3 +1,6 @@
+<!-- Notifications -->
+<app-notifications></app-notifications>
+
 <!-- Header -->
 <header>
   <div class="container">

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { environment } from "../environments/environment";
 import { standaloneProviders } from "./standalone/standalone.service";
 import { HomeComponent } from "./home/home.component";
 import { BreadcrumbsComponent } from "./breadcrumbs/breadcrumbs.component";
-import { BsDropdownModule, TabsModule } from "ngx-bootstrap";
+import { BsDropdownModule, TabsModule, AlertModule } from "ngx-bootstrap";
 import { CommonModule } from "./shared/common.module";
 import { GroupsModule } from "./groups/groups.module";
 import { StudentModule } from "./student/student.module";
@@ -18,6 +18,8 @@ import { SchoolGradeModule } from "./school-grade/school-grade.module";
 import { PopoverModule } from "ngx-bootstrap/popover";
 import { TranslateResolve } from "./home/translate.resolve";
 import { Angulartics2Module, Angulartics2GoogleAnalytics } from 'angulartics2';
+import { NotificationModule } from "./notification/notification.module";
+import { CookieModule } from "ngx-cookie";
 
 @NgModule({
   declarations: [
@@ -26,9 +28,12 @@ import { Angulartics2Module, Angulartics2GoogleAnalytics } from 'angulartics2';
     HomeComponent
   ],
   imports: [
+    AlertModule.forRoot(),
     BrowserModule,
     CommonModule,
+    CookieModule.forRoot(),
     GroupsModule,
+    NotificationModule,
     StudentModule,
     SchoolGradeModule,
     RouterModule.forRoot(routes),

--- a/webapp/src/main/webapp/src/app/notification/notification.component.html
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.html
@@ -1,0 +1,11 @@
+<div class="navbar-fixed-top mt-md mr-lg">
+  <div class="clearfix" *ngFor="let notification of notifications">
+    <alert class="pull-right"
+           [type]="notification.configuration.type"
+           [dismissible]="notification.configuration.dismissible"
+           [dismissOnTimeout]="notification.configuration.dismissOnTimeout"
+           (onClose)="onDismissed(notification)">
+      <span>{{notification.translationKey || translate}}</span>
+    </alert>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/notification/notification.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.spec.ts
@@ -1,0 +1,72 @@
+import { NotificationComponent } from "./notification.component";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NotificationService } from "./notification.service";
+import { NO_ERRORS_SCHEMA, EventEmitter } from "@angular/core";
+import { Notification } from "./notification.model";
+import Spy = jasmine.Spy;
+import createSpy = jasmine.createSpy;
+
+describe('NotificationComponent', () => {
+  let component: NotificationComponent;
+  let fixture: ComponentFixture<NotificationComponent>;
+  let service: MockNotificationService;
+
+  beforeEach(() => {
+    service = new MockNotificationService();
+    TestBed.configureTestingModule({
+      imports: [
+
+      ],
+      declarations: [ NotificationComponent ],
+      providers: [
+        {
+          provide: NotificationService,
+          useValue: service
+        }
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
+    })
+      .compileComponents();
+  });
+
+  it('should create', () => {
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should display queued notifications', () => {
+    let note: Notification = new Notification("A Notification");
+    service.unQueueNotifications.and.returnValue([note]);
+
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.notifications).toContain(note);
+  });
+
+  it('should remove dismissed notifications', () => {
+    let note: Notification = new Notification("A Notification");
+
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    service.onNotification.emit(note);
+    expect(component.notifications).toContain(note);
+    component.onDismissed(note);
+    expect(component.notifications.length).toBe(0);
+  });
+});
+
+class MockNotificationService {
+  onNotification: EventEmitter<Notification> = new EventEmitter();
+  unQueueNotifications: Spy = createSpy("unQueueNotifications");
+
+  constructor() {
+    this.unQueueNotifications.and.returnValue([]);
+  }
+}

--- a/webapp/src/main/webapp/src/app/notification/notification.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.spec.ts
@@ -39,7 +39,7 @@ describe('NotificationComponent', () => {
 
   it('should display queued notifications', () => {
     let note: Notification = new Notification("A Notification");
-    service.unQueueNotifications.and.returnValue([note]);
+    service.dequeueNotifications.and.returnValue([note]);
 
     fixture = TestBed.createComponent(NotificationComponent);
     component = fixture.componentInstance;
@@ -64,9 +64,9 @@ describe('NotificationComponent', () => {
 
 class MockNotificationService {
   onNotification: EventEmitter<Notification> = new EventEmitter();
-  unQueueNotifications: Spy = createSpy("unQueueNotifications");
+  dequeueNotifications: Spy = createSpy("dequeueNotifications");
 
   constructor() {
-    this.unQueueNotifications.and.returnValue([]);
+    this.dequeueNotifications.and.returnValue([]);
   }
 }

--- a/webapp/src/main/webapp/src/app/notification/notification.component.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.ts
@@ -19,7 +19,7 @@ export class NotificationComponent implements OnInit {
 
   ngOnInit(): void {
     //Display qeued notifications
-    this.notificationService.unQueueNotifications().forEach(notification => {
+    this.notificationService.dequeueNotifications().forEach(notification => {
       this.onNotification(notification);
     });
   }

--- a/webapp/src/main/webapp/src/app/notification/notification.component.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from "@angular/core";
+import { NotificationService } from "./notification.service";
+import { Notification } from "./notification.model";
+
+/**
+ * This component is responsible for displaying user notifications.
+ */
+@Component({
+  selector: 'app-notifications',
+  templateUrl: './notification.component.html'
+})
+export class NotificationComponent implements OnInit {
+
+  public notifications: Notification[] = [];
+
+  constructor(private notificationService: NotificationService) {
+    notificationService.notification.subscribe(this.onNotification.bind(this));
+  }
+
+  ngOnInit(): void {
+    //Display qeued notifications
+    this.notificationService.unQueueNotifications().forEach(notification => {
+      this.onNotification(notification);
+    });
+
+    // let note: Notification = new Notification("Test Notification");
+    // this.notificationService.queueNotification(note);
+  }
+
+  /**
+   * When a notification is dismissed, remove it from the list.
+   *
+   * @param notification The dismissed notification
+   */
+  public onDismissed(notification) {
+    let idx: number = this.notifications.indexOf(notification);
+    if (idx < 0) return;
+
+    this.notifications.splice(idx, 1);
+  }
+
+  /**
+   * When a notification is received, display it to the user.
+   *
+   * @param notification A notification
+   */
+  private onNotification(notification) {
+    this.notifications.push(notification);
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/notification/notification.component.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.component.ts
@@ -14,7 +14,7 @@ export class NotificationComponent implements OnInit {
   public notifications: Notification[] = [];
 
   constructor(private notificationService: NotificationService) {
-    notificationService.notification.subscribe(this.onNotification.bind(this));
+    notificationService.onNotification.subscribe(this.onNotification.bind(this));
   }
 
   ngOnInit(): void {
@@ -22,9 +22,6 @@ export class NotificationComponent implements OnInit {
     this.notificationService.unQueueNotifications().forEach(notification => {
       this.onNotification(notification);
     });
-
-    // let note: Notification = new Notification("Test Notification");
-    // this.notificationService.queueNotification(note);
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/notification/notification.model.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.model.ts
@@ -1,0 +1,22 @@
+import { isNullOrUndefined } from "util";
+import * as _ from "lodash";
+
+/**
+ * This model represents a notification message.
+ */
+export class Notification {
+
+  // Default configuration
+  public configuration: any = {
+    type: "info",
+    dismissOnTimeout: 10000,
+    dismissible: true
+  };
+
+  constructor(public translationKey: string,
+              private _configuration?: any) {
+    if (!isNullOrUndefined(_configuration)) {
+      this.configuration = _.merge(this.configuration, _configuration);
+    }
+  }
+}

--- a/webapp/src/main/webapp/src/app/notification/notification.module.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from "@angular/core";
+import { NotificationService } from "./notification.service";
+import { NotificationComponent } from "./notification.component";
+import { AlertModule } from "ngx-bootstrap";
+import { CommonModule } from "../shared/common.module";
+import { BrowserModule } from "@angular/platform-browser";
+import { CookieModule } from "ngx-cookie";
+
+@NgModule({
+  declarations: [
+    NotificationComponent
+  ],
+  imports: [
+    AlertModule,
+    BrowserModule,
+    CommonModule,
+    CookieModule.forChild()
+  ],
+  exports: [
+    NotificationComponent
+  ],
+  providers: [
+    NotificationService
+  ]
+})
+export class NotificationModule {
+}

--- a/webapp/src/main/webapp/src/app/notification/notification.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.service.spec.ts
@@ -1,0 +1,58 @@
+import { CookieService } from "ngx-cookie";
+import { NotificationService } from "./notification.service";
+import { Notification } from "./notification.model";
+import Spy = jasmine.Spy;
+import createSpy = jasmine.createSpy;
+import any = jasmine.any;
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let cookieService: any;
+  let cookieCache: any;
+
+  beforeEach(() => {
+    cookieService = {};
+    cookieService.getObject = createSpy("getObject");
+    cookieService.putObject = createSpy("putObject");
+    cookieService.remove = createSpy("remove");
+
+    cookieCache = {};
+    cookieService.getObject.and.callFake((key) => {
+      return cookieCache[key];
+    });
+    cookieService.putObject.and.callFake((key, object) => {
+      cookieCache[key] = object;
+    });
+    cookieService.remove.and.callFake((key) => {
+      delete cookieCache[key];
+    });
+
+    service = new NotificationService(cookieService as CookieService);
+  });
+
+  it("should dispatch a notification", (done) => {
+    let note: Notification = new Notification("Test Notification");
+
+    let handler = function(notification) {
+      expect(notification).toBe(note);
+      done();
+    };
+    service.onNotification.subscribe(handler);
+
+    service.showNotification(note);
+  });
+
+  it("should queue notifications in a cookie", () => {
+    let noteA: Notification = new Notification("Test Notification");
+    service.queueNotification(noteA);
+    expect(cookieService.putObject).toHaveBeenCalledWith("queuedNotifications", [noteA], any(Object));
+
+    let noteB: Notification = new Notification("Test Notification 2");
+    service.queueNotification(noteB);
+    expect(cookieService.putObject).toHaveBeenCalledWith("queuedNotifications", [noteA, noteB], any(Object));
+
+    expect(service.unQueueNotifications()).toContain(noteA, noteB);
+    expect(service.unQueueNotifications().length).toBe(0);
+  });
+});
+

--- a/webapp/src/main/webapp/src/app/notification/notification.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.service.spec.ts
@@ -51,8 +51,8 @@ describe('NotificationService', () => {
     service.queueNotification(noteB);
     expect(cookieService.putObject).toHaveBeenCalledWith("queuedNotifications", [noteA, noteB], any(Object));
 
-    expect(service.unQueueNotifications()).toContain(noteA, noteB);
-    expect(service.unQueueNotifications().length).toBe(0);
+    expect(service.dequeueNotifications()).toContain(noteA, noteB);
+    expect(service.dequeueNotifications().length).toBe(0);
   });
 });
 

--- a/webapp/src/main/webapp/src/app/notification/notification.service.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, EventEmitter } from "@angular/core";
+import { Notification } from "./notification.model";
+import { CookieService } from "ngx-cookie";
+
+/**
+ * This service is responsible for displaying notification alerts
+ * to the user.
+ */
+@Injectable()
+export class NotificationService {
+  private cookieName: string = "queuedNotifications";
+  private expirationMinutes: number = 30;
+
+  public notification: EventEmitter<Notification> = new EventEmitter();
+
+  constructor(private cookieService: CookieService) {
+
+  }
+
+  /**
+   * Dispatch a notification message for immediate display.
+   *
+   * @param notification A notification message
+   */
+  public showNotification(notification: Notification): void {
+    this.notification.emit(notification);
+  }
+
+  /**
+   * Queue a notification for display on next application initialization.
+   *
+   * @param notification A notification message
+   */
+  public queueNotification(notification: Notification): void {
+    let existing: Notification[] = this.unQueueNotifications();
+    existing.push(notification);
+
+    let expiration: Date = new Date();
+    expiration.setMinutes(expiration.getMinutes() + this.expirationMinutes);
+    this.cookieService.putObject(this.cookieName, existing, {expires: expiration});
+  }
+
+  /**
+   * Retrieve notifications queued for display on next application initialization.
+   * Note that this will purge the queue.
+   *
+   * @returns {Array} The queued notifications
+   */
+  public unQueueNotifications(): Notification[] {
+    let notifications: Notification[] = this.cookieService.getObject(this.cookieName) as Notification[] || [];
+    this.cookieService.remove(this.cookieName);
+    return notifications;
+  }
+
+}
+

--- a/webapp/src/main/webapp/src/app/notification/notification.service.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.service.ts
@@ -11,10 +11,9 @@ export class NotificationService {
   private cookieName: string = "queuedNotifications";
   private expirationMinutes: number = 30;
 
-  public notification: EventEmitter<Notification> = new EventEmitter();
+  public onNotification: EventEmitter<Notification> = new EventEmitter();
 
   constructor(private cookieService: CookieService) {
-
   }
 
   /**
@@ -23,7 +22,7 @@ export class NotificationService {
    * @param notification A notification message
    */
   public showNotification(notification: Notification): void {
-    this.notification.emit(notification);
+    this.onNotification.emit(notification);
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/notification/notification.service.ts
+++ b/webapp/src/main/webapp/src/app/notification/notification.service.ts
@@ -31,7 +31,7 @@ export class NotificationService {
    * @param notification A notification message
    */
   public queueNotification(notification: Notification): void {
-    let existing: Notification[] = this.unQueueNotifications();
+    let existing: Notification[] = this.dequeueNotifications();
     existing.push(notification);
 
     let expiration: Date = new Date();
@@ -45,7 +45,7 @@ export class NotificationService {
    *
    * @returns {Array} The queued notifications
    */
-  public unQueueNotifications(): Notification[] {
+  public dequeueNotifications(): Notification[] {
     let notifications: Notification[] = this.cookieService.getObject(this.cookieName) as Notification[] || [];
     this.cookieService.remove(this.cookieName);
     return notifications;


### PR DESCRIPTION
After discussing with @aaronsleeper and @jtreuting the way we will deal with session timeouts is to refresh the browser window when an AJAX request returns 401 Unauthenticated.

To notify the user that their session timed out and the browser was refreshed, we will display a notification once the refresh has completed and they have logged back in (which may or may not require providing their SSO credentials.)

This PR introduces a NotificationService and NotificationComponent that can be used to display both immediate notifications to the user and queue Notifications to be displayed on next application initialization.
The queueing is performed via storing serialized notifications in a browser cookie for up to 30 minutes. (We don't want to display a "Your session expired and you were logged out" notification if the user closes the application and returns the next day.)
