### PR TITLE
Minor ui tweaks for uat.

### DIFF
--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -20,8 +20,8 @@
           </div>
           <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
-              <li class="navbar-link"><a href="#">{{'labels.navigation.user-guide' | translate}}</a></li>
-              <li class="navbar-link"><a href="{{interpretiveGuide}}" target="_blank">{{'labels.navigation.interpretive-guide' | translate}}</a></li>
+              <li class="navbar-link"><a href="javascript:void(0)" (click)="showComingSoon('User Guide')">{{'labels.navigation.user-guide' | translate}}</a></li>
+              <li class="navbar-link"><a href="javascript:void(0)" (click)="showComingSoon('Interpretive Guide')" target="_blank">{{'labels.navigation.interpretive-guide' | translate}}</a></li>
               <li class="navbar-link mt-sm">
                 <div class="btn-group" dropdown>
                   <button type="button" dropdownToggle class="btn btn-link btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -4,6 +4,8 @@ import { TranslateService } from "@ngx-translate/core";
 import { UserService } from "./user/user.service";
 import { Router, NavigationEnd } from "@angular/router";
 import { Location, PopStateEvent } from "@angular/common";
+import { NotificationService } from "./shared/notification/notification.service";
+import { Notification } from "./shared/notification/notification.model";
 
 @Component({
   selector: 'app-component',
@@ -25,6 +27,7 @@ export class AppComponent {
    */
   constructor(public translate: TranslateService, private _userService: UserService,
               private router: Router, private location: Location,
+              private notifService: NotificationService,
               private angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {
 
     let languages = [ 'en', 'ja' ];
@@ -69,5 +72,12 @@ export class AppComponent {
         window.scrollTo(0, 0);
       }
     });
+  }
+
+  showComingSoon(featureName: string) {
+    let notif = new Notification('messages.coming-soon',  {dismissOnTimeout: 5000 });
+    notif.messageObject = { featureName: featureName };
+
+    this.notifService.showNotification(notif);
   }
 }

--- a/webapp/src/main/webapp/src/app/home/home.component.html
+++ b/webapp/src/main/webapp/src/app/home/home.component.html
@@ -40,9 +40,9 @@
       <div class="welcome-container well">
         <p class="lead">{{'labels.homepage.welcome.title' | translate}}</p>
         <p>{{'labels.homepage.welcome.sub-title' | translate}}</p>
-        <p><a href="#" class="btn btn-primary">{{'labels.navigation.user-guide' | translate}}</a></p>
+        <p><a href="javascript:void(0)" (click)="showComingSoon('User Guide')" class="btn btn-primary">{{'labels.navigation.user-guide' | translate}}</a></p>
         <p>{{'labels.homepage.welcome.interpret-instructions' | translate}}</p>
-        <p><a href="#" class="btn btn-success">{{'labels.navigation.interpretive-guide' | translate}}</a></p>
+        <p><a href="javascript:void(0)" (click)="showComingSoon('Interpretive Guide')" class="btn btn-success">{{'labels.navigation.interpretive-guide' | translate}}</a></p>
       </div>
 
       <!-- Summary News Dynamic Content -->

--- a/webapp/src/main/webapp/src/app/home/home.component.ts
+++ b/webapp/src/main/webapp/src/app/home/home.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from "@angular/router";
 import { User } from "../user/model/user.model";
 import { TranslateService } from "@ngx-translate/core";
+import { Notification } from "../shared/notification/notification.model";
+import { NotificationService } from "../shared/notification/notification.service";
 
 @Component({
   selector: 'home',
@@ -11,7 +13,7 @@ export class HomeComponent implements OnInit {
   user : User;
   systemNewsHtml: string;
 
-  constructor(private route : ActivatedRoute, private translate: TranslateService) { }
+  constructor(private route : ActivatedRoute, private translate: TranslateService, private notifService: NotificationService) { }
 
   ngOnInit() {
     this.user = this.route.snapshot.data[ "user" ];
@@ -20,4 +22,10 @@ export class HomeComponent implements OnInit {
     });
   }
 
+  showComingSoon(featureName: string) {
+    let notif = new Notification('messages.coming-soon',  {dismissOnTimeout: 5000 });
+    notif.messageObject = { featureName: featureName };
+
+    this.notifService.showNotification(notif);
+  }
 }

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.component.html
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.component.html
@@ -6,7 +6,7 @@
            [dismissOnTimeout]="notification.configuration.dismissOnTimeout"
            (onClose)="onDismissed(notification)">
       <h4 *ngIf="notification.titleKey" class="alert-title">{{notification.titleKey | translate}}</h4>
-      <span>{{notification.messageKey | translate}}</span>
+      <span>{{notification.messageKey | translate: notification.messageObject}}</span>
     </alert>
   </div>
 </div>

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.model.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.model.ts
@@ -19,6 +19,8 @@ export class Notification {
   // Notification message translation key
   public messageKey: string;
 
+  public messageObject: any = {};
+
   constructor(private _translationKey: string,
               private _configuration?: any) {
     this.messageKey = _translationKey;

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -20,7 +20,8 @@
       "message": "Click Ok to re-authenticate."
     },
     "toggle-navigation": "Toggle navigation",
-    "no-item-level-data": "Item level data is not available for tests administered prior to 2016-17 school year."
+    "no-item-level-data": "Item level data is not available for tests administered prior to 2016-17 school year.",
+    "coming-soon": "{{featureName}} is coming soon."
   },
   "collapse": "Collapse",
   "select": "Select",
@@ -587,6 +588,6 @@
     }
   },
   "html": {
-    "system-news":"<h2 class=\"blue-dark h3 mb-md\">Summary Reports</h2><div class=\"summary-reports-container mb-md\"><p><a href=\"#\" class=\"h5 blue\">Achievement Level Report</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit. Atque et delectus cumque at illo minima accusamus.</p><p><a href=\"#\" class=\"h5 blue\">Achievement Standard Report</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit. Atque et delectus cumque at illo minima accusamus.</p><p><a href=\"#\" class=\"h5 blue\">Longitudinal Data Report</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit. Atque et delectus cumque at illo minima accusamus.</p></div><!-- Member Reporting Resources --><h2 class=\"blue-dark h3 mb-md\">Member Reporting Resources</h2><div class=\"member-reporting-resources-container\"><p><a href=\"#\" class=\"h5 blue\">Member-provided Resources</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p><p><a href=\"#\" class=\"h5 blue\">How to Establish PII Permissions</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p><p><a href=\"#\" class=\"h5 blue\">How to Create Student Groups</a><br />Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p></div>"
+    "system-news":"<h2 class=\"blue-dark h3 mb-md\">Summary Reports</h2><div class=\"summary-reports-container mb-md\"><p>(Coming Soon)</div><!-- Member Reporting Resources --><h2 class=\"blue-dark h3 mb-md\">Member Reporting Resources</h2><div class=\"member-reporting-resources-container\"><p>(Coming Soon)</p></div>"
   }
 }


### PR DESCRIPTION
 - Now showing notifications when clicking User Guide / Interpretive Guide that these features are coming soon.
 - Removed Lorem Lipsum text from the right side panel.

Screenshot of what it looks like after clicking both:
![image](https://user-images.githubusercontent.com/5771116/28799637-3ca41f0c-75fe-11e7-9ed6-52fa95de5971.png)
