### PR TITLE
reject non-2xx responses

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClient.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClient.java
@@ -44,7 +44,11 @@ public class WkhtmltopdfWebServiceClient {
      * @return PDF as bytes from the wkhtmltopdf web service
      */
     public byte[] toPdf(final Request request) {
-        return template.exchange(url, HttpMethod.POST, new HttpEntity<>(request, HEADERS), byte[].class).getBody();
+        final ResponseEntity<byte[]> response = template.exchange(url, HttpMethod.POST, new HttpEntity<>(request, HEADERS), byte[].class);
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new RuntimeException("Error generating PDF: " + response.getStatusCode() + ", " + new String(response.getBody()));
+        }
+        return response.getBody();
     }
 
 }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClientTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClientTest.java
@@ -1,0 +1,48 @@
+package org.opentestsystem.rdw.reporting.common.report.client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WkhtmltopdfWebServiceClientTest {
+
+    private WkhtmltopdfWebServiceClient client;
+    private RestTemplate template;
+    private String endpoint = "http://wkhtmltopdf";
+
+    @Before
+    public void createClient() {
+        template = mock(RestTemplate.class);
+
+        client = new WkhtmltopdfWebServiceClient(template, endpoint);
+    }
+
+    @Test
+    public void itShouldPostRequest() {
+        final byte[] pdf = "pdf".getBytes();
+        final ResponseEntity<byte[]> response = new ResponseEntity<>(pdf, HttpStatus.OK);
+        when(template.exchange(eq(endpoint), eq(HttpMethod.POST), any(HttpEntity.class), eq(byte[].class)))
+                .thenReturn(response);
+
+        assertThat(client.toPdf(mock(Request.class))).isEqualTo(pdf);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void itShouldDealWithBadResponse() {
+        final ResponseEntity<byte[]> response = new ResponseEntity<>("OK".getBytes(), HttpStatus.NOT_ACCEPTABLE);
+        when(template.exchange(eq(endpoint), eq(HttpMethod.POST), any(HttpEntity.class), eq(byte[].class)))
+                .thenReturn(response);
+
+        client.toPdf(mock(Request.class));
+    }
+}


### PR DESCRIPTION
Quick little change to catch non-2xx responses from wkhtmltopdf service. I'm trying to diagnose errors in the k8s environment.