### PR TITLE
Respect JAVA_OPTS when running container images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ subprojects {
             label([maintainer: 'Fairway Technologies'])
             copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
             exposePort(8008, 8080)
-            entryPoint("java", "-jar", "${jar.archivePath.name}")
+            defaultCommand("sh", "-c", "java \$JAVA_OPTS -jar ${jar.archivePath.name}")
         }
 
         // task to build the docker image

--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,14 @@ subprojects {
             label([maintainer: 'Fairway Technologies'])
             copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
             exposePort(8008, 8080)
-            defaultCommand("sh", "-c", "java \$JAVA_OPTS -jar ${jar.archivePath.name}")
+            ext.java_opts = []
+            entryPoint {
+                List<String> entryPointArgs = ["java"]
+                entryPointArgs.addAll(ext.java_opts)
+                entryPointArgs.add("-jar")
+                entryPointArgs.add("${jar.archivePath.name}")
+                entryPointArgs.toArray()
+            }
         }
 
         // task to build the docker image

--- a/pdf-report-processor/build.gradle
+++ b/pdf-report-processor/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'org.springframework.boot'
 
+createDockerfile {
+    ext.java_opts = ["-Xmx300m"]
+}
+
 dependencies {
     compile project(':rdw-reporting-common')
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compile 'com.google.guava:guava'
-//    compile 'com.itextpdf:itextpdf'
     compile 'mysql:mysql-connector-java'
     compile 'org.apache.commons:commons-io'
     compile 'org.apache.pdfbox:pdfbox'


### PR DESCRIPTION
While testing deploying the report processing service to awsdev I found that our reporting containers aren't respecting the JAVA_OPTS environment variables which means we can't control java heap sizes.

This PR changes our container ENTRYPOINT into a CMD that passes the JAVA_OPTS environment variable to the java command.

We should probably look at our other projects to see if something similar is required.