### PR TITLE
Bugfix/629 ui issues

### DIFF
--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -9,15 +9,15 @@
 
 <div class="well">
   <div class="mb-md">
-    <div class="row">
-      <div class="col-md-9">
+    <div class="flex-children">
+      <div class="flex-child">
         <span class="tag tag-md {{colorService.getColor(getGradeIndex(assessment.grade))}}">
           <span class="label">{{assessment.grade | gradeDisplay}}</span>
           <span>{{assessment.name}}</span>
         </span>
       </div>
-      <div class="col-md-3">
-        <span class="gray-darker pull-right pt-sm">
+      <div class="flex-child ml-auto">
+        <span class="gray-darker">
           <i class="fa fa-calendar"></i>
           {{exam.date | date}}
         </span>

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -31,7 +31,7 @@
                tableStyleClass="table table-striped table-hover"
                rowExpandMode="single"
                expandableRows="true">
-    <p-column expander="true" ></p-column>
+    <p-column expander="true" styleClass="col-icon"></p-column>
 
     <p-column field="assessmentItem.position" header="{{'labels.groups.results.assessment.items.cols.number' | translate}}" sortable="true"></p-column>
     <p-column field="assessmentItem.claimTarget" [sortable]="true">

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -9,15 +9,15 @@
 
 <div class="well">
   <div class="mb-md">
-    <div class="flex-children">
-      <div class="flex-child">
+    <div class="row">
+      <div class="col-md-9">
         <span class="tag tag-md {{colorService.getColor(getGradeIndex(assessment.grade))}}">
           <span class="label">{{assessment.grade | gradeDisplay}}</span>
           <span>{{assessment.name}}</span>
         </span>
       </div>
-      <div class="flex-child ml-auto">
-        <span class="gray-darker">
+      <div class="col-md-3">
+        <span class="gray-darker pull-right pt-sm">
           <i class="fa fa-calendar"></i>
           {{exam.date | date}}
         </span>


### PR DESCRIPTION
- made the expander arrow on the students responses page consistent with item by points earned change
- move the date on the student response page back to the right as it used to be
