### PR TITLE
adds client side default report naming

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequest.java
@@ -11,6 +11,7 @@ public abstract class AbstractExamReportRequest<T> {
     protected int schoolYear;
     protected Locale language;
     protected T options;
+    protected String name;
 
     public ExamReportAssessmentType getAssessmentType() {
         return assessmentType;
@@ -32,6 +33,10 @@ public abstract class AbstractExamReportRequest<T> {
         return options;
     }
 
+    public String getName() {
+        return name;
+    }
+
     @SuppressWarnings({"unchecked"})
     public static class Builder<T, A extends AbstractExamReportRequest<T>, B extends Builder<T, A, B>> {
 
@@ -40,6 +45,7 @@ public abstract class AbstractExamReportRequest<T> {
         private int schoolYear;
         private Locale language;
         private T options;
+        private String name;
 
         public B assessmentType(final ExamReportAssessmentType assessmentType) {
             this.assessmentType = assessmentType;
@@ -66,12 +72,18 @@ public abstract class AbstractExamReportRequest<T> {
             return (B) this;
         }
 
+        public B name(final String name) {
+            this.name = name;
+            return (B) this;
+        }
+
         protected A build(final A search) {
             search.assessmentType = assessmentType;
             search.subject = subject;
             search.schoolYear = schoolYear;
             search.language = language;
             search.options = options;
+            search.name = name;
             return search;
         }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
@@ -8,6 +8,7 @@ import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.report.client.ReportWebServiceClient;
+import org.opentestsystem.rdw.reporting.search.group.GroupRepository;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,7 @@ class DefaultExamReportService implements ExamReportService {
 
     private final ReportWebServiceClient client;
 
+
     DefaultExamReportService(final ReportWebServiceClient client) {
         this.client = client;
     }
@@ -28,13 +30,13 @@ class DefaultExamReportService implements ExamReportService {
     @Override
     public Report createReport(@NotNull final User user, @NotNull final SchoolGradeExamReportRequest request) {
         final PermissionScope permissionScope = user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope();
-        return createReport(user, request, permissionScope, "REPORT_NAME");
+        return createReport(user, request, permissionScope);
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final GroupExamReportRequest request) {
         final PermissionScope permissionScope = user.getPermissionsById().get("GROUP_PII_READ").getScope();
-        return createReport(user, request, permissionScope, "REPORT_NAME");
+        return createReport(user, request, permissionScope);
     }
 
     @Override
@@ -43,13 +45,18 @@ class DefaultExamReportService implements ExamReportService {
     }
 
     @Override
-    public void streamReport(@NotNull final User user, final long reportId, final HttpServletResponse response) {
+    public void streamReport(@NotNull final User user, final long reportId, @NotNull final HttpServletResponse response) {
         client.streamReport(user.getUsername(), reportId, response);
     }
 
     private <T extends AbstractBatchExamReportRequest<PrintOptions>> Report createReport(
-            final User user, @NotNull final T request, @NotNull final PermissionScope permissionScope, final String name) {
-        final BatchExamReportRequestHolder holder = new BatchExamReportRequestHolder(request, permissionScope, user.getUsername(), name);
+            @NotNull final User user,
+            @NotNull final T request,
+            @NotNull final PermissionScope permissionScope) {
+
+        final BatchExamReportRequestHolder holder = new BatchExamReportRequestHolder(
+                request, permissionScope, user.getUsername(), request.getName());
+
         return client.createReport(holder);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportService.java
@@ -50,6 +50,6 @@ public interface ExamReportService {
      * @param reportId the report ID
      * @param response the response to write the report to
      */
-    void streamReport(@NotNull User user, long reportId, final HttpServletResponse response);
+    void streamReport(@NotNull User user, long reportId, @NotNull final HttpServletResponse response);
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequest.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequest.java
@@ -4,7 +4,7 @@ package org.opentestsystem.rdw.reporting.report.student;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 
-class StudentExamReportRequest extends AbstractExamReportRequest<PrintOptions> {
+public class StudentExamReportRequest extends AbstractExamReportRequest<PrintOptions> {
 
     private long studentId;
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequestArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequestArgumentResolver.java
@@ -36,6 +36,7 @@ class StudentExamReportRequestArgumentResolver implements HandlerMethodArgumentR
                 .language(StringUtils.parseLocaleString(request.getParameter("language")))
                 .options(new PrintOptions(Boolean.valueOf(request.getParameter("grayscale"))))
                 .studentId(Long.valueOf(pathVariables.get("studentId")))
+                .name(request.getParameter("name"))
                 .build();
     }
 

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -2,7 +2,7 @@
   <span class="h3 blue-dark">{{'labels.groups.name' | translate}}</span>
   <span class="pull-right text-right">
     <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
-    <span group-report-download class="ml-xs" [groupId]="currentGroup.id" [schoolYears]="filterOptions.schoolYears"></span>
+    <span group-report-download class="ml-xs" [group]="currentGroup" [schoolYears]="filterOptions.schoolYears"></span>
   </span>
 </div>
 <div *ngIf="!currentGroup" class="alert alert-danger">

--- a/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
@@ -4,6 +4,8 @@ import { saveAs } from "file-saver";
 import { ReportDownloadComponent } from "./report-download.component";
 import { NotificationService } from "../shared/notification/notification.service";
 import { Report } from "./report.model";
+import { Group } from "../user/model/group.model";
+import { TranslateService } from "@ngx-translate/core";
 
 /**
  * Component used for single-student exam report download
@@ -15,9 +17,9 @@ import { Report } from "./report.model";
 export class GroupReportDownloadComponent extends ReportDownloadComponent {
 
   @Input()
-  public groupId: number;
+  public group: Group;
 
-  constructor(private service: ReportService, notificationService: NotificationService) {
+  constructor(private service: ReportService, notificationService: NotificationService, private translate: TranslateService) {
     super('labels.reports.button-label.group', notificationService);
     this.batch = true;
   }
@@ -26,7 +28,9 @@ export class GroupReportDownloadComponent extends ReportDownloadComponent {
 
     this.popover.hide();
 
-    this.service.createGroupExamReport(this.groupId, this.options)
+    this.options.name = this.getName();
+
+    this.service.createGroupExamReport(this.group.id, this.options)
       .subscribe(
         (report: Report) => {
           this.notificationService.info({ id: 'labels.reports.messages.submitted.html', html: true });
@@ -35,6 +39,15 @@ export class GroupReportDownloadComponent extends ReportDownloadComponent {
           this.notificationService.error({ id: 'labels.reports.messages.submission-failed.html', html: true });
         }
       );
+  }
+
+  private getName(): string {
+    return [
+      this.group.name,
+      this.options.schoolYear.toString(),
+      this.options.language === this.languages[ 0 ]
+        ? '' : this.translate.instant(`labels.languages.${this.options.language}.default`)
+    ].join(' ').trim();
   }
 
 }

--- a/webapp/src/main/webapp/src/app/report/report-options.model.ts
+++ b/webapp/src/main/webapp/src/app/report/report-options.model.ts
@@ -13,5 +13,6 @@ export class ReportOptions {
   public language: string;
   public grayscale: boolean;
   public order: ReportOrder;
+  public name: string;
 
 }

--- a/webapp/src/main/webapp/src/app/report/report.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report.service.ts
@@ -121,7 +121,8 @@ export class ReportService {
       subject: AssessmentSubjectType[ options.subject ],
       schoolYear: options.schoolYear,
       language: options.language,
-      grayscale: options.grayscale
+      grayscale: options.grayscale,
+      name: options.name
     };
   }
 
@@ -135,7 +136,8 @@ export class ReportService {
     return {
       schoolYear: options.schoolYear,
       language: options.language,
-      order: ReportOrder[ options.order ]
+      order: ReportOrder[ options.order ],
+      name: options.name
     };
   }
 

--- a/webapp/src/main/webapp/src/app/report/reports.component.ts
+++ b/webapp/src/main/webapp/src/app/report/reports.component.ts
@@ -32,7 +32,6 @@ export class ReportsComponent implements OnInit {
           saveAs(download.content, download.name);
         },
         (error: any) => {
-          console.log("errorYO", error);
           this.notificationService.error({id: 'labels.reports.messages.download-failed'});
         }
       );

--- a/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
@@ -4,6 +4,9 @@ import { saveAs } from "file-saver";
 import { ReportDownloadComponent } from "./report-download.component";
 import { NotificationService } from "../shared/notification/notification.service";
 import { Report } from "./report.model";
+import { School } from "../user/model/school.model";
+import { Grade } from "../school-grade/grade.model";
+import { TranslateService } from "@ngx-translate/core";
 
 /**
  * Component used for single-student exam report download
@@ -15,12 +18,12 @@ import { Report } from "./report.model";
 export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
 
   @Input()
-  public schoolId: number;
+  public school: School;
 
   @Input()
-  public gradeId: number;
+  public grade: Grade;
 
-  constructor(private service: ReportService, notificationService: NotificationService) {
+  constructor(private service: ReportService, notificationService: NotificationService, private translate: TranslateService) {
     super('labels.reports.button-label.school-grade', notificationService);
     this.batch = true;
   }
@@ -29,7 +32,9 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
 
     this.popover.hide();
 
-    this.service.createSchoolGradeExamReport(this.schoolId, this.gradeId, this.options)
+    this.options.name = this.getName();
+
+    this.service.createSchoolGradeExamReport(this.school.id, this.grade.id, this.options)
       .subscribe(
         (report: Report) => {
           this.notificationService.info({ id: 'labels.reports.messages.submitted.html', html: true });
@@ -38,6 +43,16 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
           this.notificationService.error({ id: 'labels.reports.messages.submission-failed.html', html: true });
         }
       );
+  }
+
+  private getName(): string {
+    return [
+      this.school.name,
+      this.translate.instant(`labels.grades.${this.grade.code}.short-name`),
+      this.options.schoolYear.toString(),
+      this.options.language === this.languages[ 0 ]
+        ? '' : this.translate.instant(`labels.languages.${this.options.language}.default`)
+    ].join(' ').trim();
   }
 
 }

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -4,8 +4,8 @@
     <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
     <span school-grade-report-download class="ml-xs"
         *ngIf="currentGrade"
-        [schoolId]="currentSchool.id"
-        [gradeId]="currentGrade.id"
+        [school]="currentSchool"
+        [grade]="currentGrade"
         [schoolYears]="filterOptions.schoolYears">
     </span>
   </span>

--- a/webapp/src/main/webapp/src/app/shared/data/data.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/data/data.service.ts
@@ -52,11 +52,22 @@ export class DataService {
   private getMapper(options?: RequestOptionsArgs): (response: Response) => any {
     if (options != null && options.responseType == ResponseContentType.Blob) {
       return (response: Response) => new Download(
-        this.getFileNameFromResponse(response),
+        this.safelyFormatFileName(this.getFileNameFromResponse(response)),
         new Blob([ response.blob() ], { type: this.getContentType(response) })
       );
     }
     return response => response.json();
+  }
+
+  /**
+   * Replaces whitespace in the given name with underscores.
+   * This implementation is null-safe and will return null if provided null.
+   *
+   * @param name the name to format
+   * @returns {string} thre formatted name
+   */
+  private safelyFormatFileName(name: string) {
+    return name == null ? null : name.replace(/\s+/g, '_');
   }
 
   /**

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -39,9 +39,18 @@
       }
     },
     "languages": {
-      "eng": "English",
-      "spa": "Español",
-      "vie": "Tiếng Việt"
+      "eng": {
+        "native": "English",
+        "default" : "English"
+      },
+      "spa": {
+        "native": "Español",
+        "default": "Spanish"
+      },
+      "vie": {
+        "native": "Tiếng Việt",
+        "default": "Vietnamese"
+      }
     },
     "assessmentTypes": {
       "1": {


### PR DESCRIPTION
Basically the change here is to create batch report names client side in this format:
```
{groupName} {schoolYear}[ {language}]
{schoolName} {gradeName} {schoolYear}[ {language}]
```
When downloaded the spaces will be replaced with underscores.

Though inputing custom report names is not implemented yet, this strategy lends itself well to later presenting a default suggested report name that can be changed by the user before requesting the report.

<strong>Notice: there is currently no server-side sanitization of this text input. The angular client displaying the text is safe due to angular XSS sanitization built-ins but any other client of this text could be vulnerable to XSS if it doesn't take the proper precautions when displaying the data.</strong>