### PR TITLE
Add tolerance for PhantomJS OOM errors.

### DIFF
--- a/webapp/src/main/webapp/karma.conf.js
+++ b/webapp/src/main/webapp/karma.conf.js
@@ -40,6 +40,10 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['PhantomJS2'],
-    singleRun: false
+    singleRun: false,
+    //Quick fix for PhantomJS OOM issues
+    browserNoActivityTimeout: 60000,
+    browserDisconnectTimeout: 30000,
+    captureTimeout: 60000
   });
 };


### PR DESCRIPTION
Quick fix for:
https://github.com/karma-runner/karma-phantomjs-launcher/issues/126

Looks like we might need to go curate our component tests to avoid loading sub-components.