### PR TITLE
adds claim/target popovers to student responses view

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.module.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.module.ts
@@ -30,6 +30,7 @@ import { StudentScoreService } from "./items/item-scores/student-score.service";
 import { ItemInfoComponent } from "./items/item-info/item-info.component";
 import { ItemInfoService } from "./items/item-info/item-info.service";
 import { PopoverModule } from "ngx-bootstrap";
+import { ClaimTargetComponent } from "./results/claim-target.component";
 
 @NgModule({
   declarations: [
@@ -46,7 +47,8 @@ import { PopoverModule } from "ngx-bootstrap";
     SelectAssessmentsComponent,
     ItemExemplarComponent,
     ItemScoresComponent,
-    ItemInfoComponent
+    ItemInfoComponent,
+    ClaimTargetComponent
   ],
   imports: [
     BrowserModule,
@@ -66,7 +68,8 @@ import { PopoverModule } from "ngx-bootstrap";
     InformationLabelComponent,
     ItemTabComponent,
     PopupMenuComponent,
-    ScaleScoreComponent
+    ScaleScoreComponent,
+    ClaimTargetComponent
   ],
   providers: [
     AssessmentExamMapper,

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -192,17 +192,7 @@
                     content="{{'labels.groups.results.assessment.items.cols.claim-info-html' | translate}}"></span>
             </ng-template>
             <ng-template let-item="rowData" pTemplate="body">
-              <a href="javascript:void(0)"
-                 [popover]="'definition.claim.' + item.claim + '.description' | translate"
-                 popoverTitle="{{'definition.claim.' + item.claim + '.name' | translate}}"
-                 outsideClick="true">{{'definition.claim.' + item.claim + '.name' | translate}}</a>
-              /
-              <a href="javascript:void(0)" #me
-                 [popover]="targetPopover"
-                 popoverTitle="{{'labels.groups.results.assessment.items.target' | translate:item}}"
-                 outsideClick="true">{{'labels.groups.results.assessment.items.target' | translate:item}}</a>
-
-              <ng-template #targetPopover>{{getTargetDescription(item.targetId) | async}}</ng-template>
+              <claim-target [item]="item"></claim-target>
             </ng-template>
           </p-column>
           <p-column field="difficulty" [sortable]="true" sortField="difficultySortOrder">

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -38,6 +38,7 @@ import { ItemInfoService } from "../items/item-info/item-info.service";
 import { UserService } from "../../user/user.service";
 import { UserMapper } from "../../user/user.mapper";
 import { CachingDataService } from "../../shared/cachingData.service";
+import { ClaimTargetComponent } from "./claim-target.component";
 
 describe('AssessmentResultsComponent', () => {
   let component: AssessmentResultsComponent;
@@ -77,7 +78,8 @@ describe('AssessmentResultsComponent', () => {
         RemoveCommaPipe,
         ScaleScoreComponent,
         AverageScaleScoreComponent,
-        TestComponentWrapper
+        TestComponentWrapper,
+        ClaimTargetComponent
       ],
       providers: [ { provide: APP_BASE_HREF, useValue: '/' },
         { provide: Angulartics2, useValue: mockAngulartics2 },

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -207,7 +207,6 @@ export class AssessmentResultsComponent implements OnInit {
               private reportService: ReportService,
               private notificationService: NotificationService,
               private actionBuilder: MenuActionBuilder,
-              private itemInfoService: ItemInfoService,
               private angulartics2: Angulartics2) {
   }
 
@@ -381,10 +380,6 @@ export class AssessmentResultsComponent implements OnInit {
         }
       )
       .build();
-  }
-
-  public getTargetDescription(targetId: number): Observable<string> {
-    return this.itemInfoService.getTargetDescription(targetId);
   }
 
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/claim-target.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/claim-target.component.html
@@ -1,0 +1,11 @@
+<a href="javascript:void(0)"
+   [popover]="'definition.claim.' + item.claim + '.description' | translate"
+   popoverTitle="{{'definition.claim.' + item.claim + '.name' | translate}}"
+   outsideClick="true">{{'definition.claim.' + item.claim + '.name' | translate}}</a>
+/
+<a href="javascript:void(0)" #me
+   [popover]="targetPopover"
+   popoverTitle="{{'labels.groups.results.assessment.items.target' | translate:item}}"
+   outsideClick="true">{{'labels.groups.results.assessment.items.target' | translate:item}}</a>
+
+<ng-template #targetPopover>{{getTargetDescription() | async}}</ng-template>

--- a/webapp/src/main/webapp/src/app/assessments/results/claim-target.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/claim-target.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input } from "@angular/core";
+import { Observable } from "rxjs";
+import { ItemInfoService } from "../items/item-info/item-info.service";
+import { AssessmentItem } from "../model/assessment-item.model";
+
+/**
+ * This component is responsible for displaying a label with
+ * an information popover icon.
+ */
+@Component({
+  selector: 'claim-target',
+  templateUrl: './claim-target.component.html'
+})
+export class ClaimTargetComponent {
+
+  @Input()
+  public item: AssessmentItem;
+
+  constructor(private service: ItemInfoService) {
+  }
+
+  public getTargetDescription(): Observable<string> {
+    return this.service.getTargetDescription(this.item.targetId);
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -35,7 +35,7 @@
                     content="{{'labels.groups.results.assessment.items.cols.claim-info-html' | translate}}"></span>
       </ng-template>
       <ng-template let-item="rowData.assessmentItem" pTemplate="body">
-        {{ 'definition.claim.' + item.claim + '.name' | translate }} / {{ 'labels.groups.results.assessment.items.target' | translate:item }}
+        <claim-target [item]="item"></claim-target>
       </ng-template>
     </p-column>
     <p-column field="assessmentItem.difficulty" [sortable]="true">


### PR DESCRIPTION
Now claim/target popovers are accessible in the items by points earned view and the student response view. Change based on DWR-820 QA feedback.