### PR TITLE
DWR-823 Display answer key in item viewer.

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
@@ -7,7 +7,7 @@
      TODO: updates the white-space:nowrap style implementation-->
 <div *ngIf="model" style="white-space: normal">
   <div *ngIf="model.answerKeyValue" class="pad-bottom-10">
-    <b>{{ translateRoot + 'answer-key' | translate }}</b> {{model.answerKeyValue}}
+    <strong>{{ translateRoot + 'answer-key' | translate }}</strong> {{model.answerKeyValue}}
   </div>
 
   <div *ngIf="model.rubrics.length > 0">

--- a/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
@@ -6,7 +6,6 @@
   </tab>
   <tab *ngIf="showItemDetails" (select)="selectTab('Item Viewer')" heading="{{translateRoot + 'item-viewer' | translate }}">
     <div class="tab-content well">
-      <p>{{ 'labels.assessments.items.tabs.item-viewer-intro-text' | translate }}</p>
       <item-viewer *ngIf="loadItemViewer"
                    [bankItemKey]="item.bankItemKey"
                    [response]="response"

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -6,7 +6,7 @@
   </div>
   <div *ngIf="rubricModel" style="white-space: normal">
     <div *ngIf="rubricModel.answerKeyValue" class="mb-md">
-      <b>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</b> {{rubricModel.answerKeyValue}}
+      <strong>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</strong> {{rubricModel.answerKeyValue}}
     </div>
     <div *ngIf="!rubricModel.answerKeyValue" class="mb-md">
       {{ 'labels.assessments.items.tabs.item-viewer-see-rubric' | translate }}

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -4,5 +4,14 @@
       <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i><span class="text">{{ 'messages.loading' | translate }}</span>
     </div>
   </div>
+  <div *ngIf="rubricModel" style="white-space: normal">
+    <div *ngIf="rubricModel.answerKeyValue" class="mb-md">
+      <b>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</b> {{rubricModel.answerKeyValue}}
+    </div>
+    <div *ngIf="!rubricModel.answerKeyValue" class="mb-md">
+      {{ 'labels.assessments.items.tabs.item-viewer-see-rubric' | translate }}
+    </div>
+  </div>
+  <p>{{ 'labels.assessments.items.tabs.item-viewer-intro-text' | translate }}</p>
   <iframe class="center" #irisframe [src]="safeIrisUrl" width="950" height="500" frameborder="0" ></iframe>
 </div>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.spec.ts
@@ -3,6 +3,10 @@ import { ItemViewerComponent } from "./item-viewer.component";
 import { UserService } from "../../../user/user.service";
 import { CommonModule } from "../../../shared/common.module";
 import { MockUserService } from "../../../../test/mock.user.service";
+import { ItemScoringService } from "../item-exemplar/item-scoring.service";
+import { Observable } from "rxjs/Observable";
+import { ItemScoringGuide } from "../item-exemplar/model/item-scoring-guide.model";
+import { ItemScoringGuideMapper } from "../item-exemplar/item-scoring-guide.mapper";
 
 describe('ItemViewerComponent', () => {
   let component: ItemViewerComponent;
@@ -12,7 +16,11 @@ describe('ItemViewerComponent', () => {
     TestBed.configureTestingModule({
       imports: [ CommonModule ],
       declarations: [ ItemViewerComponent ],
-      providers: [ { provide: UserService, useClass: MockUserService } ]
+      providers: [
+        ItemScoringGuideMapper,
+        { provide: UserService, useClass: MockUserService },
+        { provide: ItemScoringService, useClass: MockItemScoringService }
+        ]
     })
       .compileComponents();
   }));
@@ -27,4 +35,10 @@ describe('ItemViewerComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+
+class MockItemScoringService extends ItemScoringService {
+  getGuide(item: string) {
+    return Observable.of(new ItemScoringGuide());
+  }
+}
 

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -292,6 +292,7 @@
           "student-scores-intro-text": "Expand each student row to view their response to this item.",
           "item-viewer": "Item Viewer",
           "item-viewer-intro-text": "This is the view of the item as seen while taking the assessment.  This does not include student responses.",
+          "item-viewer-see-rubric": "See the Rubric and Exemplar tab to get more information on correct responses.",
           "exemplar": {
             "title": "Rubric and Exemplar",
             "rubric": "Rubric",


### PR DESCRIPTION
This PR displays a simple answer key if available at the top of the item viewer.  If no simple answer key is available, it displays a message letting the user know that more information can be found in the rubric tab.
If no rubric available at all, no message is displayed to the user.

I considered caching the rubric/exemplar information should the user navigate to the exemplar screen, but decided against it since we don't have a good expiring cache impl and I don't want to continually shove rubric information into memory.

![dwr_823_complex_answer](https://user-images.githubusercontent.com/617828/29736251-57cc80d4-89b4-11e7-9e22-821de470a3a0.png)
![dwr_823_with_answer](https://user-images.githubusercontent.com/617828/29736252-57cddf42-89b4-11e7-9be9-6ae407e31010.png)
