### PR TITLE
sort by item difficulty "level" instead of alphabetical

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
@@ -19,6 +19,19 @@ export class AssessmentItem {
     return this.commonCoreStandardIds && this.commonCoreStandardIds.length > 0
   }
 
+  get difficultySortOrder() {
+    switch (this.difficulty) {
+      case 'E':
+        return 1;
+      case 'M':
+        return 2;
+      case 'D':
+        return 3;
+    }
+
+    return 0;
+  }
+
   get claimTarget() {
     return this.claim + ' / ' + this.target;
   }

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -202,7 +202,7 @@
               {{ 'definition.claim.' + item.claim + '.name' | translate }} / {{ 'labels.groups.results.assessment.items.target' | translate:item }}
             </ng-template>
           </p-column>
-          <p-column field="difficulty" [sortable]="true">
+          <p-column field="difficulty" [sortable]="true" sortField="difficultySortOrder">
             <ng-template pTemplate="header">
               <span info-label title="{{'labels.groups.results.assessment.items.cols.difficulty' | translate}}"
                           content="{{'labels.groups.results.assessment.items.cols.difficulty-info' | translate}}"></span>


### PR DESCRIPTION
I tried using the `(sortFunction)` as shown here: https://stackoverflow.com/questions/41181277/primeng-datatable-custom-sorting-or-filtering-angular-2  but for some reason I could not get it to work as expected.  The first row in the table was always incorrect and would show "Moderate" instead of "Easy" or "Difficult" depending on the sort order.

So I punted a bit and went with an easy solution of a "helper" type property that can be used.

Here is the code I was using as a reference if anyone wants to give it a shot:

```
  itemDifficultySort($event) {
    enum DifficultySortOrder {
      "E" = 1,
      "M" = 2,
      "D" = 3
    }
    
    this.filteredAssessmentItems = [...this.filteredAssessmentItems.sort((a, b) => {

      if (DifficultySortOrder[a.difficulty] < DifficultySortOrder[b.difficulty]) {
        return -1 * $event.order;
      } else if (DifficultySortOrder[a.difficulty] < DifficultySortOrder[b.difficulty]) {
        return $event.order;
      }

      return 0;
    })];
  }
```