### PR TITLE
Unlock metrics endpoints, since they're on a non-exposed port

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -527,7 +527,7 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/saml/**").permitAll();
 
         for (final AbstractEndpoint endpoint : actuatorEndpoints) {
-            http.authorizeRequests().antMatchers("/" + endpoint.getId()).permitAll();
+            http.authorizeRequests().antMatchers("/" + endpoint.getId() + "/**").permitAll();
         }
 
         http

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -13,6 +13,7 @@ import org.opensaml.xml.parse.StaticBasicParserPool;
 import org.opentestsystem.rdw.reporting.security.Http401NotAuthorizedNoChallengeEntryPoint;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -88,6 +89,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Timer;
 
 @Profile("!test")
@@ -98,14 +100,17 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     private final SamlSettings samlSettings;
     private final SamlUserDetailsService samlUserDetailsService;
     private final ResourceLoader resourceLoader;
+    private final Set<AbstractEndpoint> actuatorEndpoints;
 
     @Autowired
     public SamlWebSecurityConfiguration(final SamlSettings samlSettings,
                                         final SamlUserDetailsService samlUserDetailsService,
-                                        final ResourceLoader resourceLoader) {
+                                        final ResourceLoader resourceLoader,
+                                        final Set<AbstractEndpoint> actuatorEndpoints) {
         this.samlSettings = samlSettings;
         this.samlUserDetailsService = samlUserDetailsService;
         this.resourceLoader = resourceLoader;
+        this.actuatorEndpoints = actuatorEndpoints;
     }
 
     // Initialization of OpenSAML library
@@ -519,8 +524,14 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .addFilterAfter(samlFilter(), BasicAuthenticationFilter.class);
         http
                 .authorizeRequests()
-                .antMatchers("/saml/**").permitAll()
-                .antMatchers("/{status:(status|health|info|env|configprops|autoconfig)}/**").permitAll()
+                .antMatchers("/saml/**").permitAll();
+
+        for (final AbstractEndpoint endpoint : actuatorEndpoints) {
+            http.authorizeRequests().antMatchers("/" + endpoint.getId()).permitAll();
+        }
+
+        http
+                .authorizeRequests()
                 .antMatchers("/**").authenticated()
                 .anyRequest().authenticated();
         http


### PR DESCRIPTION
This removes SSO security from all metrics endpoints.