### PR TITLE
Now enabling the cache control headers again provided by security.  A…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -535,7 +535,6 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .logoutSuccessUrl("/");
 
         http.headers().frameOptions().sameOrigin();
-        http.headers().cacheControl().disable();
     }
 
     /**


### PR DESCRIPTION
…s it turns out, the WebMvcConfiguration overrides these so static assets are still cached while api end points are not.