### PR TITLE
DWR-201 proxy and secure requests to Iris

### DIFF
--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-data-redis'
     compile 'org.springframework.session:spring-session'
     compile 'org.springframework.cloud:spring-cloud-starter-config'
+    compile 'org.springframework.cloud:spring-cloud-starter-zuul'
     compile 'org.springframework.retry:spring-retry'
     compile 'org.springframework.security.extensions:spring-security-saml2-core'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/ApplicationConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/ApplicationConfiguration.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting;
 
 import org.opentestsystem.rdw.reporting.common.report.processor.WkhtmltopdfWebServiceHtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.web.NotFoundIndexTemplate;
+import org.opentestsystem.rdw.reporting.zuul.IrisAwareFormBodyWrapperFilter;
 import org.opentestsystem.rdw.security.client.permissionservice.PermissionWebServiceClient;
 import org.opentestsystem.rdw.security.service.ComponentPermissionService;
 import org.opentestsystem.rdw.security.service.PermissionService;
@@ -10,8 +11,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.filters.pre.FormBodyWrapperFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 
@@ -21,6 +26,7 @@ import static com.google.common.collect.Maps.newHashMap;
 import static org.springframework.boot.autoconfigure.security.SecurityProperties.DEFAULT_FILTER_ORDER;
 
 @Configuration
+@EnableZuulProxy
 public class ApplicationConfiguration {
 
     @Bean
@@ -65,5 +71,19 @@ public class ApplicationConfiguration {
         registrationBean.setOrder(DEFAULT_FILTER_ORDER - 100);
         return registrationBean;
     }
+
+    /**
+     * Overwrite the standard Zuul FormBodyWrapperFilter with one
+     * able to deal with Iris.
+     *
+     * @return An Iris-capable FormBodyWrapperFilter bean
+     */
+    @Bean
+    @Order(10)
+    @Primary
+    public FormBodyWrapperFilter formBodyWrapperFilter() {
+        return new IrisAwareFormBodyWrapperFilter();
+    }
+
 }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
@@ -9,9 +9,6 @@ class AppSettings {
     @Value("${app.iris.vendorId}")
     private String irisVendorId;
 
-    @Value("${app.iris.url}")
-    private String irisUrl;
-
     @Value("${app.analytics.trackingId}")
     private String analyticsTrackingId;
 
@@ -32,13 +29,6 @@ class AppSettings {
      */
     public String getIrisVendorId() {
         return irisVendorId;
-    }
-
-    /**
-     * @return the Iris url in which to embed the Iris iframe.
-     */
-    public String getIrisUrl() {
-        return irisUrl;
     }
 
     /**

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.saml.SAMLAuthenticationProvider;
@@ -498,11 +497,6 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
         return super.authenticationManagerBean();
-    }
-
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/iris/**");
     }
 
     /**

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/zuul/IrisAwareFormBodyWrapperFilter.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/zuul/IrisAwareFormBodyWrapperFilter.java
@@ -1,0 +1,197 @@
+package org.opentestsystem.rdw.reporting.zuul;
+
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.http.HttpServletRequestWrapper;
+import com.netflix.zuul.http.ServletInputStreamWrapper;
+import org.springframework.cloud.netflix.zuul.filters.pre.FormBodyWrapperFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+/**
+ * This class is mostly taken from {@link FormBodyWrapperFilter} which is responsible for
+ * converting a client request with content-type MediaType.APPLICATION_FORM_URLENCODED or
+ * MediaType.MULTIPART_FORM_DATA into a forwarded request to the proxied service.
+ *
+ * This class is responsible for being aware that IRIS requests are malformed and although
+ * they advertise a content-type of MediaType.APPLICATION_FORM_URLENCODED, the content actually
+ * consists of JSON.  This class re-interprets the form key of:
+ * {"items":[{"id":"I-xxx-xxxxx"}]}
+ * with an empty-string value as a JSON payload and wraps the client request in a suitable
+ * RequestWrapper.
+ */
+public class IrisAwareFormBodyWrapperFilter extends FormBodyWrapperFilter {
+
+    private static final StringHttpMessageConverter converter = new StringHttpMessageConverter(UTF_8);
+    private static final AntPathMatcher PathMatcher = new AntPathMatcher();
+    private static final String IrisPathPattern = "/iris/**";
+
+    private final Field requestField;
+    private final Field servletRequestField;
+
+    public IrisAwareFormBodyWrapperFilter() {
+        this.requestField = ReflectionUtils.findField(HttpServletRequestWrapper.class,
+                "req", HttpServletRequest.class);
+        this.servletRequestField = ReflectionUtils.findField(ServletRequestWrapper.class,
+                "request", ServletRequest.class);
+        Assert.notNull(this.requestField,
+                "HttpServletRequestWrapper.req field not found");
+        Assert.notNull(this.servletRequestField,
+                "ServletRequestWrapper.request field not found");
+        this.requestField.setAccessible(true);
+        this.servletRequestField.setAccessible(true);
+    }
+
+    @Override
+    public Object run() {
+        final RequestContext ctx = RequestContext.getCurrentContext();
+        final HttpServletRequest request = ctx.getRequest();
+        if (!PathMatcher.match(IrisPathPattern, request.getRequestURI())) {
+            return super.run();
+        }
+
+        final FormBodyRequestWrapper wrapper;
+        if (request instanceof HttpServletRequestWrapper) {
+            final HttpServletRequest wrapped = (HttpServletRequest) ReflectionUtils
+                    .getField(this.requestField, request);
+            wrapper = new FormBodyRequestWrapper(wrapped);
+            ReflectionUtils.setField(this.requestField, request, wrapper);
+            ReflectionUtils.setField(this.servletRequestField, request, wrapper);
+        }
+        else {
+            wrapper = new FormBodyRequestWrapper(request);
+            ctx.setRequest(wrapper);
+        }
+        ctx.getZuulRequestHeaders().put("content-type", wrapper.getContentType());
+        return null;
+    }
+
+    class FormBodyRequestWrapper extends Servlet30RequestWrapper {
+
+        private final HttpServletRequest request;
+
+        private byte[] contentData;
+
+        private MediaType contentType;
+
+        private int contentLength;
+
+        FormBodyRequestWrapper(final HttpServletRequest request) {
+            super(request);
+            this.request = request;
+        }
+
+        @Override
+        public String getContentType() {
+            if (this.contentData == null) {
+                buildContentData();
+            }
+            return this.contentType.toString();
+        }
+
+        @Override
+        public int getContentLength() {
+            if (super.getContentLength() <= 0) {
+                return super.getContentLength();
+            }
+            if (this.contentData == null) {
+                buildContentData();
+            }
+            return this.contentLength;
+        }
+
+        public long getContentLengthLong() {
+            return getContentLength();
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            if (this.contentData == null) {
+                buildContentData();
+            }
+            return new ServletInputStreamWrapper(this.contentData);
+        }
+
+        private synchronized void buildContentData() {
+            try {
+                String payload = EMPTY;
+                final Set<String> queryParams = findQueryParams();
+                for (final Map.Entry<String, String[]> entry : this.request.getParameterMap().entrySet()) {
+                    if (queryParams.contains(entry.getKey())) continue;
+
+                    payload = entry.getKey();
+                    break;
+                }
+
+                final FormHttpOutputMessage data = new FormHttpOutputMessage();
+                this.contentType = MediaType.valueOf(this.request.getContentType());
+                data.getHeaders().setContentType(this.contentType);
+                converter.write(payload, this.contentType, data);
+                // copy new content type including multipart boundary
+                this.contentType = data.getHeaders().getContentType();
+                this.contentData = data.getInput();
+                this.contentLength = this.contentData.length;
+            }
+            catch (final Exception e) {
+                throw new IllegalStateException("Cannot convert json-as-form data", e);
+            }
+        }
+
+        private Set<String> findQueryParams() {
+            final Set<String> result = new HashSet<>();
+            final String query = this.request.getQueryString();
+            if (query != null) {
+                for (String value : StringUtils.tokenizeToStringArray(query, "&")) {
+                    if (value.contains("=")) {
+                        value = value.substring(0, value.indexOf("="));
+                    }
+                    result.add(value);
+                }
+            }
+            return result;
+        }
+
+        private class FormHttpOutputMessage implements HttpOutputMessage {
+
+            private final HttpHeaders headers = new HttpHeaders();
+            private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return this.headers;
+            }
+
+            @Override
+            public OutputStream getBody() throws IOException {
+                return this.output;
+            }
+
+            public byte[] getInput() throws IOException {
+                this.output.flush();
+                return this.output.toByteArray();
+            }
+
+        }
+
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/zuul/Servlet30RequestWrapper.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/zuul/Servlet30RequestWrapper.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.reporting.zuul;
+
+import com.netflix.zuul.http.HttpServletRequestWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Duplicated from {@link org.springframework.cloud.netflix.zuul.filters.pre.Servlet30RequestWrapper}
+ */
+class Servlet30RequestWrapper extends HttpServletRequestWrapper {
+    private final HttpServletRequest request;
+
+    Servlet30RequestWrapper(final HttpServletRequest request) {
+        super(request);
+        this.request = request;
+    }
+
+    /**
+     * There is a bug in zuul 1.2.2 where HttpServletRequestWrapper.getRequest returns a wrapped request rather than the raw one.
+     * @return the original HttpServletRequest
+     */
+    @Override
+    public HttpServletRequest getRequest() {
+        return this.request;
+    }
+}

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -108,3 +108,16 @@ app:
     interpretive-guide: http://www.smarterbalanced.org/educators/
 
   min-item-data-year: 2016
+
+# Netflix zuul configuration.
+zuul:
+  set-content-length: true
+  FormBodyWrapperFilter:
+    pre: disable
+  host:
+    socket-timeout-millis: 100000
+  routes:
+    iris:
+      path: /iris/**
+      url: ${app.iris.url}
+      stripPrefix: true

--- a/webapp/src/main/webapp/proxy.conf.json
+++ b/webapp/src/main/webapp/proxy.conf.json
@@ -2,5 +2,9 @@
   "/api": {
     "target": "http://localhost:8080",
     "secure": false
+  },
+  "/iris": {
+    "target": "http://localhost:8080",
+    "secure": false
   }
 }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -13,5 +13,5 @@
     </div>
   </div>
   <p>{{ 'labels.assessments.items.tabs.item-viewer-intro-text' | translate }}</p>
-  <iframe class="center" #irisframe [src]="safeIrisUrl" width="950" height="500" frameborder="0" ></iframe>
+  <iframe class="center" #irisframe src="/iris" width="950" height="500" frameborder="0" ></iframe>
 </div>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
@@ -1,5 +1,4 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
-import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 import { UserService } from "../../../user/user.service";
 import { ItemScoringGuide } from "../item-exemplar/model/item-scoring-guide.model";
 import { ItemScoringService } from "../item-exemplar/item-scoring.service";
@@ -34,7 +33,6 @@ export class ItemViewerComponent implements OnInit {
   public position: number;
 
   public irisIsLoading: boolean = true;
-  public safeIrisUrl: SafeResourceUrl;
   public rubricModel: ItemScoringGuide;
 
   private vendorId;
@@ -48,16 +46,12 @@ export class ItemViewerComponent implements OnInit {
     }
   }
 
-  constructor(private sanitizer: DomSanitizer,
-              private userService: UserService,
+  constructor(private userService: UserService,
               private itemScoringService: ItemScoringService) {
   }
 
   ngOnInit() {
     this.userService.getCurrentUser().subscribe(user => {
-      let irisUrl = user.configuration.irisUrl;
-
-      this.safeIrisUrl = this.sanitizer.bypassSecurityTrustResourceUrl(irisUrl);
       this.vendorId = user.configuration.irisVendorId;
 
       this._irisFrame.addEventListener('load', this.irisframeOnLoad.bind(this));

--- a/webapp/src/main/webapp/src/app/user/model/configuration.model.ts
+++ b/webapp/src/main/webapp/src/app/user/model/configuration.model.ts
@@ -1,6 +1,5 @@
 export class Configuration {
   irisVendorId: string;
-  irisUrl: string;
   analyticsTrackingId: string;
   interpretiveGuide: string;
   minItemDataYear: number;

--- a/webapp/src/main/webapp/src/app/user/user.mapper.ts
+++ b/webapp/src/main/webapp/src/app/user/user.mapper.ts
@@ -80,7 +80,6 @@ export class UserMapper {
     if (isNullOrUndefined(apiModel)) {
       return uiModel;
     }
-    uiModel.irisUrl = apiModel.irisUrl;
     uiModel.irisVendorId = apiModel.irisVendorId;
     uiModel.analyticsTrackingId = apiModel.analyticsTrackingId;
     uiModel.interpretiveGuide = apiModel.interpretiveGuideUrl;

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/zuul/IrisAwareFormBodyWrapperFilterTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/zuul/IrisAwareFormBodyWrapperFilterTest.java
@@ -1,0 +1,86 @@
+package org.opentestsystem.rdw.reporting.zuul;
+
+import com.amazonaws.util.IOUtils;
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.http.HttpServletRequestWrapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.InputStream;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class IrisAwareFormBodyWrapperFilterTest {
+
+    private RequestContext requestContext;
+    private IrisAwareFormBodyWrapperFilter filter;
+    private String jsonContent;
+    private MockHttpServletRequest request;
+
+    @Before
+    public void setup() {
+        filter = new IrisAwareFormBodyWrapperFilter();
+
+        jsonContent = "{\"some\":\"json\"}";
+        request = new MockHttpServletRequest(RequestMethod.POST.name(), "/iris/Pages/API/content/load");
+        request.setContentType("application/x-www-form-urlencoded; charset=UTF-8");
+        request.setQueryString("id=vendorId");
+        request.addParameter("id", "vendorId");
+        request.addParameter(jsonContent, EMPTY);
+
+        requestContext = new RequestContext();
+        requestContext.setRequest(request);
+        RequestContext.testSetCurrentContext(requestContext);
+    }
+
+    @After
+    public void tearDown() {
+        RequestContext.testSetCurrentContext(null);
+    }
+
+    @Test
+    public void itShouldIgnoreNonIrisRequests() {
+        request.setRequestURI("/somewhere/else");
+        filter.run();
+        assertThat(requestContext.getRequest()).isNotInstanceOf(IrisAwareFormBodyWrapperFilter.FormBodyRequestWrapper.class);
+    }
+
+    @Test
+    public void itShouldHandleIrisRequests() {
+        filter.run();
+        assertThat(requestContext.getRequest()).isInstanceOf(IrisAwareFormBodyWrapperFilter.FormBodyRequestWrapper.class);
+    }
+
+    @Test
+    public void itShouldDeReferenceAHttpServletRequestWrapper() {
+        final HttpServletRequestWrapper wrapper = spy(new HttpServletRequestWrapper(request));
+        requestContext.setRequest(wrapper);
+
+        filter.run();
+        verify(wrapper, never()).getParameterMap();
+    }
+
+    @Test
+    public void itShouldProvideJsonAsContentInFinalRequest() throws Exception {
+        filter.run();
+        final HttpServletRequest request = requestContext.getRequest();
+        try (final InputStream content = request.getInputStream()) {
+            assertThat(IOUtils.toString(content)).isEqualTo(jsonContent);
+        }
+    }
+
+    @Test
+    public void itShouldCleanSpacesFromTheContentType() throws Exception {
+        filter.run();
+        final HttpServletRequest request = requestContext.getRequest();
+        assertThat(request.getContentType()).doesNotContain(" ");
+    }
+}


### PR DESCRIPTION
This PR removes the need for the front-end client to directly communicate with IRIS.  Instead, IRIS requests are proxied through the back-end via requests to "/iris/**"

This allows us to provide security to all IRIS requests via standard SSO authentication.

Note that since IRIS is still sending mis-labeled JSON requests as "application/x-www-form-urlencoded" a relatively ugly workaround is required to pass the JSON content through the Zuul proxy.