### PR TITLE
On route change scroll to the top of the window, except when that rou…

### DIFF
--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -2,6 +2,8 @@ import { Angulartics2GoogleAnalytics } from 'angulartics2';
 import { Component } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 import { UserService } from "./user/user.service";
+import { Router, NavigationEnd } from '@angular/router';
+import { Location, PopStateEvent } from "@angular/common";
 
 @Component({
   selector: 'app-component',
@@ -9,6 +11,7 @@ import { UserService } from "./user/user.service";
 })
 export class AppComponent {
 
+  private _lastPoppedUrl: string;
   private _user;
 
   get user() {
@@ -19,6 +22,7 @@ export class AppComponent {
   Even though the angulartics2GoogleAnalytics variable is not explicitly used, without it analytics data is not sent to the service
    */
   constructor(public translate: TranslateService, private _userService: UserService,
+              private router: Router, private location: Location,
               private angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {
 
     let languages = [ 'en', 'ja' ];
@@ -39,6 +43,26 @@ export class AppComponent {
 
       if (window['ga'] && user.configuration && user.configuration.analyticsTrackingId) {
         window['ga']('create', user.configuration.analyticsTrackingId, 'auto');
+      }
+    });
+
+
+    // by listening to the PopStateEvent we can track the back button
+    this.location.subscribe((ev:PopStateEvent) => {
+      this._lastPoppedUrl = ev.url;
+    });
+
+    this.router.events.subscribe((evt) => {
+      if (!(evt instanceof NavigationEnd)) {
+        return;
+      }
+
+      // if the user is going back, don't do the window scroll
+      // let the browser take the user back to the position where they last were
+      if (evt.url == this._lastPoppedUrl) {
+        this._lastPoppedUrl = undefined;
+      } else {
+        window.scrollTo(0, 0);
       }
     });
   }


### PR DESCRIPTION
…te change is the back button

Implemented solution found here: https://stackoverflow.com/questions/39601026/angular-2-scroll-to-top-on-route-change

Based on someone's comment, I tested in Safari and it works fine as-is without doing the `setTimeout(...,0)` trick for calling the scroll, so I didn't add that in