### PR TITLE
Bugfix/logout access denied

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -42,7 +42,7 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
 
         final Set<Grant> grants = authorizationService.getGrants(encodedGrants);
 
-		// Secures the application by throwing exception if the user has no authority to access data for this state
+		// Secures the application by setting enabled to false if the user has no authority to access data for this state
         if (grants.isEmpty()) {
             final String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
             logger.warn(message);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -47,7 +47,15 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
             final String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
             logger.warn(message);
 
-            throw new UsernameNotFoundException(message);
+            return User.builder()
+                    .id(id)
+                    .firstName(firstName)
+                    .lastName(lastName)
+                    .email(email)
+                    .username(username)
+                    .password(REDACTED)
+                    .enabled(false)
+                    .build();
         }
 
         final Set<Permission> permissions = authorizationService.getPermissions(grants);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -42,7 +42,7 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
 
         final Set<Grant> grants = authorizationService.getGrants(encodedGrants);
 
-		// Secures the application by setting enabled to false if the user has no authority to access data for this state
+		// Secures the application by returning a user without any permissions, authorities, or groups.
         if (grants.isEmpty()) {
             final String message = String.format("Grants do not permit access to tenant for user \"%s\"", username);
             logger.warn(message);
@@ -54,7 +54,6 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
                     .email(email)
                     .username(username)
                     .password(REDACTED)
-                    .enabled(false)
                     .build();
         }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -14,8 +14,6 @@ public class ViewController implements ErrorController {
     public String index(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/landing.html";
-        } else if(!user.isEnabled()) {
-            return "redirect:/error/accessDenied";
         }
 
         return "forward:/index.html";
@@ -36,8 +34,6 @@ public class ViewController implements ErrorController {
     public String error(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/assets/public/error.html";
-        } else if(!user.isEnabled()) {
-            return "redirect:/error/accessDenied";
         }
 
         // Redirect to angular's /error route.

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -14,6 +14,8 @@ public class ViewController implements ErrorController {
     public String index(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/landing.html";
+        } else if(!user.isEnabled()) {
+            return "redirect:/error/accessDenied";
         }
 
         return "forward:/index.html";
@@ -26,7 +28,7 @@ public class ViewController implements ErrorController {
     }
 
     @RequestMapping(value="/error/accessDenied", method = { RequestMethod.GET, RequestMethod.POST })
-    public String notPermitted() {
+    public String accessDenied() {
         return "forward:/assets/public/access-denied.html";
     }
 
@@ -34,6 +36,8 @@ public class ViewController implements ErrorController {
     public String error(@AuthenticationPrincipal final User user) {
         if (user == null) {
             return "forward:/assets/public/error.html";
+        } else if(!user.isEnabled()) {
+            return "redirect:/error/accessDenied";
         }
 
         // Redirect to angular's /error route.

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -20,13 +20,15 @@ import { Angulartics2Module, Angulartics2GoogleAnalytics } from "angulartics2";
 import { RdwRouteReuseStrategy } from "./shared/rdw-route-reuse.strategy";
 import { ErrorComponent } from './error/error.component';
 import { AuthenticatedHttpService } from "./shared/authentication/authenticated-http.service";
+import { AccessDeniedComponent } from './error/access-denied/access-denied.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     BreadcrumbsComponent,
     HomeComponent,
-    ErrorComponent
+    ErrorComponent,
+    AccessDeniedComponent
   ],
   imports: [
     AlertModule.forRoot(),

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -19,6 +19,8 @@ import { SessionExpiredComponent } from "./shared/authentication/session-expired
 import { ReportsResolve } from "./report/reports.resolve";
 import { ReportsComponent } from "./report/reports.component";
 import { ErrorComponent } from "./error/error.component";
+import { AccessDeniedComponent } from "./error/access-denied/access-denied.component";
+import { AuthorizeAtleastOneCanActivate } from "./user/authorize-at-least-one.can-activate";
 
 
 const studentTestHistoryChildRoute = {
@@ -64,6 +66,7 @@ export const routes: Routes = [
   },
   {
     path: '',
+    canActivate: [ AuthorizeAtleastOneCanActivate ],
     resolve: { user: UserResolve, translateComplete: TranslateResolve },
     children: [
       { path: '', pathMatch: 'full', component: HomeComponent },
@@ -149,5 +152,10 @@ export const routes: Routes = [
         component: ErrorComponent
       }
     ]
+  },
+  {
+    path: 'access-denied',
+    pathMatch: 'full',
+    component: AccessDeniedComponent
   }
 ];

--- a/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.html
+++ b/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.html
@@ -1,0 +1,8 @@
+<div>
+  <h3 class="blue mb-md">{{'messages.access-denied.title' | translate}}</h3>
+  <div class="well">
+    <p>{{'messages.access-denied.message' | translate}}</p>
+    <a class="btn btn-primary" href="javascript:void(0)" onclick="window.document.logout.submit()">{{'messages.logout' | translate}}</a>
+    <form name="logout" method="post" action="/saml/logout" class="hidden"></form>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccessDeniedComponent } from './access-denied.component';
+import { CommonModule } from "../../shared/common.module";
+
+describe('AccessDeniedComponent', () => {
+  let component: AccessDeniedComponent;
+  let fixture: ComponentFixture<AccessDeniedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ CommonModule ],
+      declarations: [ AccessDeniedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AccessDeniedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.ts
+++ b/webapp/src/main/webapp/src/app/error/access-denied/access-denied.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-access-denied',
+  templateUrl: './access-denied.component.html'
+})
+export class AccessDeniedComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/webapp/src/main/webapp/src/app/user/authorize-at-least-one.can-activate.ts
+++ b/webapp/src/main/webapp/src/app/user/authorize-at-least-one.can-activate.ts
@@ -9,19 +9,18 @@ import { UserService } from "./user.service";
 @Injectable()
 export class AuthorizeAtleastOneCanActivate implements CanActivate {
 
-  constructor(private _service : UserService, private router: Router) {
+  constructor(private _service: UserService, private router: Router) {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean>|Promise<boolean>|boolean {
     let observable = this._service.doesCurrentUserHaveAnyPermissions().share();
 
     observable.subscribe(hasPermissions => {
-      if(hasPermissions) {
-        return true;
-      } else {
-        this.router.navigate(['access-denied']);
-        return false;
+      if (!hasPermissions) {
+        this.router.navigate([ 'access-denied' ]);
       }
+
+      return hasPermissions;
     });
 
     return observable;

--- a/webapp/src/main/webapp/src/app/user/authorize-at-least-one.can-activate.ts
+++ b/webapp/src/main/webapp/src/app/user/authorize-at-least-one.can-activate.ts
@@ -1,0 +1,29 @@
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from "@angular/router";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { UserService } from "./user.service";
+
+/*
+ Allows access to a route as long as the permissions are not empty.
+ */
+@Injectable()
+export class AuthorizeAtleastOneCanActivate implements CanActivate {
+
+  constructor(private _service : UserService, private router: Router) {
+  }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean>|Promise<boolean>|boolean {
+    let observable = this._service.doesCurrentUserHaveAnyPermissions().share();
+
+    observable.subscribe(hasPermissions => {
+      if(hasPermissions) {
+        return true;
+      } else {
+        this.router.navigate(['access-denied']);
+        return false;
+      }
+    });
+
+    return observable;
+  }
+}

--- a/webapp/src/main/webapp/src/app/user/user.module.ts
+++ b/webapp/src/main/webapp/src/app/user/user.module.ts
@@ -6,12 +6,13 @@ import { UserMapper } from "./user.mapper";
 import { BrowserModule } from "@angular/platform-browser";
 import { AuthorizeCanActivate } from "./authorize.can-activate";
 import { UserResolve } from "./user.resolve";
+import { AuthorizeAtleastOneCanActivate } from "./authorize-at-least-one.can-activate";
 
 @NgModule({
   declarations: [ AuthorizeDirective ],
   imports: [ CommonModule, BrowserModule ],
   exports: [ AuthorizeDirective ],
-  providers: [ UserMapper, UserService, AuthorizeCanActivate, UserResolve ]
+  providers: [ UserMapper, UserService, AuthorizeCanActivate, AuthorizeAtleastOneCanActivate, UserResolve ]
 })
 export class UserModule {
 }

--- a/webapp/src/main/webapp/src/app/user/user.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/user/user.service.spec.ts
@@ -95,4 +95,23 @@ describe('UserService', () => {
         expect(actual).toBe(false);
       })
     }));
+
+  it('should false if user has no permissions at all',
+    inject([ UserService ], (userService) => {
+      userStub = { permissions: [] };
+
+      userService.doesCurrentUserHaveAnyPermissions().subscribe(actual => {
+        expect(actual).toBe(false);
+      })
+    }));
+
+  it('should false if user has no permissions at all',
+    inject([ UserService ], (userService) => {
+      userStub = { permissions: [ "GROUP_PII_READ" ] };
+
+      userService.doesCurrentUserHaveAnyPermissions().subscribe(actual => {
+        expect(actual).toBe(true);
+      })
+    }));
+
 });

--- a/webapp/src/main/webapp/src/app/user/user.service.ts
+++ b/webapp/src/main/webapp/src/app/user/user.service.ts
@@ -43,6 +43,17 @@ export class UserService {
     return this.currentUserObservable;
   }
 
+  doesCurrentUserHaveAnyPermissions(): Observable<boolean> {
+    return new Observable(observer => {
+      this.getCurrentUser().subscribe(user => {
+        observer.next(!isNullOrUndefined(user)
+          ? user.permissions.length !== 0
+          : false);
+        observer.complete();
+      });
+    });
+  }
+
   doesCurrentUserHaveAtLeastOnePermission(permissions: string[]): Observable<boolean> {
     return new Observable(observer => {
       this.getCurrentUser().subscribe(user => {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -19,6 +19,10 @@
       "title": "Authentication Expired",
       "message": "Click Ok to re-authenticate."
     },
+    "access-denied": {
+      "title": "Access Denied",
+      "message": "Your user account is not permitted to access this reporting system. If you believe you have reached this page in error, please contact your building administrator."
+    },
     "toggle-navigation": "Toggle navigation",
     "no-item-level-data": "Item level data is not available for tests administered prior to 2017-18 school year.",
     "coming-soon": "{{featureName}} is coming soon.",


### PR DESCRIPTION
Now redirecting to an angular access-denied route if a user is able to authenticate but is not authorized with any permissions.  By not throwing an exception, this allows the session to still get added to the `SecurityContextHolder` and allow for a successful logout.

![image](https://user-images.githubusercontent.com/5771116/30460855-875192da-996e-11e7-802d-2fc812715860.png)
