### PR TITLE
Bugfix/pdf 404 notification

### DIFF
--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -1,3 +1,6 @@
+<!-- Notifications -->
+<app-notifications></app-notifications>
+
 <!-- Header -->
 <header>
   <div class="container">

--- a/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
@@ -4,6 +4,8 @@ import { saveAs } from "file-saver";
 import { Subscription } from "rxjs";
 import { ReportDownloadComponent } from "./report-download.component";
 import { Download } from "../shared/data/download.model";
+import {NotificationService} from "../shared/notification/notification.service";
+import {Notification} from "../shared/notification/notification.model";
 
 /**
  * Component used for single-student exam report download
@@ -19,7 +21,7 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
 
   private subscription: Subscription;
 
-  constructor(private service: ReportDownloadService) {
+  constructor(private service: ReportDownloadService, private notificationService: NotificationService) {
     super();
   }
 
@@ -32,8 +34,14 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
           saveAs(download.content, download.name);
         },
         (error: any) => {
-          // TODO: add handler for 404/500 errors - consider publishing to global notification component
-          console.error(error);
+          let messageKey = "labels.reports.messages.500";
+
+          if (error.status == 404) {
+            messageKey = "labels.reports.messages.404";
+          }
+
+          this.notificationService.showNotification(new Notification(messageKey, { type: "danger" }));
+
           this.subscription = null;
         },
         () => {

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -19,6 +19,8 @@ import { AssessmentTypePipe } from "./assessment-type.pipe";
 import { ColorService } from "./color.service";
 import { Angulartics2Module } from "angulartics2";
 import { AuthenticationService } from "./authentication/authentication.service";
+import { NotificationComponent } from "./notification/notification.component";
+import { NotificationService } from "./notification/notification.service";
 import { AlertModule } from "ngx-bootstrap";
 import { SessionExpiredComponent } from "./authentication/session-expired.component";
 import { StorageService } from "./storage.service";
@@ -30,6 +32,7 @@ import { ScaleScoreService } from "./scale-score.service";
   declarations: [
     AssessmentTypePipe,
     GradeDisplayPipe,
+    NotificationComponent,
     PadStartPipe,
     RemoveCommaPipe,
     SBRadioButtonComponent,
@@ -55,6 +58,7 @@ import { ScaleScoreService } from "./scale-score.service";
   exports: [
     AssessmentTypePipe,
     GradeDisplayPipe,
+    NotificationComponent,
     PadStartPipe,
     RemoveCommaPipe,
     RouterModule,
@@ -74,6 +78,7 @@ import { ScaleScoreService } from "./scale-score.service";
     ColorService,
     DecimalPipe,
     ScaleScoreService,
+    NotificationService,
     RdwTranslateLoader,
     StorageService, {
       provide: ErrorHandler,

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.component.html
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.component.html
@@ -1,0 +1,12 @@
+<div class="navbar-fixed-top mt-md mr-lg">
+  <div class="clearfix" *ngFor="let notification of notifications">
+    <alert class="pull-right"
+           [type]="notification.configuration.type"
+           [dismissible]="notification.configuration.dismissible"
+           [dismissOnTimeout]="notification.configuration.dismissOnTimeout"
+           (onClose)="onDismissed(notification)">
+      <h4 *ngIf="notification.titleKey" class="alert-title">{{notification.titleKey | translate}}</h4>
+      <span>{{notification.messageKey | translate}}</span>
+    </alert>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.component.spec.ts
@@ -1,0 +1,57 @@
+import { NotificationComponent } from "./notification.component";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NotificationService } from "./notification.service";
+import { NO_ERRORS_SCHEMA, EventEmitter } from "@angular/core";
+import { Notification } from "./notification.model";
+import Spy = jasmine.Spy;
+import createSpy = jasmine.createSpy;
+import { TranslateModule } from "@ngx-translate/core";
+
+describe('NotificationComponent', () => {
+  let component: NotificationComponent;
+  let fixture: ComponentFixture<NotificationComponent>;
+  let service: MockNotificationService;
+
+  beforeEach(() => {
+    service = new MockNotificationService();
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      declarations: [ NotificationComponent ],
+      providers: [
+        {
+          provide: NotificationService,
+          useValue: service
+        }
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
+    })
+      .compileComponents();
+  });
+
+  it('should create', () => {
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should remove dismissed notifications', () => {
+    let note: Notification = new Notification("A Notification");
+
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    service.onNotification.emit(note);
+    expect(component.notifications).toContain(note);
+    component.onDismissed(note);
+    expect(component.notifications.length).toBe(0);
+  });
+});
+
+class MockNotificationService {
+  onNotification: EventEmitter<Notification> = new EventEmitter();
+}

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit } from "@angular/core";
+import { NotificationService } from "./notification.service";
+import { Notification } from "./notification.model";
+
+/**
+ * This component is responsible for displaying user notifications.
+ */
+@Component({
+  selector: 'app-notifications',
+  templateUrl: 'notification.component.html'
+})
+export class NotificationComponent {
+
+  public notifications: Notification[] = [];
+
+  constructor(private notificationService: NotificationService) {
+    notificationService.onNotification.subscribe(this.onNotification.bind(this));
+  }
+
+  /**
+   * When a notification is dismissed, remove it from the list.
+   *
+   * @param notification The dismissed notification
+   */
+  public onDismissed(notification) {
+    let idx: number = this.notifications.indexOf(notification);
+    if (idx < 0) return;
+
+    this.notifications.splice(idx, 1);
+  }
+
+  /**
+   * When a notification is received, display it to the user.
+   *
+   * @param notification A notification
+   */
+  private onNotification(notification) {
+    this.notifications.push(notification);
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.model.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.model.ts
@@ -1,0 +1,29 @@
+import { isNullOrUndefined } from "util";
+import * as _ from "lodash";
+
+/**
+ * This model represents a notification message.
+ */
+export class Notification {
+
+  // Default configuration
+  public configuration: any = {
+    type: "info",               //['success'|'info'|'warning'|'danger']
+    dismissOnTimeout: 10000,
+    dismissible: true
+  };
+
+  // Notification title translation key
+  public titleKey: string;
+
+  // Notification message translation key
+  public messageKey: string;
+
+  constructor(private _translationKey: string,
+              private _configuration?: any) {
+    this.messageKey = _translationKey;
+    if (!isNullOrUndefined(_configuration)) {
+      this.configuration = _.merge(this.configuration, _configuration);
+    }
+  }
+}

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.service.spec.ts
@@ -1,0 +1,26 @@
+import { NotificationService } from "./notification.service";
+import { Notification } from "./notification.model";
+import Spy = jasmine.Spy;
+import createSpy = jasmine.createSpy;
+import any = jasmine.any;
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    service = new NotificationService();
+  });
+
+  it("should dispatch a notification", (done) => {
+    let note: Notification = new Notification("Test Notification");
+
+    let handler = function(notification) {
+      expect(notification).toBe(note);
+      done();
+    };
+    service.onNotification.subscribe(handler);
+
+    service.showNotification(note);
+  });
+});
+

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, EventEmitter } from "@angular/core";
+import { Notification } from "./notification.model";
+
+/**
+ * This service is responsible for displaying notification alerts
+ * to the user.
+ */
+@Injectable()
+export class NotificationService {
+
+  public onNotification: EventEmitter<Notification> = new EventEmitter();
+
+  constructor() {
+  }
+
+  /**
+   * Dispatch a notification message for immediate display.
+   *
+   * @param notification A notification message
+   */
+  public showNotification(notification: Notification): void {
+    this.onNotification.emit(notification);
+  }
+
+}
+

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -373,7 +373,11 @@
       "download": "Download",
       "assessment-type": "Assessment Type",
       "subject": "Subject",
-      "school-year": "School Year"
+      "school-year": "School Year",
+      "messages" : {
+        "404": "This student does not have any test results for your selection. Please update your selection and try again.",
+        "500": "There was an unexpected error while generating this report.  Please try again."
+      }
     },
     "select-year": "School Year",
     "export": {


### PR DESCRIPTION
This fixes the issue where there is no notification to the user when the PDF report generation fails.  It can fail because they are trying to generation a report for a combination where there are no results for the student (IAB Math for example if they just have English results), or there could just be a 500 error on the server.

Resurrected @wtritch NotificationService from the git trash can and putting it to use.

Can consider later if it makes sense to try to disable the various combinations of the 3 dropdowns that aren't valid or not.