### PR TITLE
fix for calculating average scores when there are no scored items

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -309,13 +309,7 @@ export class AssessmentResultsComponent implements OnInit {
     stats.average = this.examCalculator.calculateAverage(this.exams);
     stats.standardError = this.examCalculator.calculateAverageStandardError(this.exams);
     stats.levels = this.examCalculator.groupLevels(this.exams, this.isIab ? 3 : 4);
-    stats.percents = stats.levels.map(x => {
-      return {
-        id: x.id,
-        value: x.value / stats.total * 100,
-        suffix: '%'
-      }
-    });
+    stats.percents = this.examCalculator.mapGroupLevelsToPercents(stats.levels);
 
     return stats;
   }

--- a/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.spec.ts
@@ -57,6 +57,22 @@ describe('Exam Calculator', () => {
     expect(actual).toBe(expected);
   });
 
+  it('should calculate the average when there no scored exams.', () => {
+    let exams: Exam[] = [];
+
+    let fixture = new ExamStatisticsCalculator();
+    let actual = fixture.calculateAverage(exams);
+    expect(actual).toBeNaN();
+  });
+
+  it('should calculate the average standard error when there no scored exams.', () => {
+    let exams: Exam[] = [];
+
+    let fixture = new ExamStatisticsCalculator();
+    let actual = fixture.calculateAverageStandardError(exams);
+    expect(actual).toBeNaN();
+  });
+
   it('should add one level for the number of specified levels', () => {
     let fixture = new ExamStatisticsCalculator();
     let actual = fixture.groupLevels([], 3);
@@ -100,6 +116,45 @@ describe('Exam Calculator', () => {
     expect(actual[ 0 ].value).toBe(4);
     expect(actual[ 1 ].value).toBe(0);
     expect(actual[ 2 ].value).toBe(4);
+  });
+
+  it('should include levels when there are no scored exams', () => {
+    let exams: Exam[] = [];
+
+    let fixture = new ExamStatisticsCalculator();
+    let actual = fixture.groupLevels(exams, 3);
+
+    expect(actual[ 0 ].value).toBe(0);
+    expect(actual[ 1 ].value).toBe(0);
+    expect(actual[ 2 ].value).toBe(0);
+  });
+
+  it('should include percent levels not present in the exams', () => {
+    let exams = [ 3, 3, 1, 3, 1, 1, 1, 3 ].map(x => {
+      let exam = new Exam();
+      exam.level = x;
+      return exam;
+    });
+
+    let fixture = new ExamStatisticsCalculator();
+    let levels = fixture.groupLevels(exams, 3);
+    let actual = fixture.mapGroupLevelsToPercents(levels);
+
+    expect(actual[ 0 ].value).toBe(50.0);
+    expect(actual[ 1 ].value).toBe(0);
+    expect(actual[ 2 ].value).toBe(50.0);
+  });
+
+  it('should include percent levels when there are no scored exams', () => {
+    let exams: Exam[] = [];
+
+    let fixture = new ExamStatisticsCalculator();
+    let levels = fixture.groupLevels(exams, 3);
+    let actual = fixture.mapGroupLevelsToPercents(levels);
+
+    expect(actual[ 0 ].value).toBe(0);
+    expect(actual[ 1 ].value).toBe(0);
+    expect(actual[ 2 ].value).toBe(0);
   });
 
   it('should aggregate items by points', () =>{

--- a/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.ts
@@ -39,6 +39,17 @@ export class ExamStatisticsCalculator {
     return levels;
   }
 
+  mapGroupLevelsToPercents(levels: ExamStatisticsLevel[]) {
+    let total = levels.reduce((x, y) => x + y.value, 0);
+    return levels.map(x => {
+      return {
+        id: x.id,
+        value: total == 0 ? 0 : x.value / total * 100,
+        suffix: '%'
+      }
+    });
+  }
+
   aggregateItemsByPoints(assessmentItems: AssessmentItem[]) {
     for(let item of assessmentItems){
       for(let i=0; i <= item.maxPoints; i++){

--- a/webapp/src/main/webapp/src/app/shared/scale-score.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/scale-score.service.spec.ts
@@ -123,7 +123,7 @@ describe('Assessment Model', () => {
       expect(actual[3]).toBe(52);
     }));
 
-  it('should calculate proper distribution numbers when the originals sum to move than 100',
+  it('should calculate proper distribution numbers when the originals sum to more than 100',
     inject([ScaleScoreService], (service: ScaleScoreService) => {
 
       let level1 = new ExamStatisticsLevel();
@@ -138,10 +138,32 @@ describe('Assessment Model', () => {
       let original = [level1, level2,  level3, level4];
 
       let actual = service.calculateDisplayScoreDistribution(original);
-      console.log(actual);
+
       expect(actual[0]).toBe(20);
       expect(actual[1]).toBe(30);
       expect(actual[2]).toBe(39);
       expect(actual[3]).toBe(11);
+    }));
+
+  it('should calculate proper distribution numbers when the originals sum to zero',
+    inject([ScaleScoreService], (service: ScaleScoreService) => {
+
+      let level1 = new ExamStatisticsLevel();
+      level1.value = 0;
+      let level2 = new ExamStatisticsLevel();
+      level2.value = 0;
+      let level3 = new ExamStatisticsLevel();
+      level3.value = 0;
+      let level4 = new ExamStatisticsLevel();
+      level4.value = 0;
+
+      let original = [level1, level2,  level3, level4];
+
+      let actual = service.calculateDisplayScoreDistribution(original);
+
+      expect(actual[0]).toBe(0);
+      expect(actual[1]).toBe(0);
+      expect(actual[2]).toBe(0);
+      expect(actual[3]).toBe(0);
     }));
 });

--- a/webapp/src/main/webapp/src/app/shared/scale-score.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/scale-score.service.ts
@@ -42,7 +42,7 @@ export class ScaleScoreService {
     // the total needs to be 100 exactly for the visualization to work, see how far above or below we are
     let deltaToWhole = 100 - adjustedPercents.reduce((x, y) => x + y.rounded, 0);
 
-    // order by the remainder so that we can adjust htem in order
+    // order by the remainder so that we can adjust them in order
     adjustedPercents.sort((a, b) => a.remainder < b.remainder ? 1 : -1);
 
     // are we adding or subtracting to get to a total of 100
@@ -50,7 +50,7 @@ export class ScaleScoreService {
 
     // adjust one at a time either adding or subtracting to get to 100
     for (let i = 0; i < deltaToWhole * increment; i++) {
-      adjustedPercents[i].rounded += increment;
+      adjustedPercents[i % adjustedPercents.length].rounded += increment;
     }
 
     // resort them based on the index so they are in the proper order for display


### PR DESCRIPTION
This should fix what @malaffoon was seeing int he UAT environment.  The data had a unscored items that were causing some issues it seems.

I added more tests when the levels were all zeroes to the statistics calculator and the scale score service.  Implemented a fix for when it is calculating percents to not return NaN and return 0 instead when there are no exams at all.  That was causing the issue as then those percents are used for later calculations and NaN caused problems.