### PR TITLE
Revert "makes the pdf templates source the stylescheet from the webapp"

### DIFF
--- a/common/src/main/resources/templates/fragments.html
+++ b/common/src/main/resources/templates/fragments.html
@@ -4,6 +4,11 @@
 </head>
 <body>
 
+<div th:fragment="styles">
+    <link rel="stylesheet"
+          href="https://raw.githack.com/SmarterApp/SBAC-Global-UI-Kit/develop/dist/css/sbac-ui-kit-wkhtmltopdf.min.css">
+</div>
+
 <div th:fragment="header">
     <header>
         <div class="container">

--- a/common/src/main/resources/templates/iab-report.html
+++ b/common/src/main/resources/templates/iab-report.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
     <head>
         <title th:text="#{report.iab.title}"></title>
+        <div th:replace="fragments::styles"></div>
     </head>
     <body>
         <div th:replace="fragments::header(prefix='report.iab')"></div>

--- a/common/src/main/resources/templates/ica-report.html
+++ b/common/src/main/resources/templates/ica-report.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
     <head>
         <title th:text="#{report.ica.title}"></title>
+        <div th:replace="fragments::styles"></div>
     </head>
     <body>
         <div th:replace="fragments::header(prefix='report.ica')"></div>
@@ -35,6 +36,7 @@
             <div class="well">
                 <div class="well-body">
                     <div th:text="#{report.accommodations.label}"></div>
+                    <!-- <li th:each="accommodation : ${report.exam.accommodationCodes}>" -->
                 </div>
             </div>
 

--- a/pdf-report-processor/src/main/resources/application.yml
+++ b/pdf-report-processor/src/main/resources/application.yml
@@ -67,4 +67,3 @@ app:
     options:
       dpi: 276
       page-size: Letter
-      user-style-sheet: http://localhost:8080/assets/css/sbac-ui-kit-wkhtmltopdf.min.css

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -85,7 +85,6 @@ app:
     options:
       dpi: 276
       page-size: Letter
-      user-style-sheet: http://localhost:8080/assets/css/sbac-ui-kit-wkhtmltopdf.min.css
 
   external-links:
     interpretive-guide: http://www.smarterbalanced.org/educators/

--- a/webapp/src/main/webapp/.angular-cli.json
+++ b/webapp/src/main/webapp/.angular-cli.json
@@ -14,11 +14,6 @@
           "glob": "**/*",
           "input": "../node_modules/sbac-ui-kit/dist/images",
           "output": "assets/image"
-        },
-        {
-          "glob": "sbac-ui-kit-wkhtmltopdf.min.css",
-          "input": "../node_modules/sbac-ui-kit/dist/css",
-          "output": "assets/css"
         }
       ],
       "index": "index.html",

--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -39,7 +39,7 @@
     "ngx-bootstrap": "^1.6.6",
     "primeng": "^4.1.0",
     "rxjs": "^5.4.2",
-    "sbac-ui-kit": "git+https://github.com/SmarterApp/SBAC-Global-UI-Kit.git#v0.0.11",
+    "sbac-ui-kit": "git+https://github.com/SmarterApp/SBAC-Global-UI-Kit.git#v0.0.10",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.8.13"
   },


### PR DESCRIPTION
Reverts SmarterApp/RDW_Reporting#294 - this didn't work upon further docker testing
This will revert it to the state where it pulls the styles from github