### PR TITLE
Bug/dwr 728 leak student data

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
@@ -37,6 +37,10 @@ class DefaultStudentExamService implements StudentExamService {
                 student.getId()
         );
 
+        if(exams.size() == 0) {
+            throw new NoSuchElementException(String.format("No exams for student with ID: %s", studentId));
+        }
+
         return new StudentExamHistory(student, exams);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamService.java
@@ -37,7 +37,7 @@ class DefaultStudentExamService implements StudentExamService {
                 student.getId()
         );
 
-        if(exams.size() == 0) {
+        if(exams.isEmpty()) {
             throw new NoSuchElementException(String.format("No exams for student with ID: %s", studentId));
         }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemService.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.reporting.search.exam.student;
 
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.exam.AssessmentItem;
 import org.opentestsystem.rdw.reporting.exam.ExamItem;
 import org.opentestsystem.rdw.reporting.search.assessment.AssessmentItemRepository;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Default implementation of an ExamItemService.
@@ -28,10 +28,13 @@ class ReportingExamItemService implements ExamItemService {
 
     @Override
     public GroupExamItemScores getExamItems(@NotNull final User user, final long examId) {
-        final PermissionScope scope = user.getPermissionsById().get("GROUP_PII_READ").getScope();
-
         final List<ExamItem> examItems = examItemRepository.findAllByExamId(user.getPermissionsById(), user.getGroupsById().keySet(), examId);
         final List<AssessmentItem> assessmentItems = assessmentItemRepository.findAllForExam(examId);
+
+        if(examItems.isEmpty() || assessmentItems.isEmpty()) {
+            throw new NoSuchElementException(String.format("No exam items found for exam ID: %s", examId));
+        }
+
         return new GroupExamItemScores(assessmentItems, examItems);
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemService.java
@@ -29,10 +29,15 @@ class ReportingExamItemService implements ExamItemService {
     @Override
     public GroupExamItemScores getExamItems(@NotNull final User user, final long examId) {
         final List<ExamItem> examItems = examItemRepository.findAllByExamId(user.getPermissionsById(), user.getGroupsById().keySet(), examId);
+
+        if(examItems.isEmpty()) {
+            throw new NoSuchElementException(String.format("No exam items found for exam ID: %s", examId));
+        }
+
         final List<AssessmentItem> assessmentItems = assessmentItemRepository.findAllForExam(examId);
 
-        if(examItems.isEmpty() || assessmentItems.isEmpty()) {
-            throw new NoSuchElementException(String.format("No exam items found for exam ID: %s", examId));
+        if(assessmentItems.isEmpty()) {
+            throw new NoSuchElementException(String.format("No assessment items found for exam ID: %s", examId));
         }
 
         return new GroupExamItemScores(assessmentItems, examItems);

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -4,14 +4,12 @@
     <span>{{student.ssid}}</span>
   </div>
 </div>
-<div *ngIf="!student" class="alert alert-danger">
+<h3 class="blue mb-md">{{'labels.student.responses.title' | translate}}</h3>
+<div *ngIf="!student || !assessment" class="alert alert-danger">
   {{ 'labels.student.messages.null-student' | translate }}
 </div>
-
-<h3 class="blue mb-md">{{'labels.student.responses.title' | translate}}</h3>
-
-<div *ngIf="student" class="well">
-  <div *ngIf="assessment" class="mb-md">
+<div *ngIf="student && assessment" class="well">
+  <div class="mb-md">
     <span class="tag tag-md {{colorService.getColor(getGradeIndex(assessment.grade))}}">
       <span class="label">{{assessment.grade | gradeDisplay}}</span>
           <span>{{assessment.name}}</span>

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.ts
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.ts
@@ -30,7 +30,10 @@ export class StudentResponsesComponent implements OnInit {
 
   ngOnInit(): void {
     let routeItems: AssessmentItem[] = this.route.snapshot.data[ "assessmentItems" ];
-    this.assessmentItems = routeItems.map(item => this.mapAssessmentItem(item));
+    if(routeItems) {
+      this.assessmentItems = routeItems.map(item => this.mapAssessmentItem(item));
+    }
+
     this.exam = this.route.snapshot.data[ "exam" ];
     this.assessment = this.route.snapshot.data[ "assessment" ];
     this.student = this.route.snapshot.data[ "student" ];

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
@@ -57,17 +57,11 @@ public class DefaultStudentExamServiceTest {
         service.getExams(user, 123L);
     }
 
-    @Test
-    public void getExamsShouldReturnEmptyHistoryWhenStudentFoundButExamsNotFound() throws Exception {
+    @Test(expected = NoSuchElementException.class)
+    public void getExamsShouldThrowExceptionWhenStudentFoundButExamsNotFound() throws Exception {
         when(studentRepository.findOneById(123L)).thenReturn(Student.builder().id(1).build());
         when(examRepository.findAllForStudent(user.getPermissionsById(), user.getGroupsById().keySet(), 1)).thenReturn(ImmutableList.of());
-        assertThat(service.getExams(user, 123L))
-                .isEqualToComparingFieldByFieldRecursively(
-                        new StudentExamHistory(
-                                Student.builder().id(1).build(),
-                                ImmutableList.of()
-                        )
-                );
+        service.getExams(user, 123L);
     }
 
     @Test

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -62,6 +63,36 @@ public class ReportingExamItemServiceTest {
         final GroupExamItemScores result = service.getExamItems(user, examId);
         assertThat(result.getAssessmentItems()).containsExactlyElementsOf(assessmentItems);
         assertThat(result.getExamItems()).containsExactlyElementsOf(examItems);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldThrowIfNoExamItems() {
+        final long examId = 456L;
+
+        when(examItemRepository.findAllByExamId(user.getPermissionsById(), user.getGroupsById().keySet(), examId))
+                .thenReturn(ImmutableList.of());
+
+        final List<AssessmentItem> assessmentItems = ImmutableList.of(
+                mock(AssessmentItem.class),
+                mock(AssessmentItem.class));
+        when(assessmentItemRepository.findAllForExam(examId)).thenReturn(assessmentItems);
+
+        service.getExamItems(user, examId);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldThrowIfNoAssessmentItems() {
+        final long examId = 456L;
+
+        final List<ExamItem> examItems = ImmutableList.of(
+                mock(ExamItem.class),
+                mock(ExamItem.class));
+        when(examItemRepository.findAllByExamId(user.getPermissionsById(), user.getGroupsById().keySet(), examId))
+                .thenReturn(examItems);
+
+        when(assessmentItemRepository.findAllForExam(examId)).thenReturn(ImmutableList.of());
+
+        service.getExamItems(user, examId);
     }
 
 }


### PR DESCRIPTION
Now throwing when no exams are found on the get student exams call.  This solution seems simpler than implementing all the sql permission checks in the studentRepository.findOneById if we are already making these same checks in the exam lookup anyway.