### PR TITLE
adds guard against null/unscored claims in icas

### DIFF
--- a/common/src/main/resources/templates/ica-body.html
+++ b/common/src/main/resources/templates/ica-body.html
@@ -79,9 +79,19 @@
             <div th:if="${scored}" class="row" th:with="columnClass=${report.assessment.claimCodes.size() == 4} ? 'col-xs-3' : 'col-xs-4'">
                 <div th:class="${columnClass}" th:each="claimCode : ${report.assessment.claimCodes}">
                     <h3 class="text-center" th:text="#{'report.claim.' + ${claimCode} + '.name'}"></h3>
-                    <span class="h4 gray-dark"><i class="fa fa-5x text-center" th:classappend="#{'report.claim.' + ${claimCode} + '.icon'}"></i></span><br />
-                    <div class="text-center gray-lightest pt-sm pb-sm mb-sm"><strong th:text="#{'report.claim.level.' + ${report.exam.claimScaleScores[claimCodeStat.index].level} + '.label'}"></strong></div>
-                    <p th:text="#{('report.claim.' + ${claimCode} + '.grade.' + ${report.assessment.gradeCode} + '.level.' + ${report.exam.claimScaleScores[claimCodeStat.index].level})(${report.student.firstName})}"></p>
+                    <span class="h4 gray-dark"><i class="fa fa-5x text-center" th:classappend="#{'report.claim.' + ${claimCode} + '.icon'}"></i></span>
+                    <br/>
+                    <div th:if="${report.exam.claimScaleScores[claimCodeStat.index] != null}">
+                        <div class="text-center gray-lightest pt-sm pb-sm mb-sm">
+                            <strong th:text="#{'report.claim.level.' + ${report.exam.claimScaleScores[claimCodeStat.index].level} + '.label'}"></strong>
+                        </div>
+                        <p th:text="#{('report.claim.' + ${claimCode} + '.grade.' + ${report.assessment.gradeCode} + '.level.' + ${report.exam.claimScaleScores[claimCodeStat.index].level})(${report.student.firstName})}"></p>
+                    </div>
+                    <div th:if="${report.exam.claimScaleScores[claimCodeStat.index] == null}">
+                        <div class="text-center gray-lightest pt-sm pb-sm mb-sm">
+                            <strong th:text="#{'report.not-scored'}"></strong>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Resolution for DWR-782.

Should we display an explanation as to why the claim might not be scored?

![screen shot 2017-08-29 at 3 28 44 pm](https://user-images.githubusercontent.com/23462925/29847170-2c9f18e0-8ccf-11e7-8f89-155160137967.png)
