### PR TITLE
Now no longer storing the location.href if it is the session-expired …

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/authentication/authentication.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/authentication/authentication.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
 import { StorageService, StorageType } from "../storage.service";
+import { WindowRefService } from "../window-ref.service";
 
 /**
  * This service is responsible for handling authentication errors.
@@ -9,31 +10,34 @@ import { StorageService, StorageType } from "../storage.service";
 export class AuthenticationService {
 
   private locationKey: string = "authFailureLocation";
+  private window: any;
 
   constructor(private router: Router,
-              private storageService: StorageService) {
+              private storageService: StorageService,
+              windowRefService: WindowRefService,) {
+    this.window = windowRefService.nativeWindow;
   }
 
   /**
    * On authentication failure, navigate the user to the session-timeout route.
    */
   handleAuthenticationFailure(): void {
-    let urlToStore = window.location.href;
+    let urlToStore = this.window.location.href;
 
     // If the url was the root, navigate to home instead so the user doesn't get the
     // landing page.
-    if(window.location.pathname === "/") {
+    if (this.window.location.pathname === "/") {
       urlToStore += "home";
     }
 
     // Prevent looping of session-expired page.
-    if(urlToStore.indexOf("session-expired") === -1) {
+    if (urlToStore.indexOf("session-expired") === -1) {
       this.storageService
         .getStorage(StorageType.Session)
         .setItem(this.locationKey, urlToStore);
     }
 
-    this.router.navigate(["session-expired"]);
+    this.router.navigate([ "session-expired" ]);
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/shared/authentication/authentication.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/authentication/authentication.service.ts
@@ -18,8 +18,21 @@ export class AuthenticationService {
    * On authentication failure, navigate the user to the session-timeout route.
    */
   handleAuthenticationFailure(): void {
-    this.storageService.getStorage(StorageType.Session)
-      .setItem(this.locationKey,  window.location.href);
+    let urlToStore = window.location.href;
+
+    // If the url was the root, navigate to home instead so the user doesn't get the
+    // landing page.
+    if(window.location.pathname === "/") {
+      urlToStore += "home";
+    }
+
+    // Prevent looping of session-expired page.
+    if(urlToStore.indexOf("session-expired") === -1) {
+      this.storageService
+        .getStorage(StorageType.Session)
+        .setItem(this.locationKey, urlToStore);
+    }
+
     this.router.navigate(["session-expired"]);
   }
 

--- a/webapp/src/main/webapp/src/app/shared/authentication/session-expired.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/authentication/session-expired.component.ts
@@ -18,8 +18,9 @@ export class SessionExpiredComponent {
   onOk(): void {
     let location = this.authenticationService.getReauthenticationLocation();
     if (!location) {
-      location = this.location.prepareExternalUrl("");
+      location = this.location.prepareExternalUrl("/home");
     }
+
     window.location.href = location;
   }
 }

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -28,6 +28,7 @@ import { DatePipe, DecimalPipe } from "@angular/common";
 import { SBErrorHandler } from "./sb-error-handler.service";
 import { ScaleScoreService } from "./scale-score.service";
 import { LoaderComponent } from "./loader/loader.component";
+import { WindowRefService } from "./window-ref.service";
 
 @NgModule({
   declarations: [
@@ -83,7 +84,8 @@ import { LoaderComponent } from "./loader/loader.component";
     ScaleScoreService,
     NotificationService,
     RdwTranslateLoader,
-    StorageService, {
+    StorageService,
+    WindowRefService, {
       provide: ErrorHandler,
       useClass: SBErrorHandler
     }

--- a/webapp/src/main/webapp/src/app/shared/window-ref.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/window-ref.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+function getWindow (): any {
+  return window;
+}
+
+/** WindowRefService that creates a layer of abstraction so that
+ * the native js window object can be mocked in unit tests.
+ */
+@Injectable()
+export class WindowRefService {
+  get nativeWindow (): any {
+    return getWindow();
+  }
+}


### PR DESCRIPTION
…link to prevent sending back to the session-expired page after login.  Also sending to /home now instead of / so the user doesn't have to see the landing page again if they were coming from the home route.