### PR TITLE
Bugfix/657 csv null scale score

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -139,7 +139,7 @@
                           content="{{performanceLevelHeaderInfo | translate}}"></span>
             </ng-template>
             <ng-template let-exam="rowData" pTemplate="body">
-              {{ examLevelEnum + exam.level | translate }}
+              {{ examLevelEnum + (exam.level ? exam.level : 'missing') | translate }}
             </ng-template>
           </p-column>
           <p-column field="score" [sortable]="true" [hidden]="isClaimScoreSelected">

--- a/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.spec.ts
@@ -4,6 +4,7 @@ import { inject, TestBed } from "@angular/core/testing";
 import { DatePipe, DecimalPipe } from "@angular/common";
 import { Angular2CsvProvider } from "./angular-csv.provider";
 import Spy = jasmine.Spy;
+import {Exam} from "../assessments/model/exam.model";
 
 describe('CsvBuilder', () => {
   let datePipe: MockDatePipe;
@@ -64,6 +65,32 @@ describe('CsvBuilder', () => {
       expect(tabularData[1]).toEqual(["value A1", "value B1"]);
       expect(tabularData[2]).toEqual(["value A2", "value B2"]);
     }));
+
+  it('should create tabular data from source data handling empty scale scores',
+    inject([ CsvBuilder ], (builder: CsvBuilder) => {
+      let exams = [ {score: 2580, level: 1 }, {score: null, level: null}].map(x => {
+        let exam = new Exam();
+        exam.score = x.score;
+        exam.level = x.level;
+
+        return exam;
+      });
+
+      builder
+        .newBuilder()
+        .withScaleScore((exam) => exam)
+        .withAchievementLevel((exam) => exam)
+        .withReportingCategory((exam) => exam)
+        .build(exams);
+
+      let tabularData: string[][] = angular2Csv.export.calls.mostRecent().args[0];
+
+      expect(tabularData.length).toBe(3);
+      expect(tabularData[0]).toEqual(["labels.groups.results.assessment.exams.cols.score", "labels.groups.results.assessment.exams.cols.ica.performance", "labels.groups.results.assessment.exams.cols.iab.performance"]);
+      expect(tabularData[1]).toEqual([2580, "enum.achievement-level.full.1", "enum.iab-category.full.1"]);
+      expect(tabularData[2]).toEqual(["", "", ""]);
+    }));
+
 });
 
 export class MockDatePipe {
@@ -72,4 +99,8 @@ export class MockDatePipe {
 
 export class MockDecimalPipe {
   transform: Spy = jasmine.createSpy("transform");
+}
+
+export class MockTranslateService {
+  instant: Spy = jasmine.createSpy("instant");
 }

--- a/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
+++ b/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
@@ -169,7 +169,7 @@ export class CsvBuilder {
       this.translateService.instant('labels.groups.results.assessment.exams.cols.ica.performance'),
       (item) => {
         let exam: Exam = getExam(item);
-        if (!exam) return "";
+        if (!exam || !exam.level) return "";
 
         return this.translateService.instant(`enum.achievement-level.full.${exam.level}`);
       }
@@ -181,7 +181,7 @@ export class CsvBuilder {
       this.translateService.instant('labels.groups.results.assessment.exams.cols.iab.performance'),
       (item) => {
         let exam: Exam = getExam(item);
-        if (!exam) return "";
+        if (!exam || !exam.level) return "";
 
         return this.translateService.instant(`enum.iab-category.full.${exam.level}`);
       }
@@ -232,11 +232,9 @@ export class CsvBuilder {
         this.translateService.instant(`enum.subject-claim-code.${claim}`),
         (item) => {
           let exam: Exam = getExam(item);
-          if (!exam) return "";
+          if (!exam || !exam.claimScores[idx].level) return "";
 
-          let level = !exam.claimScores[idx].level ? 'missing' : exam.claimScores[idx].level;
-
-          return this.translateService.instant(`enum.iab-category.full.${level}`);
+          return this.translateService.instant(`enum.iab-category.full.${exam.claimScores[idx].level}`);
         }
       )
     });

--- a/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
+++ b/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
@@ -191,7 +191,10 @@ export class CsvBuilder {
   withScaleScore(getExam: (item: any) => Exam) {
     return this.withColumn(
       this.translateService.instant('labels.groups.results.assessment.exams.cols.score'),
-      (item) => getExam(item).score
+      (item) => {
+        let score = getExam(item).score;
+        return !score ? '' : score;
+      }
     )
   }
 
@@ -200,7 +203,7 @@ export class CsvBuilder {
       this.translateService.instant('labels.export.cols.error-band-min'),
       (item) => {
         let exam: Exam = getExam(item);
-        return exam.score - exam.standardError;
+        return !exam.score ? '' : exam.score - exam.standardError;
       }
     )
   }
@@ -210,7 +213,7 @@ export class CsvBuilder {
       this.translateService.instant('labels.export.cols.error-band-max'),
       (item) => {
         let exam: Exam = getExam(item);
-        return exam.score + exam.standardError;
+        return !exam.score ? '' : exam.score + exam.standardError;
       }
     )
   }
@@ -231,7 +234,9 @@ export class CsvBuilder {
           let exam: Exam = getExam(item);
           if (!exam) return "";
 
-          return this.translateService.instant(`enum.iab-category.full.${exam.claimScores[idx].level}`);
+          let level = !exam.claimScores[idx].level ? 'missing' : exam.claimScores[idx].level;
+
+          return this.translateService.instant(`enum.iab-category.full.${level}`);
         }
       )
     });


### PR DESCRIPTION
Fixed bug where NULL scale score and claim and levels were showing incorrect values in CSV

NULL scale score was showing 0
NULL levels was showing the translation string with undefined at the end

While testing the fix I found a problem with the display of the Reporting Category or Achievement Level value when NULL in the data table