### PR TITLE
Handle unscored exams and claim scores

### DIFF
--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
@@ -43,7 +43,7 @@
                   content="{{'labels.groups.results.assessment.exams.cols.iab.performance-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData.exam" pTemplate="body">
-      {{ 'enum.iab-category.full.' + exam.level.toString() | translate }}
+      {{ 'enum.iab-category.full.' + (exam.level ? exam.level.toString() : 'missing') | translate }}
     </ng-template>
   </p-column>
   <p-column field="exam.score" sortable="true">

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.html
@@ -68,7 +68,7 @@
                   content="{{'labels.groups.results.assessment.exams.cols.ica.performance-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData.exam" pTemplate="body">
-      {{ 'enum.achievement-level.full.' + exam.level.toString() | translate }}
+      {{ 'enum.achievement-level.full.' + (exam.level ? exam.level.toString() : 'missing') | translate }}
     </ng-template>
   </p-column>
   <p-column field="exam.score"
@@ -90,7 +90,7 @@
             sortable="true"
             [hidden]="displayState.table !== 'claim'">
     <ng-template let-exam="rowData.exam" pTemplate="body">
-      <span *ngIf="exam.claimScores[idx].level">{{ 'enum.iab-category.full.' + exam.claimScores[idx].level.toString() | translate }}</span>
+      <span *ngIf="exam.claimScores[idx].level">{{ 'enum.iab-category.full.' + (exam.claimScores[idx] ? exam.claimScores[idx].level.toString() : 'missing') | translate }}</span>
       <span *ngIf="!exam.claimScores[idx].level">-</span>
     </ng-template>
   </p-column>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -436,12 +436,14 @@
       "short": {
         "1": "Below",
         "2": "Near",
-        "3": "Above"
+        "3": "Above",
+        "missing": "-"
       },
       "full": {
         "1": "Below Standard",
         "2": "Near Standard",
-        "3": "Above Standard"
+        "3": "Above Standard",
+        "missing": "-"
       }
     },
     "achievement-level": {
@@ -449,13 +451,15 @@
         "1": "Did Not Meet",
         "2": "Nearly Met",
         "3": "Met",
-        "4": "Exceeded"
+        "4": "Exceeded",
+        "missing": "-"
       },
       "full": {
         "1": "Did Not Meet Standard",
         "2": "Nearly Met Standard",
         "3": "Met Standard",
-        "4": "Exceeded Standard"
+        "4": "Exceeded Standard",
+        "missing": "-"
       }
     },
     "subject-claim-code": {


### PR DESCRIPTION
The problem was calling toString() on a null property.  So added a missing value to the enum for IAB and ICA to display these as dashes.

Went back and forth on whether the mapper should translate a missing level to some known value that the translate could use or whether to do that check on the display side.  Open to thoughts.