### PR TITLE
No longer throwing exception but instead returning a disabled user ob…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -42,7 +42,7 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
 
         final Set<Grant> grants = authorizationService.getGrants(encodedGrants);
 
-		// Secures the application by throwing exception if the user has no authority to access data for this state
+		// Secures the application by setting enabled to false if the user has no authority to access data for this state
         if (grants.isEmpty()) {
             final String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
             logger.warn(message);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -47,7 +47,15 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
             final String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
             logger.warn(message);
 
-            throw new UsernameNotFoundException(message);
+            return User.builder()
+                    .id(id)
+                    .firstName(firstName)
+                    .lastName(lastName)
+                    .email(email)
+                    .username(username)
+                    .password(REDACTED)
+                    .enabled(false)
+                    .build();
         }
 
         final Set<Permission> permissions = authorizationService.getPermissions(grants);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -14,6 +14,8 @@ public class ViewController implements ErrorController {
     public String index(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/landing.html";
+        } else if(!user.isEnabled()) {
+            return "redirect:/error/accessDenied";
         }
 
         return "forward:/index.html";
@@ -26,7 +28,7 @@ public class ViewController implements ErrorController {
     }
 
     @RequestMapping(value="/error/accessDenied", method = { RequestMethod.GET, RequestMethod.POST })
-    public String notPermitted() {
+    public String accessDenied() {
         return "forward:/assets/public/access-denied.html";
     }
 
@@ -34,6 +36,8 @@ public class ViewController implements ErrorController {
     public String error(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/assets/public/error.html";
+        } else if(!user.isEnabled()) {
+            return "redirect:/error/accessDenied";
         }
 
         // Redirect to angular's /error route.


### PR DESCRIPTION
…ject.  Now when navigating to index.html, checking the user is enabled first otherwise sending them to accessDenied.

Users will now be able to successfully log out from the accessDenied page.  They were not before because the authentication does not get added to the SecurityContextHolder if we throw an exception.