### PR TITLE
Adds spring-session + redis

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/GroupGrant.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/GroupGrant.java
@@ -1,11 +1,12 @@
 package org.opentestsystem.rdw.reporting.common.security;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * This class represents an access grant to a specific group in the system and is used for access control
  */
-public class GroupGrant {
+public class GroupGrant implements Serializable {
 
     private long id;
     private int subjectId;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/GroupGrant.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/GroupGrant.java
@@ -1,12 +1,11 @@
 package org.opentestsystem.rdw.reporting.common.security;
 
-import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * This class represents an access grant to a specific group in the system and is used for access control
  */
-public class GroupGrant implements Serializable {
+public class GroupGrant {
 
     private long id;
     private int subjectId;
@@ -14,7 +13,8 @@ public class GroupGrant implements Serializable {
     /**
      * No-arg contructor for JSON serialization and deserialization
      */
-    private GroupGrant(){}
+    private GroupGrant() {
+    }
 
     public GroupGrant(final long id, final int subjectId) {
         this.id = id;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
@@ -4,12 +4,14 @@ import com.google.common.base.MoreObjects;
 
 import javax.validation.constraints.NotNull;
 
+import java.io.Serializable;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Scoped permission used to limit database results
  */
-public class Permission {
+public class Permission implements Serializable {
 
     /**
      * The permission ID

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
@@ -11,7 +11,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Scoped permission used to limit database results
  */
-public class Permission implements Serializable {
+public class Permission {
 
     /**
      * The permission ID

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
@@ -4,8 +4,6 @@ import com.google.common.base.MoreObjects;
 
 import javax.validation.constraints.NotNull;
 
-import java.io.Serializable;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/PermissionScope.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/PermissionScope.java
@@ -2,14 +2,14 @@ package org.opentestsystem.rdw.reporting.common.security;
 
 import com.google.common.collect.ImmutableSet;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Set;
 
 /**
  * Used to limit database query results
  */
-public class PermissionScope implements Serializable {
+public class PermissionScope {
+
     /**
      * Statewide permission scope flyweight
      * Since all statewide permission scopes will be identical, we can use the same immutable object instance
@@ -40,7 +40,7 @@ public class PermissionScope implements Serializable {
         this.isStatewide = true;
     }
 
-    private PermissionScope(final boolean isStatewide){
+    private PermissionScope(final boolean isStatewide) {
         this.isStatewide = isStatewide;
     }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/PermissionScope.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/PermissionScope.java
@@ -2,13 +2,14 @@ package org.opentestsystem.rdw.reporting.common.security;
 
 import com.google.common.collect.ImmutableSet;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Set;
 
 /**
  * Used to limit database query results
  */
-public class PermissionScope {
+public class PermissionScope implements Serializable {
     /**
      * Statewide permission scope flyweight
      * Since all statewide permission scopes will be identical, we can use the same immutable object instance

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     links:
       - config-server
       - rabbitmq
+      - redis
       - wkhtmltopdf
     environment:
       - spring.profiles.active=local-docker
@@ -80,3 +81,6 @@ services:
     image: fwsbac/wkhtmltopdf-image:latest
     ports:
       - 8082:80
+
+  redis:
+    image: redis:4

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     links:
       - config-server
       - rabbitmq
-      - redis
       - wkhtmltopdf
     environment:
       - spring.profiles.active=local-docker
@@ -81,6 +80,3 @@ services:
     image: fwsbac/wkhtmltopdf-image:latest
     ports:
       - 8082:80
-
-  redis:
-    image: redis:4

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.boot:spring-boot-starter-security'
     compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.boot:spring-boot-starter-data-redis'
+    compile 'org.springframework.session:spring-session'
     compile 'org.springframework.cloud:spring-cloud-starter-config'
     compile 'org.springframework.retry:spring-retry'
     compile 'org.springframework.security.extensions:spring-security-saml2-core'

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/session/SecuredRedisConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/session/SecuredRedisConfiguration.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.reporting.security.session;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+/**
+ * This class allows spring-redis to work in a secured redis environment
+ */
+@Configuration
+@ConditionalOnProperty(name = "spring.session.store-type", havingValue = "redis")
+public class SecuredRedisConfiguration {
+
+    /**
+     * This bean informs spring-redis to not configure session expiration and deletion keyspace events.
+     * In a secured environment, these events must be configured manually by a redis admin.
+     *
+     * Without this instruction, spring-redis will try to configure redis to dispatch these events and cause a startup
+     * exception.
+     *
+     * @return ConfigureRedisAction.NO_OP
+     */
+    @Bean
+    public static ConfigureRedisAction configureRedisAction() {
+        return ConfigureRedisAction.NO_OP;
+    }
+
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/session/SecuredRedisConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/session/SecuredRedisConfiguration.java
@@ -1,9 +1,20 @@
 package org.opentestsystem.rdw.reporting.security.session;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+import java.io.IOException;
 
 /**
  * This class allows spring-redis to work in a secured redis environment
@@ -24,6 +35,63 @@ public class SecuredRedisConfiguration {
     @Bean
     public static ConfigureRedisAction configureRedisAction() {
         return ConfigureRedisAction.NO_OP;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> redisTemplate(
+            final RedisConnectionFactory connectionFactory,
+            final ObjectMapper objectMapper) {
+
+        final RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new RedisJsonSerializer(objectMapper));
+        return template;
+    }
+
+    /**
+     * TODO: move to org.opentestsystem.rdw.common
+     *
+     * This Redis serializer uses an ObjectMapper to serialize objects.
+     */
+    public class RedisJsonSerializer implements RedisSerializer<Object> {
+
+        private final ObjectMapper objectMapper;
+
+        /**
+         * Constructor
+         * This class clones and modifies the given ObjectMapper and configures it to embed
+         * class type information in the serialized values so that they can be deserialized
+         * without knowing the target class type ahead of time
+         *
+         * @param objectMapper The application ObjectMapper
+         */
+        public RedisJsonSerializer(final ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper.copy()
+                    .enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        }
+
+        @Override
+        public byte[] serialize(final Object value) throws SerializationException {
+            try {
+                return objectMapper.writeValueAsBytes(value);
+            } catch (final JsonProcessingException exception) {
+                throw new SerializationException("Redis is unable to serialize object", exception);
+            }
+        }
+
+        @Override
+        public Object deserialize(final byte[] bytes) throws SerializationException {
+            if (bytes == null) {
+                return null;
+            }
+            try {
+                return objectMapper.readValue(bytes, Object.class);
+            } catch (final IOException exception) {
+                throw new SerializationException("Redis is unable to deserialize object", exception);
+            }
+        }
     }
 
 }

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -23,6 +23,9 @@ saml:
 
 
 spring:
+  session:
+    store-type: none
+
   jackson:
     default-property-inclusion: non_null
     serialization:


### PR DESCRIPTION
This RP will come paired with config-repo settings:
```yaml
spring:
  session:
    store-type: redis
  redis:
    host: redis
    port: 6379
```

### This will break k8s images until they include redis/ellasticache.

For some context on spring-session/ellasticache integration/AWS setup see:

1. http://docs.spring.io/spring-session/docs/current/reference/html5/#api-redisoperationssessionrepository-sessiondestroyedevent
2. https://github.com/spring-projects/spring-session/issues/124
