### PR TITLE
DWR-652 - Send generated HTML report to pdf generation service for co…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ReportConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ReportConfiguration.java
@@ -1,23 +1,19 @@
 package org.opentestsystem.rdw.reporting.common.report;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentestsystem.rdw.reporting.common.report.client.WkhtmltopdfWebServiceClient;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -26,9 +22,16 @@ import static com.google.common.collect.Lists.newArrayList;
 public class ReportConfiguration {
 
     @Bean
+    public ClientHttpRequestFactory requestFactory() {
+        return new SimpleClientHttpRequestFactory();
+    }
+
+    @Bean
     public WkhtmltopdfWebServiceClient wkhtmlToPdfWebServiceClient(
-            @Value("${app.wkhtmltopdf.url}") final String url) {
-        return new WkhtmltopdfWebServiceClient(pdfAcceptingRestTemplate(), url);
+            @Value("${app.wkhtmltopdf.url}") final String url,
+            final ClientHttpRequestFactory requestFactory,
+            final ObjectMapper objectMapper) {
+        return new WkhtmltopdfWebServiceClient(requestFactory, url, objectMapper);
     }
 
     @Bean

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClient.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClient.java
@@ -1,13 +1,19 @@
 package org.opentestsystem.rdw.reporting.common.report.client;
 
-import org.springframework.http.HttpEntity;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
 
 import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,28 +31,38 @@ public class WkhtmltopdfWebServiceClient {
         HEADERS.setContentType(MediaType.APPLICATION_JSON);
     }
 
-    /**
-     * Spring REST Template used to connect to the wkhtmltopdf web service REST API
-     */
-    private final RestTemplate template;
+    private final ClientHttpRequestFactory requestFactory;
+    private final ObjectMapper objectMapper;
 
     /**
      * wkhtmltopdf web service REST API URL
      */
     private final String url;
 
-    public WkhtmltopdfWebServiceClient(@NotNull final RestTemplate template, @NotNull final String endpoint) {
-        this.template = checkNotNull(template);
+    public WkhtmltopdfWebServiceClient(@NotNull final ClientHttpRequestFactory requestFactory,
+                                       @NotNull final String endpoint,
+                                       @NotNull final ObjectMapper objectMapper) {
+        this.requestFactory = checkNotNull(requestFactory);
         this.url = checkNotNull(endpoint);
+        this.objectMapper = checkNotNull(objectMapper);
     }
 
     /**
-     * @return PDF as bytes from the wkhtmltopdf web service
+     * @return PDF stream from the wkhtmltopdf web service
      */
-    public byte[] toPdf(final Request request) {
-        final ResponseEntity<byte[]> response = template.exchange(url, HttpMethod.POST, new HttpEntity<>(request, HEADERS), byte[].class);
+    public InputStream toPdf(final Request request) throws IOException {
+        final ClientHttpRequest req = requestFactory.createRequest(URI.create(url), HttpMethod.POST);
+        req.getHeaders().putAll(HEADERS);
+        try (final OutputStream reqOutput = req.getBody()) {
+            objectMapper.writeValue(reqOutput, request);
+        }
+        final ClientHttpResponse response = req.execute();
         if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new RuntimeException("Error generating PDF: " + response.getStatusCode() + ", " + new String(response.getBody()));
+            final String responseContent;
+            try (final InputStream responseData = response.getBody()) {
+                responseContent = IOUtils.toString(responseData);
+            }
+            throw new RuntimeException("Error generating PDF: " + response.getStatusCode() + ", " + responseContent);
         }
         return response.getBody();
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/DefaultExamReportPdfProcessor.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/DefaultExamReportPdfProcessor.java
@@ -1,13 +1,15 @@
 package org.opentestsystem.rdw.reporting.common.report.processor;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.IOUtils;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.ReportViewSupport;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 /**
@@ -36,7 +38,11 @@ class DefaultExamReportPdfProcessor implements ExamReportPdfProcessor {
             final AbstractExamReportRequest<PrintOptions> request) {
         final Map<String, Object> model = ImmutableMap.of("report", report, "request", request, "support", support);
         final byte[] html = templateProcessor.process(request.getAssessmentType().template(), model, request.getLanguage());
-        return htmlToPdfProcessor.process(html, request.getOptions());
+        try (final InputStream pdfStream = htmlToPdfProcessor.process(html, request.getOptions())) {
+            return IOUtils.toByteArray(pdfStream);
+        } catch (final IOException e) {
+            throw new RuntimeException("Unable to convert HTML to PDF", e);
+        }
     }
 
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/HtmlToPdfProcessor.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/HtmlToPdfProcessor.java
@@ -2,6 +2,9 @@ package org.opentestsystem.rdw.reporting.common.report.processor;
 
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * Responsible for transforming HTML into a PDF
  */
@@ -14,6 +17,6 @@ public interface HtmlToPdfProcessor {
      * @param options the pdf generation options
      * @return PDF version of the input HTML
      */
-    byte[] process(byte[] html, PrintOptions options);
+    InputStream process(byte[] html, PrintOptions options) throws IOException;
 
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfCommandLineHtmlToPdfProcessor.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfCommandLineHtmlToPdfProcessor.java
@@ -7,6 +7,7 @@ import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,7 +26,7 @@ public class WkhtmltopdfCommandLineHtmlToPdfProcessor implements HtmlToPdfProces
     private static final String OPTION_OUTPUT_TO_STDOUT = "-";
 
     @Override
-    public byte[] process(final byte[] html, final PrintOptions options) {
+    public InputStream process(final byte[] html, final PrintOptions options) {
         try {
             final File temporaryFile = createTemporaryFile();
             FileUtils.writeByteArrayToFile(temporaryFile, html);
@@ -51,10 +52,9 @@ public class WkhtmltopdfCommandLineHtmlToPdfProcessor implements HtmlToPdfProces
         return File.createTempFile(temporaryFilename, ".html");
     }
 
-    private byte[] createPDFFromFile(final String command) throws IOException, InterruptedException {
+    private InputStream createPDFFromFile(final String command) throws IOException, InterruptedException {
 
         final Process process = Runtime.getRuntime().exec(command);
-        final byte[] inputBytes = IOUtils.toByteArray(process.getInputStream());
         final byte[] errorBytes = IOUtils.toByteArray(process.getErrorStream());
 
         // TODO add timeout
@@ -66,7 +66,7 @@ public class WkhtmltopdfCommandLineHtmlToPdfProcessor implements HtmlToPdfProces
                     command, process.exitValue(), new String(errorBytes)));
         }
 
-        return inputBytes;
+        return process.getInputStream();
     }
 
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfWebServiceHtmlToPdfProcessor.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfWebServiceHtmlToPdfProcessor.java
@@ -7,6 +7,8 @@ import org.opentestsystem.rdw.reporting.common.report.client.WkhtmltopdfWebServi
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 /**
@@ -36,7 +38,7 @@ public class WkhtmltopdfWebServiceHtmlToPdfProcessor implements HtmlToPdfProcess
     }
 
     @Override
-    public byte[] process(final byte[] html, final PrintOptions printOptions) {
+    public InputStream process(final byte[] html, final PrintOptions printOptions) throws IOException {
         return client.toPdf(new Request(html, computeOptions(printOptions)));
     }
 

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClientTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/client/WkhtmltopdfWebServiceClientTest.java
@@ -1,48 +1,106 @@
 package org.opentestsystem.rdw.reporting.common.report.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpEntity;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
+@RunWith(MockitoJUnitRunner.class)
 public class WkhtmltopdfWebServiceClientTest {
 
+    @Mock
+    private ClientHttpRequestFactory requestFactory;
+
+    @Mock
+    private ClientHttpRequest request;
+
+    @Mock
+    private ClientHttpResponse response;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
     private WkhtmltopdfWebServiceClient client;
-    private RestTemplate template;
-    private String endpoint = "http://wkhtmltopdf";
 
     @Before
-    public void createClient() {
-        template = mock(RestTemplate.class);
+    public void createClient() throws Exception {
+        doAnswer(invocation -> {
+            invocation.getArgumentAt(0, OutputStream.class)
+                    .write(invocation.getArgumentAt(1, Object.class).toString().getBytes());
+            return null;
+        }).when(objectMapper).writeValue(any(OutputStream.class), anyObject());
 
-        client = new WkhtmltopdfWebServiceClient(template, endpoint);
+        final String endpoint = "http://wkhtmltopdf";
+        final URI uri = URI.create(endpoint);
+        when(requestFactory.createRequest(eq(uri), eq(HttpMethod.POST)))
+                .thenReturn(request);
+
+        final HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+        when(request.execute()).thenReturn(response);
+
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+
+        client = new WkhtmltopdfWebServiceClient(requestFactory, endpoint, objectMapper);
     }
 
     @Test
-    public void itShouldPostRequest() {
-        final byte[] pdf = "pdf".getBytes();
-        final ResponseEntity<byte[]> response = new ResponseEntity<>(pdf, HttpStatus.OK);
-        when(template.exchange(eq(endpoint), eq(HttpMethod.POST), any(HttpEntity.class), eq(byte[].class)))
-                .thenReturn(response);
+    public void itShouldPostRequest() throws Exception {
+        final Request requestBody = new Request("html".getBytes());
 
-        assertThat(client.toPdf(mock(Request.class))).isEqualTo(pdf);
+        try (final ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
+             final ByteArrayInputStream responseStream = new ByteArrayInputStream("pdf".getBytes())) {
+            when(request.getBody()).thenReturn(requestStream);
+            when(response.getBody()).thenReturn(responseStream);
+
+            try (final InputStream response = client.toPdf(requestBody)) {
+                assertThat(StreamUtils.copyToString(response, Charsets.UTF_8)).isEqualTo("pdf");
+            }
+        }
+
+        verify(objectMapper).writeValue(any(OutputStream.class), eq(requestBody));
+        assertThat(request.getHeaders().getContentType()).isEqualTo(APPLICATION_JSON);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void itShouldDealWithBadResponse() {
-        final ResponseEntity<byte[]> response = new ResponseEntity<>("OK".getBytes(), HttpStatus.NOT_ACCEPTABLE);
-        when(template.exchange(eq(endpoint), eq(HttpMethod.POST), any(HttpEntity.class), eq(byte[].class)))
-                .thenReturn(response);
+    @Test
+    public void itShouldDealWithBadResponse() throws Exception {
+        final Request requestBody = new Request("html".getBytes());
 
-        client.toPdf(mock(Request.class));
+        try (final ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
+             final ByteArrayInputStream responseStream = new ByteArrayInputStream("Some Error".getBytes())) {
+            when(request.getBody()).thenReturn(requestStream);
+            when(response.getBody()).thenReturn(responseStream);
+            when(response.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+            try {
+                client.toPdf(requestBody);
+            } catch (final RuntimeException e) {
+                assertThat(e.getMessage()).contains("Some Error");
+            }
+        }
     }
 }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfCommandLineHtmlToPdfProcessorIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/processor/WkhtmltopdfCommandLineHtmlToPdfProcessorIT.java
@@ -1,7 +1,10 @@
 package org.opentestsystem.rdw.reporting.common.report.processor;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
+
+import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,20 +19,26 @@ public class WkhtmltopdfCommandLineHtmlToPdfProcessorIT {
 
     @Test
     public void itShouldProcessEmptyHTML() throws Exception {
-        final byte[] pdf = processor.process(emptyHtmlDocument.getBytes("UTF-8"), defaultPrintOptions);
-        assertThat(pdf).isNotEmpty();
+        try (final InputStream data = processor.process(emptyHtmlDocument.getBytes("UTF-8"), defaultPrintOptions)) {
+            final byte[] pdf = IOUtils.toByteArray(data);
+            assertThat(pdf).isNotEmpty();
+        }
     }
 
     @Test
     public void itShouldProcessInvalidHTML() throws Exception {
-        final byte[] pdf = processor.process(invalidHtmlDocument.getBytes("UTF-8"), defaultPrintOptions);
-        assertThat(pdf).isNotEmpty();
+        try (final InputStream data = processor.process(invalidHtmlDocument.getBytes("UTF-8"), defaultPrintOptions)) {
+            final byte[] pdf = IOUtils.toByteArray(data);
+            assertThat(pdf).isNotEmpty();
+        }
     }
 
     @Test
     public void itShouldProcessValidHTML() throws Exception {
-        final byte[] pdf = processor.process(validHtmlDocument.getBytes("UTF-8"), defaultPrintOptions);
-        assertThat(pdf).isNotEmpty();
+        try (final InputStream data = processor.process(validHtmlDocument.getBytes("UTF-8"), defaultPrintOptions)) {
+            final byte[] pdf = IOUtils.toByteArray(data);
+            assertThat(pdf).isNotEmpty();
+        }
     }
 
 }

--- a/pdf-report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/configuration/ReportGenerationJobConfiguration.java
+++ b/pdf-report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/configuration/ReportGenerationJobConfiguration.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.processor.configuration;
 
+import org.opentestsystem.rdw.reporting.common.report.processor.WkhtmltopdfWebServiceHtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.processor.ReportGenerationJobExecutionListener;
 import org.opentestsystem.rdw.reporting.processor.model.StudentCompositeReport;
 import org.opentestsystem.rdw.reporting.processor.step.FetchStudentIds;
@@ -14,6 +15,7 @@ import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
@@ -22,6 +24,8 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+
+import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * This configuration is responsible for defining a report generation job.
@@ -102,5 +106,16 @@ public class ReportGenerationJobConfiguration {
     @JobScope
     public Map<Long, StudentCompositeReport> studentReportsByExecution() {
         return new ConcurrentHashMap<>();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "app.wkhtmltopdf.options")
+    public Map<String, Object> wkhtmltopdfOptions() {
+        return newHashMap();
+    }
+
+    @Autowired
+    public void configure(final WkhtmltopdfWebServiceHtmlToPdfProcessor processor) {
+        processor.setOptions(wkhtmltopdfOptions());
     }
 }

--- a/pdf-report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/step/GeneratePdf.java
+++ b/pdf-report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/step/GeneratePdf.java
@@ -2,11 +2,14 @@ package org.opentestsystem.rdw.reporting.processor.step;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
+import org.apache.commons.io.IOUtils;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportOrder;
+import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.ReportViewSupport;
+import org.opentestsystem.rdw.reporting.common.report.processor.HtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.common.report.processor.TemplateProcessor;
 import org.opentestsystem.rdw.reporting.processor.model.StudentCompositeReport;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationJobParameterProvider;
@@ -19,6 +22,9 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeSet;
@@ -40,16 +46,19 @@ public class GeneratePdf implements Tasklet {
     private final ReportViewSupport support;
     private final Map<Long, StudentCompositeReport> studentReports;
     private final ReportGenerationJobParameterProvider parameterProvider;
+    private final HtmlToPdfProcessor htmlToPdfProcessor;
 
     @Autowired
     public GeneratePdf(final Map<Long, StudentCompositeReport> studentReports,
                        final ReportGenerationJobParameterProvider parameterProvider,
                        final TemplateProcessor templateProcessor,
-                       final ReportViewSupport support) {
+                       final ReportViewSupport support,
+                       final HtmlToPdfProcessor htmlToPdfProcessor) {
         this.studentReports = studentReports;
         this.parameterProvider = parameterProvider;
         this.templateProcessor = templateProcessor;
         this.support = support;
+        this.htmlToPdfProcessor = htmlToPdfProcessor;
     }
 
     @Override
@@ -79,13 +88,14 @@ public class GeneratePdf implements Tasklet {
                 model,
                 report.getReportRequest().getLanguage());
 
-        //Temporary hack to store HTML output as a file
-        //This will be sent to the wkhtmltopdf service for PDF generation
-        //In a followup PR
-//        final File tempFile = new File("/tmp/output.html");
-//        try (final FileOutputStream output = new FileOutputStream(tempFile)) {
-//            output.write(html);
-//        }
+        try (final InputStream pdfStream = htmlToPdfProcessor.process(html, (PrintOptions) report.getReportRequest().getOptions())) {
+            //Temporary hack to store PDF output as a file
+            //This will be sent to S3 for storage in a followup PR
+            final File tempFile = new File("/tmp/output.pdf");
+            try (final FileOutputStream output = new FileOutputStream(tempFile)) {
+                IOUtils.copy(pdfStream, output);
+            }
+        }
 
         //TODO send to PDF generation service
         return RepeatStatus.FINISHED;

--- a/pdf-report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/GeneratePdfTest.java
+++ b/pdf-report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/GeneratePdfTest.java
@@ -10,7 +10,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.ReportViewSupport;
+import org.opentestsystem.rdw.reporting.common.report.processor.HtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.common.report.processor.TemplateProcessor;
 import org.opentestsystem.rdw.reporting.processor.model.StudentCompositeReport;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationJobParameterProvider;
@@ -52,6 +54,9 @@ public class GeneratePdfTest {
     @Mock
     private ChunkContext chunkContext;
 
+    @Mock
+    private HtmlToPdfProcessor htmlToPdfProcessor;
+
     @Captor
     private ArgumentCaptor<Map<String, Object>> modelCaptor;
 
@@ -79,10 +84,12 @@ public class GeneratePdfTest {
         when(parameterProvider.reportFromParameters(params)).thenReturn(report);
 
         reportRequest = mock(AbstractBatchExamReportRequest.class);
+        final PrintOptions printOptions = new PrintOptions(false);
+        when(reportRequest.getOptions()).thenReturn(printOptions);
         when(reportRequest.getLanguage()).thenReturn(Locale.US);
         when(report.getReportRequest()).thenReturn(reportRequest);
 
-        tasklet = new GeneratePdf(studentReports, parameterProvider, templateProcessor, support);
+        tasklet = new GeneratePdf(studentReports, parameterProvider, templateProcessor, support, htmlToPdfProcessor);
     }
 
     @Test
@@ -127,6 +134,25 @@ public class GeneratePdfTest {
         assertThat((Collection<StudentCompositeReport>) modelCaptor.getValue().get("studentCompositeReports"))
                 .containsExactly(reportA, reportC, reportB);
         assertThat(studentReports.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void itShouldSubmitGeneratedHTMLToPdfService() throws Exception {
+        final StudentCompositeReport reportA = compositeReport("LastA", "FirstA", "SSID1");
+        final StudentCompositeReport reportB = compositeReport("LastA", "FirstB", "SSID2");
+        final StudentCompositeReport reportC = compositeReport("LastB", "FirstA", "SSID3");
+
+        studentReports.put(reportC.getStudent().getId(), reportC);
+        studentReports.put(reportB.getStudent().getId(), reportB);
+        studentReports.put(reportA.getStudent().getId(), reportA);
+
+        tasklet.execute(stepContribution, chunkContext);
+
+        final ArgumentCaptor<byte[]> htmlCaptor = ArgumentCaptor.forClass(byte[].class);
+        final PrintOptions options = (PrintOptions) report.getReportRequest().getOptions();
+        verify(htmlToPdfProcessor).process(htmlCaptor.capture(), eq(options));
+
+        assertThat(new String(htmlCaptor.getValue())).isEqualTo("HTML Response");
     }
 
     private StudentCompositeReport compositeReport(final String lastName,

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/status/WkhtmltopdfStatusIndicator.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/status/WkhtmltopdfStatusIndicator.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.status;
 
+import org.apache.commons.io.IOUtils;
 import org.opentestsystem.rdw.common.status.AbstractStatusIndicator;
 import org.opentestsystem.rdw.common.status.DiagnosticLevel;
 import org.opentestsystem.rdw.common.status.Rating;
@@ -8,6 +9,7 @@ import org.opentestsystem.rdw.reporting.common.report.client.Request;
 import org.opentestsystem.rdw.reporting.common.report.client.WkhtmltopdfWebServiceClient;
 import org.springframework.stereotype.Component;
 
+import java.io.InputStream;
 import java.nio.charset.Charset;
 
 /**
@@ -37,8 +39,8 @@ public class WkhtmltopdfStatusIndicator extends AbstractStatusIndicator {
     protected void doStatusCheck(final Status.Builder builder, final int level) {
         final byte[] html = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Status Check</title></head><body></body></html>".getBytes(utf8);
         final byte[] pdf = responseTime(builder, 500, () -> {
-            try {
-                return client.toPdf(new Request(html));
+            try (final InputStream response = client.toPdf(new Request(html))) {
+                return IOUtils.toByteArray(response);
             } catch (final Exception e) {
                 builder.detail("message", e.getMessage());
                 return null;

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/status/WkhtmltopdfStatusIndicatorTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/status/WkhtmltopdfStatusIndicatorTest.java
@@ -7,9 +7,11 @@ import org.opentestsystem.rdw.common.status.Status;
 import org.opentestsystem.rdw.reporting.common.report.client.Request;
 import org.opentestsystem.rdw.reporting.common.report.client.WkhtmltopdfWebServiceClient;
 
-import java.nio.charset.Charset;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Map;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -39,18 +41,20 @@ public class WkhtmltopdfStatusIndicatorTest {
     }
 
     @Test
-    public void itShouldReturnIdealStatus() {
-        when(client.toPdf(any(Request.class))).thenReturn("OK".getBytes(Charset.forName("UTF-8")));
+    public void itShouldReturnIdealStatus() throws Exception {
+        try (final InputStream response = new ByteArrayInputStream("OK".getBytes(UTF_8))) {
+            when(client.toPdf(any(Request.class))).thenReturn(response);
 
-        final Status status = statusIndicator.status(5);
-        assertThat(status.getStatusRating()).isEqualTo(Rating.Ideal.value());
-        final Map<String, Object> details = status.getDetails();
-        assertThat(details).hasSize(1);
-        assertThat(details.containsKey("responseTime"));
+            final Status status = statusIndicator.status(5);
+            assertThat(status.getStatusRating()).isEqualTo(Rating.Ideal.value());
+            final Map<String, Object> details = status.getDetails();
+            assertThat(details).hasSize(1);
+            assertThat(details.containsKey("responseTime"));
+        }
     }
 
     @Test
-    public void itShouldReturnFailedStatus() {
+    public void itShouldReturnFailedStatus() throws Exception {
         when(client.toPdf(any(Request.class))).thenThrow(new RuntimeException("test fail"));
 
         final Status status = statusIndicator.status(5);


### PR DESCRIPTION
…nversion into PDF

This PR modifies the GeneratePDF tasklet to send the generated report HTML to the pdf generation microservice.  I've had to make some changes to the WkhtmltopdfWebServiceClient to return an unbuffered InputStream of the PDF contents.
