### PR TITLE
fix iris pathing

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -18,5 +18,5 @@
       {{ 'labels.assessments.items.tabs.item-viewer-response-not-included' | translate }}
     </span>
   </p>
-  <iframe class="center" #irisframe src="/iris" width="950" height="500" frameborder="0" ></iframe>
+  <iframe class="center" #irisframe src="/iris/" width="950" height="500" frameborder="0" ></iframe>
 </div>


### PR DESCRIPTION
It looks like iris hand-jams it's resource paths based upon the frame source path.  So the previous frame source of "/iris" caused malformed resource requests like "/irisScripts/blahblah" rather than "/iris/Scripts/blahblah"
