### PR TITLE
Allow /status through security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.0.0-SNAPSHOT`
 
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.0.0-40"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.0.0-41"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.0.0-190"
 String dockerPrefix = "smarterbalanced"
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -520,7 +520,8 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/", "/*.ico").permitAll()
                 .antMatchers("/assets/public/**").permitAll()
-                .antMatchers("/saml/**").permitAll();
+                .antMatchers("/saml/**").permitAll()
+                .antMatchers("/status/**").permitAll();
 
         for (final AbstractEndpoint endpoint : actuatorEndpoints) {
             http.authorizeRequests().antMatchers("/" + endpoint.getId() + "/**").permitAll();

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -520,8 +520,7 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/", "/*.ico").permitAll()
                 .antMatchers("/assets/public/**").permitAll()
-                .antMatchers("/saml/**").permitAll()
-                .antMatchers("/status/**").permitAll();
+                .antMatchers("/saml/**").permitAll();
 
         for (final AbstractEndpoint endpoint : actuatorEndpoints) {
             http.authorizeRequests().antMatchers("/" + endpoint.getId() + "/**").permitAll();


### PR DESCRIPTION
Our StatusEndpoint isn't registered as a Bean in StatusConfiguration which means we need to manually account for it when poking security holes.

UPDATE: I instead modified RDW_Common to register the StatusEndpoint as a bean, so our standard passthrough of all actuator endpoints now picks it up.