### PR TITLE
Added a public error and not-permitted.html pages to reporting webapp…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -6,6 +6,8 @@ import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.opentestsystem.rdw.reporting.security.auth.AuthorizationService;
 import org.opentestsystem.rdw.security.Grant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,6 +21,7 @@ import java.util.Set;
 
 @Service
 public class SamlUserDetailsService implements SAMLUserDetailsService {
+    private static final Logger logger = LoggerFactory.getLogger(SamlUserDetailsService.class);
 
     private static final String REDACTED = "[REDACTED]";
     private AuthorizationService authorizationService;
@@ -41,8 +44,10 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
 
 		// Secures the application by throwing exception if the user has no authority to access data for this state
         if (grants.isEmpty()) {
-            throw new RuntimeException(String.format(
-                    "Grants do not permit access to tenant for user \"%s\"", username));
+            String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
+            logger.warn(message);
+
+            throw new UsernameNotFoundException(message);
         }
 
         final Set<Permission> permissions = authorizationService.getPermissions(grants);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.security.saml.websso.WebSSOProfileECPImpl;
 import org.springframework.security.saml.websso.WebSSOProfileImpl;
 import org.springframework.security.saml.websso.WebSSOProfileOptions;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -356,7 +357,7 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     public SimpleUrlAuthenticationFailureHandler authenticationFailureHandler() {
         SimpleUrlAuthenticationFailureHandler failureHandler = new SimpleUrlAuthenticationFailureHandler();
         failureHandler.setUseForward(true);
-        failureHandler.setDefaultFailureUrl("/error");
+        failureHandler.setDefaultFailureUrl("/error/notPermitted");
         return failureHandler;
     }
 
@@ -520,6 +521,7 @@ public class SamlWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/", "/*.ico").permitAll()
                 .antMatchers("/assets/public/**").permitAll()
+                .antMatchers("/error", "/error/**").permitAll()
                 .antMatchers("/saml/**").permitAll();
 
         for (final AbstractEndpoint endpoint : actuatorEndpoints) {

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -4,6 +4,7 @@ import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -19,9 +20,24 @@ public class ViewController implements ErrorController {
     }
 
     // matches all routes that are not /api/**, /assets/**, /iris/**, or /*.*
-    @RequestMapping("/{path:^(?!api|assets|iris|.*\\..*).+}/**")
+    @RequestMapping("/{path:^(?!api|assets|iris|error|.*\\..*).+}/**")
     public String forward(@AuthenticationPrincipal final User user) {
         return  index(user);
+    }
+
+    @PostMapping(value="/error/notPermitted")
+    public String notPermitted() {
+
+        return "redirect:/assets/public/not-permitted.html";
+    }
+
+    @RequestMapping(value="/error")
+    public String error(@AuthenticationPrincipal final User user) {
+        if (user == null) {
+            return "forward:/assets/public/error.html";
+        }
+
+        return "forward:/index.html";
     }
 
     @Override

--- a/webapp/src/main/webapp/src/assets/public/error.html
+++ b/webapp/src/main/webapp/src/assets/public/error.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Smarter Balanced Reporting</title>
+  <link rel="stylesheet" type="text/css" href="/assets/public/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" href="/assets/public/ui.jqgrid.css">
+  <link rel="stylesheet" type="text/css" href="/assets/public/style.css">
+  <link rel="shortcut icon" href="favicon.ico">
+<body class="login">
+<div id="header" class="content" role="banner">
+  <div class="logo"></div>
+  <ul class="action" role="menubar">
+    <li>
+      <div class="divider">
+        <a href="/" class="btn btn-primary btn-login edware-btn-primary" role="menuitem">Go Home</a>
+      </div>
+    </li>
+  </ul>
+  <div class="helpMenuContainer"></div>
+</div>
+<div role="main">
+  <div>
+    <div class="content">
+      <div class="intro">
+        <h2>Error</h2>
+        <p>
+          An unknown error has occurred. You can try the same action again or click the button above to go to the home page.
+          If this problem persists, please contact your building administrator.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div id="footer">
+  </div>
+</div>
+</body>
+</html>

--- a/webapp/src/main/webapp/src/assets/public/not-permitted.html
+++ b/webapp/src/main/webapp/src/assets/public/not-permitted.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Smarter Balanced Reporting</title>
+  <link rel="stylesheet" type="text/css" href="/assets/public/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" href="/assets/public/ui.jqgrid.css">
+  <link rel="stylesheet" type="text/css" href="/assets/public/style.css">
+  <link rel="shortcut icon" href="favicon.ico">
+<body class="login">
+<div id="header" class="content" role="banner">
+  <div class="logo"></div>
+  <ul class="action" role="menubar">
+    <li>
+      <div class="divider">
+        <a href="javascript:void(0)" onclick="window.document.logoutForm.submit()" class="btn btn-primary btn-login edware-btn-primary" role="menuitem" type="submit">Log Out</a>
+        <form action="/saml/logout" class="hidden" method="post" name="logoutForm" novalidate=""></form>
+      </div>
+    </li>
+  </ul>
+  <div class="helpMenuContainer"></div>
+</div>
+<div role="main">
+  <div>
+    <div class="content">
+      <div class="intro">
+        <h2>Not Permitted</h2>
+        <p>
+          Your user account is not permitted to access this reporting system. If you believe you have reached
+          this page in error, please contact your building administrator.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div id="footer">
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
… to prevent infinite looping of sso login when a user doesn't have credentials to this tenant.  Now writing the warn to the logger explicitly and throwing a UserNameNotFoundException rather than the RuntimeException we were throwing previously which has different meaning.

This fixes DWR 913 (stack trace logged with bad login) and DWR 1002 (inf. sso loop)