### PR TITLE
Feature/disable report download when report will be empty

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/schoolyear/StubSchoolYearService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/schoolyear/StubSchoolYearService.java
@@ -9,12 +9,11 @@ import java.util.Set;
 public class StubSchoolYearService implements SchoolYearService {
 
     /**
-     * @return set containing (2017, 2016, 2015, 2014, 2013)
+     * @return set containing (2017, 2016)
      */
     @Override
     public Set<Integer> getSchoolYears() {
         return ImmutableSet.of(2017, 2016);
-        //return ImmutableSet.of(2017, 2016, 2015, 2014, 2013);
     }
 
 }

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -1,7 +1,9 @@
 <div class="mb-md" *ngIf="currentGroup">
   <span class="h3 blue-dark">{{'labels.groups.name' | translate}}</span>
   <span class="pull-right text-right">
-    <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
+    <button class="btn btn-default btn-sm"
+            (click)="exportCsv()"
+            [disabled]="assessmentExams.length == 0"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
     <span group-report-download #downloader class="ml-xs"
           [group]="currentGroup"
           [schoolYears]="filterOptions.schoolYears"

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -5,6 +5,7 @@
     <span group-report-download #downloader class="ml-xs"
           [group]="currentGroup"
           [schoolYears]="filterOptions.schoolYears"
+          [disabled]="assessmentExams.length == 0"
           (onShown)="initializeDownloader(downloader)"></span>
   </span>
 </div>

--- a/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
@@ -33,10 +33,14 @@ export class GroupReportDownloadComponent extends ReportDownloadComponent {
     this.service.createGroupExamReport(this.group.id, this.options)
       .subscribe(
         (report: Report) => {
-          this.notificationService.info({ id: 'labels.reports.messages.submitted.html', html: true });
+          this.notificationService.info({ id: 'labels.reports.messages.create.success-html', html: true });
         },
         (error: any) => {
-          this.notificationService.error({ id: 'labels.reports.messages.submission-failed.html', html: true });
+          this.notificationService.error({
+            id: error.name === 'NotFoundError'
+              ? 'labels.reports.messages.create.group-no-content'
+              : 'labels.reports.messages.create.error'
+          });
         }
       );
   }

--- a/webapp/src/main/webapp/src/app/report/report-download.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.html
@@ -1,6 +1,7 @@
 <span *ngIf="options" class="report-download-container">
 
   <button class="btn btn-sm btn-default"
+          [disabled]="disabled"
           (onShown)="onShownInternal($event)"
           #downloadPopover="bs-popover"
           containerClass="report-download-popover"

--- a/webapp/src/main/webapp/src/app/report/report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.ts
@@ -21,6 +21,9 @@ export abstract class ReportDownloadComponent implements OnInit {
   @Input()
   public batch: boolean = false;
 
+  @Input()
+  public disabled: boolean = false;
+
   @Output()
   public onShown: EventEmitter<any> = new EventEmitter<any>();
 

--- a/webapp/src/main/webapp/src/app/report/reports.component.html
+++ b/webapp/src/main/webapp/src/app/report/reports.component.html
@@ -2,7 +2,7 @@
 
 <div class="well" *ngIf="resolution.isOk()">
 
-  <p *ngIf="!reports.length" [innerHtml]="'labels.reports.no-reports-html' | translate"></p>
+  <p *ngIf="!reports.length" [innerHtml]="'labels.reports.messages.get-all.no-results-html' | translate"></p>
 
   <p-dataTable *ngIf="reports.length"
       [value]="reports"
@@ -33,7 +33,7 @@
   <div class="row">
     <div class="col-md-8 col-md-offset-2">
       <div class="alert alert-danger">
-        <p>{{'labels.reports.messages.get-reports-error' | translate}}</p>
+        <p>{{'labels.reports.messages.get-all.error' | translate}}</p>
       </div>
     </div>
   </div>

--- a/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
@@ -37,10 +37,14 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
     this.service.createSchoolGradeExamReport(this.school.id, this.grade.id, this.options)
       .subscribe(
         (report: Report) => {
-          this.notificationService.info({ id: 'labels.reports.messages.submitted.html', html: true });
+          this.notificationService.info({ id: 'labels.reports.messages.create.success-html', html: true });
         },
         (error: any) => {
-          this.notificationService.error({ id: 'labels.reports.messages.submission-failed.html', html: true });
+          this.notificationService.error({
+            id: error.name === 'NotFoundError'
+              ? 'labels.reports.messages.create.school-grade-no-content'
+              : 'labels.reports.messages.create.error'
+          });
         }
       );
   }

--- a/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
@@ -25,8 +25,6 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
 
     this.popover.hide();
 
-    this.notificationService.info({ id: 'labels.reports.messages.submitted-single' });
-
     this.service.getStudentExamReport(this.studentId, this.options)
       .subscribe(
         (download: Download) => {
@@ -35,8 +33,8 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
         (error: any) => {
           this.notificationService.error({
             id: error.name === 'NotFoundError'
-              ? 'labels.reports.messages.404'
-              : 'labels.reports.messages.500'
+              ? 'labels.reports.messages.create.student-no-content'
+              : 'labels.reports.messages.get.error'
           });
         }
       )

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -1,7 +1,9 @@
 <div *ngIf="currentSchool" class="mb-md">
   <span class="h3 blue-dark">{{currentSchool.name}}<span *ngIf="currentGrade"> - {{currentGrade.code | gradeDisplay:'long-name'}}</span></span>
   <span class="pull-right text-right">
-    <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
+    <button class="btn btn-default btn-sm"
+            (click)="exportCsv()"
+            [disabled]="assessmentExams.length == 0"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
     <span school-grade-report-download #downloader class="ml-xs"
         *ngIf="currentGrade"
         [school]="currentSchool"

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -7,6 +7,7 @@
         [school]="currentSchool"
         [grade]="currentGrade"
         [schoolYears]="filterOptions.schoolYears"
+        [disabled]="assessmentExams.length == 0"
         (onShown)="initializeDownloader(downloader)"></span>
   </span>
 </div>

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.html
@@ -8,6 +8,7 @@
     <span student-report-download #downloader class="ml-xs"
           [studentId]="examHistory.student.id"
           [schoolYears]="filterState.years"
+          [disabled]="examHistory.exams.length == 0"
           (onShown)="initializeDownloader(downloader)"></span>
   </span>
 </div>

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.html
@@ -4,7 +4,9 @@
     <span>{{examHistory.student.ssid}}</span>
   </span>
   <span class="pull-right text-right">
-    <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
+    <button class="btn btn-default btn-sm"
+            (click)="exportCsv()"
+            [disabled]="examHistory.exams.length == 0"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
     <span student-report-download #downloader class="ml-xs"
           [studentId]="examHistory.student.id"
           [schoolYears]="filterState.years"

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -386,7 +386,6 @@
     "reports": {
       "link": "My Reports",
       "heading": "My Reports",
-      "no-reports-html": "<p>To create a report, first select a group or school from the <a href=\"/\">Home page</a>. Next click the \"Student Reports\" button to get started.",
       "reload": "Reload",
       "column": {
         "created": {
@@ -418,17 +417,20 @@
         "1": "Student SSID"
       },
       "messages" : {
-        "get-reports-error": "There was an unexpected error while getting your reports. Please click the button below to reload the page and try again.",
-        "404": "This student does not have any test results for your selection. Please update your selection and try again.",
-        "500": "There was an unexpected error while generating this report.  Please try again.",
-        "submitted-single": "Creating report. Your download will begin in a moment.",
-        "submitted": {
-          "html": "Creating report. See <a href=\"/reports\">status</a>."
+        "get": {
+          "error": "There was an unexpected error while getting this report. Please try again."
         },
-        "submission-failed": {
-          "html": "Error creating report. See <a href=\"/reports\">status</a>."
+        "get-all": {
+          "error": "There was an unexpected error while getting your reports. Please click the button below to reload the page and try again.",
+          "no-results-html": "<p>To create a report, first select a group or school from the <a href=\"/\">Home page</a>. Next click the \"Student Reports\" button to get started."
         },
-        "download-failed": "There was an unexpected error while getting this report. Please try again.",
+        "create": {
+          "success-html": "Creating report. See <a href=\"/reports\">status</a>.",
+          "error": "There was an unexpected error while generating this report.  Please try again..",
+          "student-no-content": "This student does not have any test results for your selection. Please update your selection and try again.",
+          "school-grade-no-content": "This school and assessment grade does not have any test results for your selection. Please update your selection and try again.",
+          "group-no-content": "This group does not have any test results for your selection. Please update your selection and try again."
+        },
         "coming-soon": {
           "report-regeneration": "Report regeneration is coming soon."
         }


### PR DESCRIPTION
This PR makes the group, school grade and student assessment results page "Student Report" button appear disabled when the current year selection has no results.

<img width="1153" alt="screen shot 2017-08-15 at 11 02 21 am" src="https://user-images.githubusercontent.com/23462925/29329028-59f766a2-81a9-11e7-97ac-cb89615be0eb.png">


