### PR TITLE
Add expanded UserPermissions to BatchExamReportRequestHolder

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 /**
  * Holds common methods for preparing SQL queries and parsing their results
@@ -24,8 +26,8 @@ public class QueryUtils {
     public static final List<Long> UNMATCHABLE_IDS = ImmutableList.of(-1L);
     private static final Map<String, String> PERMISSION_PREFIXES = ImmutableMap
             .<String, String>builder()
-            .put("GROUP_PII_READ", "group_")
-            .put("INDIVIDUAL_PII_READ", "individual_")
+            .put(GroupPiiRead, "group_")
+            .put(IndividualPiiRead, "individual_")
             .build();
 
     private QueryUtils() {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/BatchExamReportRequestHolder.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/BatchExamReportRequestHolder.java
@@ -9,6 +9,7 @@ public class BatchExamReportRequestHolder {
 
     private String id;
     private PermissionScope permissionScope;
+    private UserPermissions userPermissions;
     private String user;
     private String label;
 
@@ -20,12 +21,14 @@ public class BatchExamReportRequestHolder {
      */
     private BatchExamReportRequestHolder() {}
 
-    public BatchExamReportRequestHolder(final AbstractBatchExamReportRequest<PrintOptions> request,
+    public BatchExamReportRequestHolder(final AbstractExamReportRequest<PrintOptions> request,
                                         final PermissionScope permissionScope,
+                                        final UserPermissions userPermissions,
                                         final String user,
                                         final String label) {
         this.id = UUID.randomUUID().toString();
         this.permissionScope = permissionScope;
+        this.userPermissions = userPermissions;
         this.request = request;
         this.user = user;
         this.label = label;
@@ -37,6 +40,10 @@ public class BatchExamReportRequestHolder {
 
     public PermissionScope getPermissionScope() {
         return permissionScope;
+    }
+
+    public UserPermissions getUserPermissions() {
+        return userPermissions;
     }
 
     public AbstractExamReportRequest<PrintOptions> getRequest() {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/UserPermissions.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/UserPermissions.java
@@ -1,0 +1,58 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * This class is responsible for containing the user's granted permissions
+ * within the context of the Reporting application suite.
+ */
+public class UserPermissions {
+
+    private Map<String, Permission> permissionsById;
+    private Map<Long, GroupGrant> groupsById;
+
+    /**
+     * @return The user permissions by scope
+     */
+    public Map<String, Permission> getPermissionsById() {
+        return permissionsById == null ? Collections.emptyMap() : permissionsById;
+    }
+
+    /**
+     * @return The group grants by group id
+     */
+    public Map<Long, GroupGrant> getGroupsById() {
+        return groupsById == null ? Collections.emptyMap() : groupsById;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Map<String, Permission> permissionsById;
+        private Map<Long, GroupGrant> groupsById;
+
+        public UserPermissions build() {
+            final UserPermissions permissions = new UserPermissions();
+            permissions.groupsById = ImmutableMap.copyOf(groupsById);
+            permissions.permissionsById = ImmutableMap.copyOf(permissionsById);
+            return permissions;
+        }
+
+        public Builder permissionsById(final Map<String, Permission> permissionsById) {
+            this.permissionsById = permissionsById;
+            return this;
+        }
+
+        public Builder groupsById(final Map<Long, GroupGrant> groupsById) {
+            this.groupsById = groupsById;
+            return this;
+        }
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Permission.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.reporting.common.security;
 import com.google.common.base.MoreObjects;
 
 import javax.validation.constraints.NotNull;
-
 import java.io.Serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -22,6 +21,13 @@ public class Permission implements Serializable {
      * The scope or access level the permission is granted for
      */
     private final PermissionScope scope;
+
+    /**
+     * No-arg contructor for JSON serialization and deserialization
+     */
+    private Permission() {
+        this("UNKNOWN", PermissionScope.EMPTY);
+    }
 
     public Permission(
             @NotNull final String id,

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/ReportingRoles.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/ReportingRoles.java
@@ -1,0 +1,11 @@
+package org.opentestsystem.rdw.reporting.common.security;
+
+/**
+ * Security roles used by the reporting application suite.
+ */
+public class ReportingRoles {
+
+    public static String IndividualPiiRead = "INDIVIDUAL_PII_READ";
+    public static String GroupPiiRead = "GROUP_PII_READ";
+
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/PermissionScopes.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/PermissionScopes.java
@@ -9,6 +9,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
 /**
  * Testing utilities for dealing with permission scopes
  */
@@ -27,11 +30,11 @@ public final class PermissionScopes {
     }
 
     public static Permission groupOf(PermissionScope scope) {
-        return new Permission("GROUP_PII_READ", scope);
+        return new Permission(GroupPiiRead, scope);
     }
 
     public static Permission individualOf(PermissionScope scope) {
-        return new Permission("INDIVIDUAL_PII_READ", scope);
+        return new Permission(IndividualPiiRead, scope);
     }
 
     public static PermissionScope statewide() {

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.processor.service;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,12 +11,15 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.stream.FetchStudentsSource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 
 import java.time.Instant;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -25,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.FAILED;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.PENDING;
 import static org.opentestsystem.rdw.reporting.common.security.PermissionScope.STATEWIDE;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SpringStreamReportGeneratorTest {
@@ -99,9 +104,15 @@ public class SpringStreamReportGeneratorTest {
                 .gradeId(7)
                 .build();
 
+        final UserPermissions userPermissions = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(IndividualPiiRead, new Permission(IndividualPiiRead, STATEWIDE)))
+                .groupsById(Collections.emptyMap())
+                .build();
+
         return new BatchExamReportRequestHolder(
                 reportRequest,
                 STATEWIDE,
+                userPermissions,
                 "user",
                 "label"
         );

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -9,6 +10,8 @@ import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.common.web.ReportContentResource;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
@@ -25,6 +28,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,6 +44,8 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.PermissionScope.STATEWIDE;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -79,9 +85,15 @@ public class ReportControllerIT {
         when(reportGenerator.generateReport(any(BatchExamReportRequestHolder.class)))
                 .thenReturn(report);
 
+        final UserPermissions userPermissions = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(IndividualPiiRead, new Permission(IndividualPiiRead, STATEWIDE)))
+                .groupsById(Collections.emptyMap())
+                .build();
+
         final BatchExamReportRequestHolder requestHolder = new BatchExamReportRequestHolder(
                 (SchoolGradeExamReportRequest)report.getReportRequest(),
                 PermissionScope.STATEWIDE,
+                userPermissions,
                 "user",
                 "label"
         );

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
@@ -7,16 +7,18 @@ import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHold
 import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.report.client.ReportWebServiceClient;
-import org.opentestsystem.rdw.reporting.search.group.GroupRepository;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
-import java.io.OutputStream;
 import java.util.List;
+
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 @Service
 class DefaultExamReportService implements ExamReportService {
@@ -30,13 +32,13 @@ class DefaultExamReportService implements ExamReportService {
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final SchoolGradeExamReportRequest request) {
-        final PermissionScope permissionScope = user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope();
+        final PermissionScope permissionScope = user.getPermissionsById().get(IndividualPiiRead).getScope();
         return createReport(user, request, permissionScope);
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final GroupExamReportRequest request) {
-        final PermissionScope permissionScope = user.getPermissionsById().get("GROUP_PII_READ").getScope();
+        final PermissionScope permissionScope = user.getPermissionsById().get(GroupPiiRead).getScope();
         return createReport(user, request, permissionScope);
     }
 
@@ -60,8 +62,13 @@ class DefaultExamReportService implements ExamReportService {
             @NotNull final T request,
             @NotNull final PermissionScope permissionScope) {
 
+        final UserPermissions userPermissions = UserPermissions.builder()
+                .permissionsById(user.getPermissionsById())
+                .groupsById(user.getGroupsById())
+                .build();
+
         final BatchExamReportRequestHolder holder = new BatchExamReportRequestHolder(
-                request, permissionScope, user.getUsername(), request.getName());
+                request, permissionScope, userPermissions, user.getUsername(), request.getName());
 
         return client.createReport(holder);
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/assessmentgrade/DefaultAssessmentGradeService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/assessmentgrade/DefaultAssessmentGradeService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
 @Service("schoolGradeDefaultGradeService")
 class DefaultAssessmentGradeService implements AssessmentGradeService {
 
@@ -22,7 +24,7 @@ class DefaultAssessmentGradeService implements AssessmentGradeService {
     @Override
     public Set<Grade> getAssessmentGradesInSchool(@NotNull final User user, final long schoolId) {
         return ImmutableSet.copyOf(repository.findAllForSchool(
-                user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope(),
+                user.getPermissionsById().get(IndividualPiiRead).getScope(),
                 schoolId
         ));
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupAssessmentService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupAssessmentService.java
@@ -12,6 +12,8 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+
 @Service
 class DefaultGroupAssessmentService implements GroupAssessmentService {
 
@@ -27,7 +29,7 @@ class DefaultGroupAssessmentService implements GroupAssessmentService {
     }
 
     public Optional<GroupAssessment> getLatestAssessment(@NotNull final User user, @NotNull final GroupAssessmentSearch search) {
-        final Assessment assessment = repository.findLatest(user.getPermissionsById().get("GROUP_PII_READ").getScope(), search);
+        final Assessment assessment = repository.findLatest(user.getPermissionsById().get(GroupPiiRead).getScope(), search);
         if (assessment == null) {
             return Optional.empty();
         }
@@ -43,7 +45,7 @@ class DefaultGroupAssessmentService implements GroupAssessmentService {
     }
 
     public List<Assessment> getAllAssessments(@NotNull final User user, @NotNull final GroupAssessmentSearch search) {
-        return ImmutableList.copyOf(repository.findAll(user.getPermissionsById().get("GROUP_PII_READ").getScope(), search));
+        return ImmutableList.copyOf(repository.findAll(user.getPermissionsById().get(GroupPiiRead).getScope(), search));
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupExamItemService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+
 @Service
 class DefaultGroupExamItemService implements GroupExamItemService {
 
@@ -28,7 +30,7 @@ class DefaultGroupExamItemService implements GroupExamItemService {
     public GroupExamItemScores getExamItemScores(@NotNull final User user, @NotNull final GroupExamSearch search) {
         final List<AssessmentItem> assessmentItems = assessmentItemRepository.findAllForAssessment(search.getAssessmentId());
         final List<ExamItem> examItems = examItemRepository
-                .findAllExamItemScoresForAssessment(user.getPermissionsById().get("GROUP_PII_READ").getScope(), search);
+                .findAllExamItemScoresForAssessment(user.getPermissionsById().get(GroupPiiRead).getScope(), search);
         return new GroupExamItemScores(assessmentItems, examItems);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/DefaultGroupExamService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+
 @Service
 class DefaultGroupExamService implements GroupExamService {
 
@@ -21,7 +23,7 @@ class DefaultGroupExamService implements GroupExamService {
 
     public List<Exam> getExams(@NotNull final User user, @NotNull final GroupExamSearch search) {
         return ImmutableList.copyOf(repository.findAllForAssessment(
-                user.getPermissionsById().get("GROUP_PII_READ").getScope(), search));
+                user.getPermissionsById().get(GroupPiiRead).getScope(), search));
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeAssessmentService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeAssessmentService.java
@@ -3,8 +3,8 @@ package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 import com.google.common.collect.ImmutableList;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
-import org.opentestsystem.rdw.reporting.exam.GroupAssessment;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.exam.GroupAssessment;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
+
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 @Service
 class DefaultSchoolGradeAssessmentService implements SchoolGradeAssessmentService {
@@ -28,7 +30,7 @@ class DefaultSchoolGradeAssessmentService implements SchoolGradeAssessmentServic
     }
 
     public Optional<GroupAssessment> getLatestAssessment(@NotNull final User user, @NotNull final SchoolGradeAssessmentSearch search) {
-        final PermissionScope securityContext = user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope();
+        final PermissionScope securityContext = user.getPermissionsById().get(IndividualPiiRead).getScope();
         final Assessment assessment = repository.findLatest(securityContext, search);
         if (assessment == null) {
             return Optional.empty();
@@ -47,7 +49,7 @@ class DefaultSchoolGradeAssessmentService implements SchoolGradeAssessmentServic
 
     public List<Assessment> getAllAssessments(@NotNull final User user, @NotNull final SchoolGradeAssessmentSearch search) {
         return ImmutableList.copyOf(repository.findAll(
-                user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope(),
+                user.getPermissionsById().get(IndividualPiiRead).getScope(),
                 search
         ));
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeExamItemService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeExamItemService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
 @Service
 class DefaultSchoolGradeExamItemService implements SchoolGradeExamItemService {
 
@@ -28,7 +30,7 @@ class DefaultSchoolGradeExamItemService implements SchoolGradeExamItemService {
     public GroupExamItemScores getExamItemScores(@NotNull final User user, @NotNull final SchoolGradeExamSearch search) {
         final List<AssessmentItem> assessmentItems = assessmentItemRepository.findAllForAssessment(search.getAssessmentId());
         final List<ExamItem> examItems = examItemRepository.findAllExamItemScoresForAssessment(
-                user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope(), search);
+                user.getPermissionsById().get(IndividualPiiRead).getScope(), search);
         return new GroupExamItemScores(assessmentItems, examItems);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeExamService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/DefaultSchoolGradeExamService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
 @Service
 class DefaultSchoolGradeExamService implements SchoolGradeExamService {
 
@@ -21,7 +23,7 @@ class DefaultSchoolGradeExamService implements SchoolGradeExamService {
 
     public List<Exam> getExams(@NotNull final User user, @NotNull final SchoolGradeExamSearch search) {
         return ImmutableList.copyOf(repository.findAllForAssessment(
-                user.getPermissionsById().get("INDIVIDUAL_PII_READ").getScope(),
+                user.getPermissionsById().get(IndividualPiiRead).getScope(),
                 search
         ));
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/group/DefaultGroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/group/DefaultGroupService.java
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Sets.newHashSet;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 
 @Service
 public class DefaultGroupService implements GroupService {
@@ -22,7 +21,7 @@ public class DefaultGroupService implements GroupService {
     }
 
     public Set<Group> getGroups(@NotNull final User user) {
-        if (!user.getPermissionsById().containsKey("GROUP_PII_READ")) {
+        if (!user.getPermissionsById().containsKey(GroupPiiRead)) {
             return ImmutableSet.of();
         }
         return ImmutableSet.copyOf(groupRepository.findAllForUsername(user.getUsername(), user.getGroupsById().keySet()));

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/school/DefaultSchoolService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/school/DefaultSchoolService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
 @Service("schoolGradeDefaultSchoolService")
 class DefaultSchoolService implements SchoolService {
 
@@ -22,7 +24,7 @@ class DefaultSchoolService implements SchoolService {
 
     @Override
     public Set<School> getSchools(@NotNull final User user) {
-        final Permission permission = user.getPermissionsById().get("INDIVIDUAL_PII_READ");
+        final Permission permission = user.getPermissionsById().get(IndividualPiiRead);
         if (permission == null) {
             return ImmutableSet.of();
         }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationService.java
@@ -4,9 +4,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.security.Authorities;
-import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.security.Grant;
 import org.opentestsystem.rdw.security.service.PermissionService;
 import org.opentestsystem.rdw.security.service.PermissionServiceException;
@@ -29,6 +29,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newLinkedHashSet;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.DISTRICT;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.INSTITUTION;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.STATE;
@@ -161,7 +162,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
     @Override
     public Set<GroupGrant> getGroups(final Collection<Permission> permissions, final String username) {
         // only lookup groups for those with the group PII permission
-        if (permissions.stream().noneMatch(permission -> permission.getId().equals("GROUP_PII_READ"))) {
+        if (permissions.stream().noneMatch(permission -> permission.getId().equals(GroupPiiRead))) {
             return ImmutableSet.of();
         }
         return ImmutableSet.copyOf(groupMembershipRepository.findAllForUsername(username));

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/DefaultStudentExamServiceTest.java
@@ -5,12 +5,12 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
-import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.exam.Organization;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.individualOf;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.permissions;
 
@@ -45,7 +46,7 @@ public class DefaultStudentExamServiceTest {
 
         when(user.getPermissionsById())
                 .thenReturn(ImmutableMap.of(
-                        "GROUP_PII_READ", new Permission("GROUP_PII_READ", PermissionScope.STATEWIDE)
+                        GroupPiiRead, new Permission(GroupPiiRead, PermissionScope.STATEWIDE)
                 ));
 
         this.service = new DefaultStudentExamService(studentRepository, examRepository);

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/ReportingExamItemServiceTest.java
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 
 @RunWith(SpringRunner.class)
 public class ReportingExamItemServiceTest {
@@ -40,7 +41,7 @@ public class ReportingExamItemServiceTest {
     public void setup() {
         when(user.getPermissionsById())
                 .thenReturn(ImmutableMap.of(
-                        "GROUP_PII_READ", new Permission("GROUP_PII_READ", PermissionScope.STATEWIDE)
+                        GroupPiiRead, new Permission(GroupPiiRead, PermissionScope.STATEWIDE)
                 ));
         service = new ReportingExamItemService(examItemRepository, assessmentItemRepository);
     }

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/group/DefaultGroupServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/group/DefaultGroupServiceTest.java
@@ -12,11 +12,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.List;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 
 
 @RunWith(SpringRunner.class)
@@ -54,7 +53,7 @@ public class DefaultGroupServiceTest {
                         10L, new GroupGrant(10L, 1)
                 ))
                 .permissionsById(ImmutableMap.of(
-                        "GROUP_PII_READ", new Permission("GROUP_PII_READ", PermissionScope.STATEWIDE)
+                        GroupPiiRead, new Permission(GroupPiiRead, PermissionScope.STATEWIDE)
                 ));
     }
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/school/DefaultSchoolServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/school/DefaultSchoolServiceTest.java
@@ -5,8 +5,8 @@ import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 
 @RunWith(SpringRunner.class)
@@ -33,14 +34,14 @@ public class DefaultSchoolServiceTest {
     public void before() {
         when(user.getPermissionsById())
                 .thenReturn(ImmutableMap.of(
-                        "INDIVIDUAL_PII_READ", new Permission("INDIVIDUAL_PII_READ", PermissionScope.STATEWIDE)
+                        IndividualPiiRead, new Permission(IndividualPiiRead, PermissionScope.STATEWIDE)
                 ));
         this.service = new DefaultSchoolService(repository);
     }
 
     @Test
     public void getSchoolsShouldForwardCorrectPermission() throws Exception {
-        final Permission permission = new Permission("INDIVIDUAL_PII_READ", PermissionScope.STATEWIDE);
+        final Permission permission = new Permission(IndividualPiiRead, PermissionScope.STATEWIDE);
         when(user.getPermissionsById()).thenReturn(Maps.uniqueIndex(newArrayList(permission), Permission::getId));
 
         service.getSchools(user);

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/security/auth/DefaultAuthorizationServiceTest.java
@@ -7,8 +7,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.security.Grant;
 import org.opentestsystem.rdw.security.service.PermissionService;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.DISTRICT;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.INSTITUTION;
 import static org.opentestsystem.rdw.security.Grant.EntityLevel.STATE;
@@ -224,7 +225,7 @@ public class DefaultAuthorizationServiceTest {
 
     @Test
     public void getGroupsByIdShouldReturnAllOfTheGroupsAssociatedWithTheUsernameForUsersWithGroupPII() throws Exception {
-        assertThat(authorizationService.getGroups(ImmutableSet.of(new Permission("GROUP_PII_READ", PermissionScope.STATEWIDE)), "a"))
+        assertThat(authorizationService.getGroups(ImmutableSet.of(new Permission(GroupPiiRead, PermissionScope.STATEWIDE)), "a"))
                 .containsExactlyInAnyOrder(new GroupGrant(1L, 1));
     }
 


### PR DESCRIPTION
Add constants for well-known reporting roles.

This PR adds expanded user permissions to the request sent from the reporting webapp to the report processor.  This is in support of generating single-student reports which require more than just INDIVIDUAL_PII_READ permissions.