### PR TITLE
adds failfast for empty batch reports - like how student reports works

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
@@ -17,26 +17,37 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 class DefaultExamReportService implements ExamReportService {
 
     private final ReportWebServiceClient client;
+    private final ExamReportExamRepository repository;
 
 
-    DefaultExamReportService(final ReportWebServiceClient client) {
+    DefaultExamReportService(final ReportWebServiceClient client, final ExamReportExamRepository repository) {
         this.client = client;
+        this.repository = repository;
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final SchoolGradeExamReportRequest request) {
         final PermissionScope permissionScope = user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope();
+        if (!repository.existsForSchoolAndAssessmentGradeAndSchoolYear(
+                permissionScope, request.getSchoolId(), request.getGradeId(), request.getSchoolYear())) {
+            throw new NoSuchElementException("There are no exams matching the given search criteria");
+        }
         return createReport(user, request, permissionScope);
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final GroupExamReportRequest request) {
         final PermissionScope permissionScope = user.getPermissionsById().get("GROUP_PII_READ").getScope();
+        if (!repository.existsForGroupAndSchoolYear(
+                permissionScope, request.getGroupGrant().getId(), request.getGroupGrant().getSubjectId(), request.getSchoolYear())) {
+            throw new NoSuchElementException("There are no exams matching the given search criteria");
+        }
         return createReport(user, request, permissionScope);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportExamRepository.java
@@ -1,0 +1,21 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+
+import javax.validation.constraints.NotNull;
+
+interface ExamReportExamRepository {
+
+    boolean existsForSchoolAndAssessmentGradeAndSchoolYear(
+            @NotNull PermissionScope permissionScope,
+            long schoolId,
+            int gradeId,
+            int schoolYear);
+
+    boolean existsForGroupAndSchoolYear(
+            @NotNull PermissionScope permissionScope,
+            long groupId,
+            int subjectId,
+            int schoolYear);
+
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportExamRepository.java
@@ -4,14 +4,35 @@ import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 
 import javax.validation.constraints.NotNull;
 
+/**
+ * Repository responsible for searching exams in relation to exam reports
+ */
 interface ExamReportExamRepository {
 
+    /**
+     * Checks if there are any exams to create a school grade assessment report with
+     *
+     * @param permissionScope the accessing user's permissions
+     * @param schoolId        the school for the report
+     * @param gradeId         the assessment grade for the report
+     * @param schoolYear      the school year for the report
+     * @return <code>true</code> if there are exams matching the given search criteria
+     */
     boolean existsForSchoolAndAssessmentGradeAndSchoolYear(
             @NotNull PermissionScope permissionScope,
             long schoolId,
             int gradeId,
             int schoolYear);
 
+    /**
+     * Checks if there are any exams to create a group assessment report with
+     *
+     * @param permissionScope the accessing user's permissions
+     * @param groupId         the group for the report
+     * @param subjectId       the subject of the group
+     * @param schoolYear      the school year for the report
+     * @return <code>true</code> if there are exams matching the given search criteria
+     */
     boolean existsForGroupAndSchoolYear(
             @NotNull PermissionScope permissionScope,
             long groupId,

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/JdbcExamReportExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/JdbcExamReportExamRepository.java
@@ -1,0 +1,73 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
+
+@Repository
+class JdbcExamReportExamRepository implements ExamReportExamRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.exam.existsForSchoolAndAssessmentGradeAndSchoolYear}")
+    private String existsForSchoolAndAssessmentGradeAndSchoolYear;
+
+    @Value("${sql.exam.existsForGroupAndSchoolYear}")
+    private String existsForGroupAndSchoolYear;
+
+    @Autowired
+    JdbcExamReportExamRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public boolean existsForSchoolAndAssessmentGradeAndSchoolYear(
+            final PermissionScope permissionScope,
+            final long schoolId,
+            final int gradeId,
+            final int schoolYear) {
+
+        try {
+            return template.queryForObject(
+                    existsForSchoolAndAssessmentGradeAndSchoolYear,
+                    new MapSqlParameterSource()
+                            .addValues(getSecurityParameters(permissionScope))
+                            .addValue("school_year", schoolYear)
+                            .addValue("school_id", schoolId)
+                            .addValue("grade_id", gradeId),
+                    Boolean.class
+            );
+        } catch (final EmptyResultDataAccessException exception) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean existsForGroupAndSchoolYear(
+            final PermissionScope permissionScope,
+            final long groupId,
+            final int subjectId,
+            final int schoolYear) {
+
+        try {
+            return template.queryForObject(
+                    existsForGroupAndSchoolYear,
+                    new MapSqlParameterSource()
+                            .addValues(getSecurityParameters(permissionScope))
+                            .addValue("school_year", schoolYear)
+                            .addValue("group_id", groupId)
+                            .addValue("group_subject_id", subjectId),
+                    Boolean.class
+            );
+        } catch (final EmptyResultDataAccessException exception) {
+            return false;
+        }
+    }
+
+}

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -1,5 +1,28 @@
 sql:
   exam:
+    existsForSchoolAndAssessmentGradeAndSchoolYear: >-
+      select 1
+      from exam e
+        join asmt a on e.asmt_id=a.id
+        join school s on e.school_id=s.id
+      where e.school_year=:school_year
+        and e.school_id=:school_id
+        and a.grade_id=:grade_id
+        and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+      limit 1
+
+    existsForGroupAndSchoolYear: >-
+      select 1
+      from exam e
+        join asmt a on e.asmt_id=a.id
+        join school s on e.school_id=s.id
+        join student_group_membership sgm on e.student_id = sgm.student_id
+      where e.school_year=:school_year
+        and sgm.student_group_id=:group_id
+        and (0=:group_subject_id or a.subject_id=:group_subject_id)
+        and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
+      limit 1
+
     findAllByStudentId: >-
       select e.id,
         e.type_id,

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportServiceTest.java
@@ -1,0 +1,140 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.reporting.common.model.Report;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
+import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.report.client.ReportWebServiceClient;
+import org.opentestsystem.rdw.reporting.security.User;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.groupOf;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.individualOf;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.permissions;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+
+public class DefaultExamReportServiceTest {
+
+    private PermissionScope permissivePermissionScope = statewide();
+    private ReportWebServiceClient client;
+    private ExamReportExamRepository repository;
+    private DefaultExamReportService service;
+    private Report report = Report.builder()
+            .id(1L)
+            .status(ReportStatus.RUNNING)
+            .created(Instant.now())
+            .label("label")
+            .build();
+
+
+    @Before
+    public void before() {
+        client = mock(ReportWebServiceClient.class);
+        repository = mock(ExamReportExamRepository.class);
+        service = new DefaultExamReportService(client, repository);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void createSchoolGradeReportShouldThrowExceptionWhenThereRepositoryReturnsEmpty() throws Exception {
+
+        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder()
+                .schoolId(10)
+                .gradeId(1)
+                .schoolYear(2017)
+                .build();
+
+        when(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(
+                permissivePermissionScope, request.getSchoolId(), request.getGradeId(), request.getSchoolYear()))
+                .thenReturn(false);
+
+        service.createReport(individualPiiUser(), request);
+    }
+
+    @Test
+    public void createSchoolGradeReportShouldCallWebServiceClient() throws Exception {
+
+        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder()
+                .schoolId(10)
+                .gradeId(1)
+                .schoolYear(2017)
+                .build();
+
+        when(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(
+                permissivePermissionScope, request.getSchoolId(), request.getGradeId(), request.getSchoolYear()))
+                .thenReturn(true);
+
+        when(client.createReport(any(BatchExamReportRequestHolder.class))).thenReturn(report);
+
+        assertThat(service.createReport(individualPiiUser(), request)).isEqualToComparingFieldByField(report);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void createGroupReportShouldThrowExceptionWhenThereRepositoryReturnsEmpty() throws Exception {
+
+        final GroupExamReportRequest request = GroupExamReportRequest.builder()
+                .groupGrant(new GroupGrant(1, 1))
+                .schoolYear(2017)
+                .build();
+
+        when(repository.existsForGroupAndSchoolYear(
+                permissivePermissionScope, request.getGroupGrant().getId(), request.getGroupGrant().getSubjectId(), request.getSchoolYear()))
+                .thenReturn(false);
+
+        service.createReport(groupPiiUser(), request);
+    }
+
+    @Test
+    public void createGroupReportShouldCallWebServiceClient() throws Exception {
+
+        final GroupExamReportRequest request = GroupExamReportRequest.builder()
+                .groupGrant(new GroupGrant(1, 1))
+                .schoolYear(2017)
+                .build();
+
+        when(repository.existsForGroupAndSchoolYear(
+                permissivePermissionScope, request.getGroupGrant().getId(), request.getGroupGrant().getSubjectId(), request.getSchoolYear()))
+                .thenReturn(true);
+
+        when(client.createReport(any(BatchExamReportRequestHolder.class))).thenReturn(report);
+
+        assertThat(service.createReport(groupPiiUser(), request)).isEqualToComparingFieldByField(report);
+    }
+
+    @Test
+    public void getReportsPassesCorrectParams() throws Exception {
+        final User user = individualPiiUser();
+        final List<Report> reports = newArrayList(report);
+        when(client.getReports(user.getUsername())).thenReturn(reports);
+        assertThat(service.getReports(user)).isEqualTo(reports);
+    }
+
+    private User individualPiiUser() {
+        return User.builder()
+                .id("user")
+                .username("username")
+                .permissionsById(permissions(individualOf(permissivePermissionScope)))
+                .build();
+    }
+
+    private User groupPiiUser() {
+        return User.builder()
+                .id("user")
+                .username("username")
+                .permissionsById(permissions(groupOf(permissivePermissionScope)))
+                .build();
+    }
+
+}

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/JdbcExamReportExamRepositoryTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/JdbcExamReportExamRepositoryTest.java
@@ -1,0 +1,124 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
+import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districts;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.empty;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {ITDataSourceConfiguration.class, JdbcExamReportExamRepository.class})
+@Sql(scripts = {"classpath:integration-test-data.sql"})
+@ActiveProfiles("test")
+public class JdbcExamReportExamRepositoryTest {
+
+
+    @Autowired
+    private JdbcExamReportExamRepository repository;
+
+    // existsForSchool tests
+
+    @Test
+    public void existsForSchoolShouldBeTrueForValidInput() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(statewide(), -10, -1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForGoodSchoolPermissionScope() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(schools(-10L), -10, -1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForGoodDistrictPermissionScope() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(districts(-10L), -10, -1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForEmptyPermissionScope() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(empty(), -10, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForBadSchoolPermissionScope() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(schools(0L), -10, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForBadDistrictPermissionScope() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(districts(0L), -10, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForBadSchool() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(statewide(), 0, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForBadGrade() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(statewide(), -10L, 0, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForSchoolShouldBeFalseForBadYear() throws Exception {
+        assertThat(repository.existsForSchoolAndAssessmentGradeAndSchoolYear(statewide(), -10L, -1, 0)).isFalse();
+    }
+
+    // existsForGroup tests
+
+    @Test
+    public void existsForGroupShouldBeTrueForValidInput() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(statewide(), -10, 1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForGoodSchoolPermissionScope() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(schools(-10L), -10, 1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForGoodDistrictPermissionScope() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(districts(-10L), -10, 1, 2017)).isTrue();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForEmptyPermissionScope() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(empty(), -10, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForBadSchoolPermissionScope() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(schools(0L), -10, 1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForBadDistrictPermissionScope() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(districts(0L), -10, 1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForBadGroup() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(statewide(), 0, 1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForBadSubject() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(statewide(), -10L, -1, 2017)).isFalse();
+    }
+
+    @Test
+    public void existsForGroupShouldBeFalseForBadYear() throws Exception {
+        assertThat(repository.existsForGroupAndSchoolYear(statewide(), -10L, 1, 0)).isFalse();
+    }
+
+}


### PR DESCRIPTION
Adds fail fast to batch report generation so that "POST /reports" requests return 404s when the report will have no contents