### PR TITLE
Improved error logging / handling for item scoring guide.  The getXml…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/item/DefaultExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/item/DefaultExamItemService.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URLConnection;
 import java.util.Base64;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -82,12 +83,18 @@ class DefaultExamItemService implements ExamItemService {
     public ExamItemScoringGuide getScoringGuide(final String id) {
         try {
             return getExamItemSolution(getXmlDocument(id), id);
-        } catch (final IOException | SAXException | XPathExpressionException exception) {
+        }
+        catch(SAXException exception) {
+            logger.error(String.format("SAXException while trying to read the item xml: %s", id), exception);
             throw new RuntimeException(String.format("Error reading the xml for item: %s", id), exception);
+        }
+        catch (final IOException | XPathExpressionException exception) {
+            throw new NoSuchElementException(String.format("Rubric/Exemplar data is not available for item: %s", id));
         }
     }
 
-    private Document getXmlDocument(final String id) throws IOException, SAXException {
+    // DocumentBuilder.parse is not thread-safe: https://stackoverflow.com/questions/12455602/is-documentbuilder-thread-safe
+    private synchronized Document getXmlDocument(final String id) throws IOException, SAXException {
         return documentBuilder.parse(artifactRepository.getItemXml(id));
     }
 


### PR DESCRIPTION
…Document method is now synchronized as the parse method is not thread-safe and will throw an exception if two different threads attempt to call parse at the same time.