### PR TITLE
merges dropdown menu and expander icons with first column of tables

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
@@ -2,11 +2,11 @@
   <button type="button"
           (click)="open = !open"
           class="btn btn-info btn-xs btn-block text-left dropdown-toggle"
-          [ngClass]="{'icon-only': !hasText()}"
+          [ngClass]="{'icon-only': !hasText}"
           aria-haspopup="true"
           aria-expanded="false">
     <span class="sr-only">{{'labels.menu' | translate}}</span>
-    <i class="fa fa-ellipsis-v" [ngClass]="{'mr-xs': hasText()}"></i> {{text}}
+    <i class="fa fa-ellipsis-v" [ngClass]="{'mr-xs': hasText}"></i> {{text}}
   </button>
   <ul *ngIf="open" class="dropdown-menu" role="menu">
     <li *ngFor="let action of actions; let idx = index" role="menuitem">

--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
@@ -2,11 +2,12 @@
      [ngClass]="{'open': open}">
   <button type="button"
           (click)="open = !open"
-          class="btn btn-info icon-only btn-xs dropdown-toggle"
+          class="btn btn-info btn-xs dropdown-toggle"
+          [ngClass]="{'icon-only': (!text || text.length === 0)}"
           aria-haspopup="true"
           aria-expanded="false">
     <span class="sr-only">{{'labels.menu' | translate}}</span>
-    <i class="fa fa-ellipsis-v"></i>
+    <i class="fa fa-ellipsis-v"> {{text}}</i>
   </button>
   <ul *ngIf="open" class="dropdown-menu" role="menu">
     <li *ngFor="let action of actions; let idx = index" role="menuitem">

--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.html
@@ -1,13 +1,12 @@
-<div class="btn-group"
-     [ngClass]="{'open': open}">
+<div class="btn-group btn-block" [ngClass]="{'open': open}">
   <button type="button"
           (click)="open = !open"
-          class="btn btn-info btn-xs dropdown-toggle"
-          [ngClass]="{'icon-only': (!text || text.length === 0)}"
+          class="btn btn-info btn-xs btn-block text-left dropdown-toggle"
+          [ngClass]="{'icon-only': !hasText()}"
           aria-haspopup="true"
           aria-expanded="false">
     <span class="sr-only">{{'labels.menu' | translate}}</span>
-    <i class="fa fa-ellipsis-v"> {{text}}</i>
+    <i class="fa fa-ellipsis-v" [ngClass]="{'mr-xs': hasText()}"></i> {{text}}
   </button>
   <ul *ngIf="open" class="dropdown-menu" role="menu">
     <li *ngFor="let action of actions; let idx = index" role="menuitem">

--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
@@ -25,6 +25,14 @@ export class PopupMenuComponent {
   @Input()
   public actions: PopupMenuAction[];
 
+  private _open: boolean;
+
+  private removeListener: () => void;
+
+  constructor(private renderer: Renderer2,
+              private domElement: ElementRef) {
+  }
+
   public get open(): boolean {
     return this._open;
   }
@@ -36,21 +44,15 @@ export class PopupMenuComponent {
    * @param value True to open the menu, false to close
    */
   public set open(value: boolean) {
-    if (this._open === value) return;
-
+    if (this._open === value) {
+      return;
+    }
     this._open = value;
     if (value) {
       this.removeListener = this.renderer.listen(document, 'click', this.onClick.bind(this));
     } else if (!isNullOrUndefined(this.removeListener)) {
       this.removeListener();
     }
-  }
-
-  private _open: boolean;
-  private removeListener: () => void;
-
-  constructor(private renderer: Renderer2,
-              private domElement: ElementRef) {
   }
 
   /**
@@ -73,6 +75,10 @@ export class PopupMenuComponent {
     event.preventDefault();
 
     action.perform(this.item);
+  }
+
+  hasText(): boolean {
+    return this.text !== null && this.text.length !== 0;
   }
 
 }

--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ElementRef, Renderer2 } from "@angular/core";
 import { isNullOrUndefined } from "util";
 import { PopupMenuAction } from "./popup-menu-action.model";
-
+import { Utils } from "../../shared/Utils";
 /**
  * This component is responsible for displaying a table-row menu button
  * with configurable actions.
@@ -31,6 +31,10 @@ export class PopupMenuComponent {
 
   constructor(private renderer: Renderer2,
               private domElement: ElementRef) {
+  }
+
+  public get hasText(): boolean {
+    return !Utils.isNullOrEmpty(this.text);
   }
 
   public get open(): boolean {
@@ -75,10 +79,6 @@ export class PopupMenuComponent {
     event.preventDefault();
 
     action.perform(this.item);
-  }
-
-  hasText(): boolean {
-    return this.text !== null && this.text.length !== 0;
   }
 
 }

--- a/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/menu/popup-menu.component.ts
@@ -17,6 +17,9 @@ import { PopupMenuAction } from "./popup-menu-action.model";
 export class PopupMenuComponent {
 
   @Input()
+  public text: string = '';
+
+  @Input()
   public item: any;
 
   @Input()

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -104,15 +104,9 @@
         <!-- Student Results Table -->
         <p-dataTable [value]="exams" emptyMessage="{{'labels.groups.results.assessment.exams.empty-message' | translate}}" sortField="student.lastName" tableStyleClass="table table-striped table-hover overflow" expandableRows="true">
           <!-- Row Menu -->
-          <p-column styleClass="cell-dropdown">
-            <ng-template let-data="rowData" pTemplate="body">
-              <popup-menu [item]="data" [actions]="actions"></popup-menu>
-            </ng-template>
-          </p-column>
-
           <p-column sortField="student.lastName" header="{{'labels.groups.results.assessment.exams.cols.name' | translate}}" [sortable]="true">
-            <ng-template let-exam="rowData" pTemplate="body">
-              {{ 'labels.personName' | translate:exam.student }}
+            <ng-template let-data="rowData" let-exam="rowData" pTemplate="body">
+              <popup-menu [item]="data" [actions]="actions" [text]="'labels.personName' | translate:exam.student"></popup-menu>
             </ng-template>
           </p-column>
           <p-column field="date" header="{{'labels.groups.results.assessment.exams.cols.date' | translate}}" [sortable]="true">
@@ -183,9 +177,13 @@
             <span>{{'labels.export.items-by-points-earned' | translate}}</span>
           </button>
         </h3>
-        <p-dataTable [value]="filteredAssessmentItems" sortField="position" tableStyleClass="table table-striped table-hover" [tableStyle]="{'table-layout':'auto'}" expandableRows="true" rowExpandMode="single">
-          <p-column expander="true" styleClass="col-icon"></p-column>
-          <p-column field="position" header="{{'labels.groups.results.assessment.items.cols.number' | translate}}" [sortable]="true"></p-column>
+        <p-dataTable #datatable [value]="filteredAssessmentItems" sortField="position" tableStyleClass="table table-striped table-hover" [tableStyle]="{'table-layout':'auto'}" expandableRows="true" rowExpandMode="single">
+          <p-column field="position" header="{{'labels.groups.results.assessment.items.cols.number' | translate}}" sortable="true">
+            <ng-template let-row="rowData" let-item="rowData" pTemplate="body">
+              <datatable-row-expander [datatable]="datatable" [row]="row" [text]="item.position"></datatable-row-expander>
+            </ng-template>
+          </p-column>
+
           <p-column field="claimTarget" [sortable]="true">
             <ng-template pTemplate="header">
               <span info-label title="{{'labels.groups.results.assessment.items.cols.claim' | translate}}"

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -105,8 +105,8 @@
         <p-dataTable [value]="exams" emptyMessage="{{'labels.groups.results.assessment.exams.empty-message' | translate}}" sortField="student.lastName" tableStyleClass="table table-striped table-hover overflow" expandableRows="true">
           <!-- Row Menu -->
           <p-column sortField="student.lastName" header="{{'labels.groups.results.assessment.exams.cols.name' | translate}}" [sortable]="true">
-            <ng-template let-data="rowData" let-exam="rowData" pTemplate="body">
-              <popup-menu [item]="data" [actions]="actions" [text]="'labels.personName' | translate:exam.student"></popup-menu>
+            <ng-template let-exam="rowData" pTemplate="body">
+              <popup-menu [item]="exam" [actions]="actions" [text]="'labels.personName' | translate:exam.student"></popup-menu>
             </ng-template>
           </p-column>
           <p-column field="date" header="{{'labels.groups.results.assessment.exams.cols.date' | translate}}" [sortable]="true">

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -39,6 +39,7 @@ import { UserService } from "../../user/user.service";
 import { UserMapper } from "../../user/user.mapper";
 import { CachingDataService } from "../../shared/cachingData.service";
 import { ClaimTargetComponent } from "./claim-target.component";
+import { DataTableRowExpanderComponent } from "../../shared/datatable/datatable-row-expander.component";
 
 describe('AssessmentResultsComponent', () => {
   let component: AssessmentResultsComponent;
@@ -79,7 +80,8 @@ describe('AssessmentResultsComponent', () => {
         ScaleScoreComponent,
         AverageScaleScoreComponent,
         TestComponentWrapper,
-        ClaimTargetComponent
+        ClaimTargetComponent,
+        DataTableRowExpanderComponent
       ],
       providers: [ { provide: APP_BASE_HREF, useValue: '/' },
         { provide: Angulartics2, useValue: mockAngulartics2 },

--- a/webapp/src/main/webapp/src/app/shared/Utils.ts
+++ b/webapp/src/main/webapp/src/app/shared/Utils.ts
@@ -1,5 +1,6 @@
 export class Utils {
-  static getPropertyValue( propertyName, object ) {
+
+  static getPropertyValue(propertyName, object): any {
     var parts = propertyName.split("."),
       length = parts.length,
       i,
@@ -8,30 +9,32 @@ export class Utils {
     for (i = 0; i < length; i++) {
       property = property[ parts[ i ] ];
     }
-
     return property;
   }
 
-  static newGuid() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+  static newGuid(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
       return v.toString(16);
     });
   }
 
-  static polarEnumToBoolean(value): boolean {
+  static polarEnumToBoolean(value: any): boolean {
     return value === 1;
   }
 
-  static booleanToPolarEnum(value): string {
-    if(value === true) {
+  static booleanToPolarEnum(value: any): string {
+    if (value === true) {
       return '1';
     }
-
-    if(value === false) {
+    if (value === false) {
       return '2';
     }
-
     return undefined;
   }
+
+  static isNullOrEmpty(value: string): boolean {
+    return value === null || value.length === 0;
+  }
+
 }

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -29,6 +29,7 @@ import { ScaleScoreService } from "./scale-score.service";
 import { LoaderComponent } from "./loader/loader.component";
 import { WindowRefService } from "./window-ref.service";
 import { AuthenticatedHttpService } from "./authentication/authenticated-http.service";
+import { DataTableRowExpanderComponent } from "./datatable/datatable-row-expander.component";
 
 @NgModule({
   declarations: [
@@ -43,7 +44,8 @@ import { AuthenticatedHttpService } from "./authentication/authenticated-http.se
     SearchPipe,
     SessionExpiredComponent,
     SubjectPipe,
-    LoaderComponent
+    LoaderComponent,
+    DataTableRowExpanderComponent
   ],
   imports: [
     AlertModule,
@@ -72,7 +74,8 @@ import { AuthenticatedHttpService } from "./authentication/authenticated-http.se
     SessionExpiredComponent,
     SubjectPipe,
     TranslateModule,
-    LoaderComponent
+    LoaderComponent,
+    DataTableRowExpanderComponent
   ],
   providers: [
     AuthenticatedHttpService,

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
@@ -1,0 +1,1 @@
+<button class="btn btn-info btn-xs btn-block" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !isExpanded(), 'fa-chevron-down': isExpanded()}"></i> {{text}}</button>

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
@@ -1,1 +1,1 @@
-<button class="btn btn-info btn-xs btn-block text-left" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !isExpanded(), 'fa-chevron-down': isExpanded(), 'mr-xs': hasText()}"></i> {{text}}</button>
+<button class="btn btn-info btn-xs btn-block text-left" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !expanded, 'fa-chevron-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.html
@@ -1,1 +1,1 @@
-<button class="btn btn-info btn-xs btn-block" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !isExpanded(), 'fa-chevron-down': isExpanded()}"></i> {{text}}</button>
+<button class="btn btn-info btn-xs btn-block text-left" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !isExpanded(), 'fa-chevron-down': isExpanded(), 'mr-xs': hasText()}"></i> {{text}}</button>

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
@@ -19,12 +19,16 @@ export class DataTableRowExpanderComponent {
   @Input()
   text: string = '';
 
-  toggle() {
+  toggle(): void {
     this.datatable.toggleRow(this.row);
   }
 
-  isExpanded() {
+  isExpanded(): boolean {
     return this.datatable.isRowExpanded(this.row);
+  }
+
+  hasText(): boolean {
+    return this.text !== null && this.text.length !== 0;
   }
 
 }

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { DataTable } from "primeng/components/datatable/datatable";
+import { Utils } from "../Utils";
 
 /**
  * This component is responsible for displaying user notifications.
@@ -23,12 +24,12 @@ export class DataTableRowExpanderComponent {
     this.datatable.toggleRow(this.row);
   }
 
-  isExpanded(): boolean {
+  get expanded(): boolean {
     return this.datatable.isRowExpanded(this.row);
   }
 
-  hasText(): boolean {
-    return this.text !== null && this.text.length !== 0;
+  get hasText(): boolean {
+    return !Utils.isNullOrEmpty(this.text);
   }
 
 }

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input } from "@angular/core";
+import { DataTable } from "primeng/components/datatable/datatable";
+
+/**
+ * This component is responsible for displaying user notifications.
+ */
+@Component({
+  selector: 'datatable-row-expander',
+  templateUrl: 'datatable-row-expander.component.html'
+})
+export class DataTableRowExpanderComponent {
+
+  @Input()
+  datatable: DataTable;
+
+  @Input()
+  row: any;
+
+  @Input()
+  text: string = '';
+
+  toggle() {
+    this.datatable.toggleRow(this.row);
+  }
+
+  isExpanded() {
+    return this.datatable.isRowExpanded(this.row);
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
+++ b/webapp/src/main/webapp/src/app/student/responses/student-responses.component.html
@@ -20,15 +20,17 @@
     </span>
   </div>
 
-  <p-dataTable *ngIf="assessmentItems" [value]="assessmentItems"
+  <p-dataTable #datatable *ngIf="assessmentItems" [value]="assessmentItems"
                emptyMessage="{{'messages.noExamsMatchingCriteria' | translate}}"
                sortField="assessmentItem.position"
                tableStyleClass="table table-striped table-hover"
                rowExpandMode="single"
                expandableRows="true">
-    <p-column expander="true" styleClass="col-icon"></p-column>
-
-    <p-column field="assessmentItem.position" header="{{'labels.groups.results.assessment.items.cols.number' | translate}}" sortable="true"></p-column>
+    <p-column field="assessmentItem.position" header="{{'labels.groups.results.assessment.items.cols.number' | translate}}" sortable="true">
+      <ng-template let-row="rowData" let-item="rowData.assessmentItem" pTemplate="body">
+        <datatable-row-expander [datatable]="datatable" [row]="row" [text]="item.position"></datatable-row-expander>
+      </ng-template>
+    </p-column>
     <p-column field="assessmentItem.claimTarget" [sortable]="true">
       <ng-template pTemplate="header">
               <span info-label title="{{'labels.groups.results.assessment.items.cols.claim' | translate}}"

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
@@ -4,15 +4,9 @@
              sortOrder="-1"
              tableStyleClass="table table-striped table-hover">
   <!-- Menu column -->
-  <p-column styleClass="cell-dropdown">
-    <ng-template let-data="rowData" pTemplate="body">
-      <popup-menu [item]="data" [actions]="actions"></popup-menu>
-    </ng-template>
-  </p-column>
-
   <p-column field="exam.date" header="{{'labels.student.results.cols.date' | translate}}" sortable="true">
-    <ng-template let-exam="rowData.exam" pTemplate="body">
-      {{ exam.date | date }}
+    <ng-template let-data="rowData" let-exam="rowData.exam" pTemplate="body">
+      <popup-menu [item]="data" [actions]="actions" [text]="exam.date | date"></popup-menu>
     </ng-template>
   </p-column>
   <p-column field="assessment.name" header="{{'labels.student.results.cols.assessment' | translate}}" sortable="true"></p-column>


### PR DESCRIPTION
Merged menu icons with first column of tables.
Took some artistic liberty with this and added ```btn-block``` to ```btn``` and ```mr-xs``` to ```<i>```

![image](https://user-images.githubusercontent.com/23462925/30340148-63f23548-97a6-11e7-9323-87a86bbd8e6b.png)

<img width="766" alt="screen shot 2017-09-12 at 10 35 10 am" src="https://user-images.githubusercontent.com/23462925/30340181-7ba696ca-97a6-11e7-8365-6dda3eb99c4d.png">
<img width="763" alt="screen shot 2017-09-12 at 10 35 20 am" src="https://user-images.githubusercontent.com/23462925/30340182-7da6c882-97a6-11e7-9ea8-0ce55d1948d8.png">
<img width="684" alt="screen shot 2017-09-12 at 10 35 40 am" src="https://user-images.githubusercontent.com/23462925/30340187-80ac7770-97a6-11e7-9794-841f0b60cd4a.png">

