### PR TITLE
Generate a single-student report with unspecified individual/group pe…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
@@ -4,8 +4,10 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -104,6 +106,7 @@ public class QueryUtils {
         params.put("grade_id", examQueryParams.getGradeId());
         params.put("group_id", examQueryParams.getGroupId());
         params.put("school_year", examQueryParams.getSchoolYear());
+        params.put("student_id", examQueryParams.getStudentId());
         return params;
     }
 
@@ -140,6 +143,39 @@ public class QueryUtils {
             return null;
         }
         return ImmutableList.copyOf(Splitter.on(delimiter).split(delimitedValues));
+    }
+
+    /**
+     * Retrieve the correct security parameters for the given user permissions
+     * and exam query permission type.
+     *
+     * @param userPermissions       The requesting user's permissions
+     * @param queryPermissionType   The query permission type
+     * @return The appropriate security parameters
+     */
+    public static Map<String, Object> getSecurityParameters(final UserPermissions userPermissions,
+                                                            final ExamQueryParams.ExamQueryPermissionType queryPermissionType) {
+        switch (queryPermissionType) {
+            case Unknown:
+                return new MapSqlParameterSource()
+                        .addValues(getSecurityParameters(userPermissions.getPermissionsById()))
+                        .addValue("group_ids", nullOrEmptyToDefault(userPermissions.getGroupsById().keySet(), UNMATCHABLE_IDS))
+                        .getValues();
+            case Individual:
+                final Permission individualPiiPermission = userPermissions.getPermissionsById().get(IndividualPiiRead);
+                final PermissionScope individualScope = individualPiiPermission == null ? PermissionScope.EMPTY : individualPiiPermission.getScope();
+                return new MapSqlParameterSource()
+                        .addValues(getSecurityParameters(individualScope))
+                        .getValues();
+            case Group:
+                final Permission groupPiiPermission = userPermissions.getPermissionsById().get(GroupPiiRead);
+                final PermissionScope groupScope = groupPiiPermission == null ? PermissionScope.EMPTY : groupPiiPermission.getScope();
+                return new MapSqlParameterSource()
+                        .addValues(getSecurityParameters(groupScope))
+                        .getValues();
+            default:
+                throw new IllegalArgumentException("Unknown query permission type: " + queryPermissionType);
+        }
     }
 
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExamQueryParams.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExamQueryParams.java
@@ -13,6 +13,8 @@ public class ExamQueryParams {
     private Integer gradeId;
     private Long groupId;
     private Integer schoolYear;
+    private Long studentId;
+    private ExamQueryPermissionType queryPermissionType;
 
     /**
      * @return The exam subject
@@ -56,6 +58,20 @@ public class ExamQueryParams {
         return schoolYear;
     }
 
+    /**
+     * @return The target student's id
+     */
+    public Long getStudentId() {
+        return studentId;
+    }
+
+    /**
+     * @return The exam query type
+     */
+    public ExamQueryPermissionType getQueryPermissionType() {
+        return queryPermissionType;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -67,6 +83,8 @@ public class ExamQueryParams {
         private Integer gradeId;
         private Long groupId;
         private Integer schoolYear;
+        private Long studentId;
+        private ExamQueryPermissionType queryPermissionType;
 
         public ExamQueryParams build() {
             final ExamQueryParams examQueryParams = new ExamQueryParams();
@@ -76,6 +94,8 @@ public class ExamQueryParams {
             examQueryParams.gradeId = gradeId;
             examQueryParams.groupId = groupId;
             examQueryParams.schoolYear = schoolYear;
+            examQueryParams.studentId = studentId;
+            examQueryParams.queryPermissionType = queryPermissionType;
             return examQueryParams;
         }
 
@@ -108,5 +128,21 @@ public class ExamQueryParams {
             this.schoolYear = schoolYear;
             return this;
         }
+
+        public Builder studentId(final Long studentId) {
+            this.studentId = studentId;
+            return this;
+        }
+
+        public Builder queryPermissionType(final ExamQueryPermissionType queryPermissionType) {
+            this.queryPermissionType = queryPermissionType;
+            return this;
+        }
+    }
+
+    public enum ExamQueryPermissionType {
+        Unknown,
+        Individual,
+        Group
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExamReportRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExamReportRepository.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.reporting.common.report;
 
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
@@ -30,12 +29,12 @@ public interface ExamReportRepository<T extends AbstractExamReport> {
     /**
      * Find all exams for students by school id and school year.
      *
-     * @param permissionScope   The user permission scope
+     * @param userPermissions   The user permissions
      * @param studentIds        The student ids
-     * @param examQueryParams        The request filter
+     * @param examQueryParams   The request filter
      * @return  Exams for each student id, mapped by subject
      */
-    Map<Long, Map<Subject, T>> findAllForStudentsByExamFilter(@NotNull PermissionScope permissionScope,
+    Map<Long, Map<Subject, T>> findAllForStudentsByExamFilter(@NotNull UserPermissions userPermissions,
                                                               Collection<Long> studentIds,
                                                               ExamQueryParams examQueryParams);
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequest.java
@@ -1,8 +1,5 @@
-package org.opentestsystem.rdw.reporting.report.student;
+package org.opentestsystem.rdw.reporting.common.report;
 
-
-import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
-import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 
 public class StudentExamReportRequest extends AbstractExamReportRequest<PrintOptions> {
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/UserPermissions.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/UserPermissions.java
@@ -40,8 +40,8 @@ public class UserPermissions {
 
         public UserPermissions build() {
             final UserPermissions permissions = new UserPermissions();
-            permissions.groupsById = ImmutableMap.copyOf(groupsById);
-            permissions.permissionsById = ImmutableMap.copyOf(permissionsById);
+            permissions.groupsById = groupsById == null ? Collections.emptyMap() : ImmutableMap.copyOf(groupsById);
+            permissions.permissionsById = permissionsById == null ? Collections.emptyMap() : ImmutableMap.copyOf(permissionsById);
             return permissions;
         }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/iab/JdbcIabReportRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/iab/JdbcIabReportRepository.java
@@ -13,8 +13,8 @@ import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.StudentEnrollments;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -39,14 +39,17 @@ class JdbcIabReportRepository implements IabReportRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    @Value("${sql.exam.findAllIabsByStudentIdAndSchoolYear}")
-    private String findAllIabsByStudentIdAndSchoolYear;
+    @Value("${sql.exam.findAllIabsByStudentIdAndSchoolYearAndSubject}")
+    private String findAllIabsByStudentIdAndSchoolYearAndSubject;
 
-    @Value("${sql.exam.findAllIabsByStudentIdsAndQueryParams}")
-    private String findAllIabsByStudentIdsAndQueryParams;
+    @Value("${sql.exam.findAllIabsByStudentIdsAndQueryParamsUnknownPermissions}")
+    private String findAllIabsByStudentIdsAndQueryParamsUnknownPermissions;
 
-    @Value("${sql.exam.findAllIabsByStudentIdsAndQueryParamsWithGroup}")
-    private String findAllIabsByStudentIdsAndQueryParamsWithGroup;
+    @Value("${sql.exam.findAllIabsByStudentIdsAndQueryParamsIndividualPermissions}")
+    private String findAllIabsByStudentIdsAndQueryParamsIndividualPermissions;
+
+    @Value("${sql.exam.findAllIabsByStudentIdsAndQueryParamsGroupPermissions}")
+    private String findAllIabsByStudentIdsAndQueryParamsGroupPermissions;
 
     @Value("${app.state.code}")
     private String stateCode;
@@ -59,7 +62,7 @@ class JdbcIabReportRepository implements IabReportRepository {
     @Override
     public IabReport findOneByStudentIdAndSchoolYear(
             @NotNull final Map<String, Permission> permissions,
-            Set<Long> groupIds,
+            final Set<Long> groupIds,
             final long studentId,
             final int schoolYear,
             final int subjectId) {
@@ -72,7 +75,7 @@ class JdbcIabReportRepository implements IabReportRepository {
                 .build();
 
         template.query(
-                findAllIabsByStudentIdAndSchoolYear,
+                findAllIabsByStudentIdAndSchoolYearAndSubject,
                 ImmutableMap.<String, Object>builder()
                         .putAll(getSecurityParameters(permissions))
                         .put("group_ids", nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
@@ -104,18 +107,19 @@ class JdbcIabReportRepository implements IabReportRepository {
 
     @Override
     public Map<Long, Map<Subject, IabReport>> findAllForStudentsByExamFilter(
-            @NotNull final PermissionScope permissionScope,
+            @NotNull final UserPermissions userPermissions,
             final Collection<Long> studentIds,
             final ExamQueryParams examQueryParams) {
 
         final Map<Long, Map<Subject, IabReport.Builder>> studentReportBuilders = new HashMap<>();
         final Map<Long, Map<Subject, Multimap<Assessment, Exam>>> studentReportAssessments = new HashMap<>();
 
-        final String query = examQueryParams.getGroupId() == null ? findAllIabsByStudentIdsAndQueryParams : findAllIabsByStudentIdsAndQueryParamsWithGroup;
+        final String query = getExamFilterQuery(examQueryParams.getQueryPermissionType());
+
         template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams))
                         .addValue("student_ids", studentIds),
                 (row) -> {
@@ -153,12 +157,10 @@ class JdbcIabReportRepository implements IabReportRepository {
         // Collate the assessments/exams into reports
         final Map<Long, Map<Subject, IabReport>> reportsByStudent = new HashMap<>();
 
-        studentReportBuilders.entrySet().forEach((studentEntry) -> {
-            final long studentId = studentEntry.getKey();
+        studentReportBuilders.forEach((key, value) -> {
+            final long studentId = key;
 
-            studentEntry.getValue().entrySet().forEach((subjectEntry) -> {
-                final Subject subject = subjectEntry.getKey();
-                final IabReport.Builder builder = subjectEntry.getValue();
+            value.forEach((subject, builder) -> {
 
                 final Multimap<Assessment, Exam> assessmentsBySubject = studentReportAssessments
                         .getOrDefault(studentId, new HashMap<>())
@@ -173,6 +175,19 @@ class JdbcIabReportRepository implements IabReportRepository {
         });
 
         return reportsByStudent;
+    }
+
+    private String getExamFilterQuery(final ExamQueryParams.ExamQueryPermissionType queryType) {
+        switch (queryType) {
+            case Unknown:
+                return findAllIabsByStudentIdsAndQueryParamsUnknownPermissions;
+            case Individual:
+                return findAllIabsByStudentIdsAndQueryParamsIndividualPermissions;
+            case Group:
+                return findAllIabsByStudentIdsAndQueryParamsGroupPermissions;
+            default:
+                throw new IllegalArgumentException("Unknown query permission type: " + queryType);
+        }
     }
 
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ica/JdbcIcaReportRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ica/JdbcIcaReportRepository.java
@@ -10,8 +10,8 @@ import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.StudentEnrollments;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -36,14 +36,17 @@ class JdbcIcaReportRepository implements IcaReportRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    @Value("${sql.exam.findLatestIcaByStudentIdAndSchoolYear}")
-    private String findLatestIcaByStudentIdAndSchoolYear;
+    @Value("${sql.exam.findLatestIcaByStudentIdAndSchoolYearAndSubject}")
+    private String findLatestIcaByStudentIdAndSchoolYearAndSubject;
 
-    @Value("${sql.exam.findAllIcasByStudentIdsAndQueryParams}")
-    private String findAllIcasByStudentIdsAndQueryParams;
+    @Value("${sql.exam.findAllIcasByStudentIdsAndQueryParamsUnknownPermissions}")
+    private String findAllIcasByStudentIdsAndQueryParamsUnknownPermissions;
 
-    @Value("${sql.exam.findAllIcasByStudentIdsAndQueryParamsWithGroup}")
-    private String findAllIcasByStudentIdsAndQueryParamsWithGroup;
+    @Value("${sql.exam.findAllIcasByStudentIdsAndQueryParamsIndividualPermissions}")
+    private String findAllIcasByStudentIdsAndQueryParamsIndividualPermissions;
+
+    @Value("${sql.exam.findAllIcasByStudentIdsAndQueryParamsGroupPermissions}")
+    private String findAllIcasByStudentIdsAndQueryParamsGroupPermissions;
 
     @Value("${app.state.code}")
     private String stateCode;
@@ -56,14 +59,14 @@ class JdbcIcaReportRepository implements IcaReportRepository {
     @Override
     public IcaReport findOneByStudentIdAndSchoolYear(
             @NotNull final Map<String, Permission> permissions,
-            Set<Long> groupIds,
+            final Set<Long> groupIds,
             final long studentId,
             final int schoolYear,
             final int subjectId) {
 
         try {
             return template.queryForObject(
-                    findLatestIcaByStudentIdAndSchoolYear,
+                    findLatestIcaByStudentIdAndSchoolYearAndSubject,
                     ImmutableMap.<String, Object>builder()
                             .putAll(getSecurityParameters(permissions))
                             .put("group_ids", nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
@@ -88,17 +91,17 @@ class JdbcIcaReportRepository implements IcaReportRepository {
 
     @Override
     public Map<Long, Map<Subject, IcaReport>> findAllForStudentsByExamFilter(
-            @NotNull final PermissionScope permissionScope,
+            @NotNull final UserPermissions userPermissions,
             final Collection<Long> studentIds,
             final ExamQueryParams examQueryParams) {
 
         final Map<Long, Map<Subject, IcaReport>> reportsByStudent = new HashMap<>();
-        final String query = examQueryParams.getGroupId() == null ? findAllIcasByStudentIdsAndQueryParams : findAllIcasByStudentIdsAndQueryParamsWithGroup;
+        final String query = getExamFilterQuery(examQueryParams.getQueryPermissionType());
 
         template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams))
                         .addValue("student_ids", studentIds),
                 (row) -> {
@@ -120,6 +123,19 @@ class JdbcIcaReportRepository implements IcaReportRepository {
         );
 
         return reportsByStudent;
+    }
+
+    private String getExamFilterQuery(final ExamQueryParams.ExamQueryPermissionType queryPermissionType) {
+        switch (queryPermissionType) {
+            case Unknown:
+                return findAllIcasByStudentIdsAndQueryParamsUnknownPermissions;
+            case Individual:
+                return findAllIcasByStudentIdsAndQueryParamsIndividualPermissions;
+            case Group:
+                return findAllIcasByStudentIdsAndQueryParamsGroupPermissions;
+            default:
+                throw new IllegalArgumentException("Unknown query permission type: " + queryPermissionType);
+        }
     }
 
 }

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -7,7 +7,7 @@ sql:
       and language_code=:language_code
 
   exam:
-    findAllIabsByStudentIdAndSchoolYear: >-
+    findAllIabsByStudentIdAndSchoolYearAndSubject: >-
       select
         e.id,
         e.session_id,
@@ -67,7 +67,67 @@ sql:
       )
       order by e.completed_at desc
 
-    findAllIabsByStudentIdsAndQueryParams: >-
+    findAllIabsByStudentIdsAndQueryParamsUnknownPermissions: >-
+      select
+        e.id,
+        e.session_id,
+        e.type_id,
+        e.school_year,
+        e.grade_code,
+        e.completeness_code,
+        e.administration_condition_code,
+        e.school_year,
+        e.completed_at,
+        e.scale_score,
+        e.scale_score_std_err,
+        e.performance_level,
+        a.id as asmt_id,
+        a.type_id as asmt_type_id,
+        a.label as asmt_label,
+        a.subject_id as asmt_subject_id,
+        a.school_year as asmt_school_year,
+        a.grade_code as asmt_grade_code,
+        a.min_score as asmt_min_score,
+        a.cut_point_1 as asmt_cut_point_1,
+        a.cut_point_2 as asmt_cut_point_2,
+        a.cut_point_3 as asmt_cut_point_3,
+        a.max_score as asmt_max_score,
+        ir.resource as asmt_resource,
+        st.id as student_id,
+        st.ssid as student_ssid,
+        st.first_name as student_first_name,
+        st.last_or_surname as student_last_name,
+        st.gender_code as student_gender_code,
+        s.name as school_name,
+        d.name as district_name
+      from exam e
+        join asmt a on e.asmt_id=a.id
+        left join instructional_resource ir on ir.name = a.name
+        join student st on e.student_id=st.id
+        join school s on e.school_id=s.id
+        join district d on s.district_id=d.id
+      where e.student_id in (:student_ids)
+        and (:school_year is null or e.school_year=:school_year)
+        and a.type_id=2
+        and (:subject_id is null or a.subject_id=:subject_id)
+      and
+      ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+        (1 = :individual_statewide or s.district_id in (:individual_district_ids) or e.school_id in (:individual_school_ids))
+        or (
+          exists(
+              select 1
+              from student_group_membership sgm
+                join student_group sg on sgm.student_group_id = sg.id
+              where sgm.student_group_id in (:group_ids)
+                    and sgm.student_id in (:student_ids)
+                    and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+          )
+          and (1 = :group_statewide or s.district_id in (:group_district_ids) or e.school_id in (:group_school_ids))
+        )
+      )
+      order by e.completed_at desc
+
+    findAllIabsByStudentIdsAndQueryParamsIndividualPermissions: >-
       select
         e.id,
         e.session_id,
@@ -115,7 +175,7 @@ sql:
         and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
       order by e.completed_at desc
 
-    findAllIabsByStudentIdsAndQueryParamsWithGroup: >-
+    findAllIabsByStudentIdsAndQueryParamsGroupPermissions: >-
       select
         e.id,
         e.session_id,
@@ -167,7 +227,7 @@ sql:
         and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
       order by e.completed_at desc
 
-    findLatestIcaByStudentIdAndSchoolYear: >-
+    findLatestIcaByStudentIdAndSchoolYearAndSubject: >-
       select
         e.id,
         e.session_id,
@@ -249,7 +309,88 @@ sql:
       order by e.completed_at desc
       limit 1
 
-    findAllIcasByStudentIdsAndQueryParams: >-
+    findAllIcasByStudentIdsAndQueryParamsUnknownPermissions: >-
+      select
+        e.id,
+        e.session_id,
+        e.type_id,
+        e.school_year,
+        e.grade_code,
+        e.completeness_code,
+        e.administration_condition_code,
+        e.school_year,
+        e.completed_at,
+        e.scale_score,
+        e.scale_score_std_err,
+        e.performance_level,
+        a.claim1_score_code,
+        e.claim1_category,
+        e.claim1_scale_score,
+        e.claim1_scale_score_std_err,
+        a.claim2_score_code,
+        e.claim2_category,
+        e.claim2_scale_score,
+        e.claim2_scale_score_std_err,
+        a.claim3_score_code,
+        e.claim3_category,
+        e.claim3_scale_score,
+        e.claim3_scale_score_std_err,
+        a.claim4_score_code,
+        e.claim4_category,
+        e.claim4_scale_score,
+        e.claim4_scale_score_std_err,
+        e.available_accommodation_codes,
+        a.id as asmt_id,
+        a.type_id as asmt_type_id,
+        a.label as asmt_label,
+        a.subject_id as asmt_subject_id,
+        a.school_year as asmt_school_year,
+        a.grade_code as asmt_grade_code,
+        a.claim1_score_code as asmt_claim1_score_code,
+        a.claim2_score_code as asmt_claim2_score_code,
+        a.claim3_score_code as asmt_claim3_score_code,
+        a.claim4_score_code as asmt_claim4_score_code,
+        a.min_score as asmt_min_score,
+        a.cut_point_1 as asmt_cut_point_1,
+        a.cut_point_2 as asmt_cut_point_2,
+        a.cut_point_3 as asmt_cut_point_3,
+        a.max_score as asmt_max_score,
+        ir.resource as asmt_resource,
+        st.id as student_id,
+        st.ssid as student_ssid,
+        st.first_name as student_first_name,
+        st.last_or_surname as student_last_name,
+        st.gender_code as student_gender_code,
+        s.name as school_name,
+        d.name as district_name
+      from exam e
+        join asmt a on e.asmt_id=a.id
+        left join instructional_resource ir on ir.name = a.name
+        join student st on e.student_id=st.id
+        join school s on e.school_id=s.id
+        join district d on s.district_id=d.id
+      where e.student_id in (:student_ids)
+        and (:school_year is null or e.school_year=:school_year)
+        and a.type_id=1
+        and (:subject_id is null or a.subject_id=:subject_id)
+      and
+      ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+        (1 = :individual_statewide OR s.district_id IN (:individual_district_ids) OR e.school_id IN (:individual_school_ids))
+        or (
+          exists(
+              select 1
+              from student_group_membership sgm
+                join student_group sg on sgm.student_group_id = sg.id
+              where sgm.student_group_id in (:group_ids)
+                    and sgm.student_id in (:student_ids)
+                    and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+          )
+          and (1 = :group_statewide or s.district_id in (:group_district_ids) or e.school_id in (:group_school_ids))
+        )
+      )
+      order by e.completed_at asc
+
+    findAllIcasByStudentIdsAndQueryParamsIndividualPermissions: >-
       select
         e.id,
         e.session_id,
@@ -318,7 +459,7 @@ sql:
         and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
       order by e.completed_at asc
 
-    findAllIcasByStudentIdsAndQueryParamsWithGroup: >-
+    findAllIcasByStudentIdsAndQueryParamsGroupPermissions: >-
       select
         e.id,
         e.session_id,

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/iab/JdbcIabReportRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/iab/JdbcIabReportRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.common.report.iab;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,6 +12,9 @@ import org.opentestsystem.rdw.reporting.common.model.ScaleScore;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.StudentEnrollment;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.common.test.support.Instants;
@@ -30,12 +34,18 @@ import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.common.model.Subject.ELA;
 import static org.opentestsystem.rdw.common.model.Subject.MATH;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Group;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Individual;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Unknown;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districts;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.groupOf;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.individualOf;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.permissions;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.group;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.individual;
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
@@ -217,9 +227,10 @@ public class JdbcIabReportRepositoryIT {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .schoolId(-10L)
                 .schoolYear(1997)
+                .queryPermissionType(Individual)
                 .build();
         final Map<Long, Map<Subject, IabReport>> reports = repository.findAllForStudentsByExamFilter(
-                statewide(),
+                individual(statewide()),
                 of(-1L, -2L),
                 examQueryParams);
 
@@ -237,10 +248,55 @@ public class JdbcIabReportRepositoryIT {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .groupId(-20L)
                 .schoolYear(1997)
+                .queryPermissionType(Group)
                 .build();
         final Map<Long, Map<Subject, IabReport>> reports = repository.findAllForStudentsByExamFilter(
-                statewide(),
+                group(statewide()),
                 of(-1L, -2L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-1L)).hasSize(2);
+        assertThat(reports.get(-1L).get(MATH).getExamsByAssessment()).hasSize(2);
+        assertThat(reports.get(-1L).get(ELA).getExamsByAssessment()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldFindAllIabReportsForAStudentByIndividualPiiRights() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-10L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> reports = repository.findAllForStudentsByExamFilter(
+                individual(districts(-10L)),
+                of(-1L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-1L)).hasSize(2);
+        assertThat(reports.get(-1L).get(MATH).getExamsByAssessment()).hasSize(2);
+        assertThat(reports.get(-1L).get(ELA).getExamsByAssessment()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldFindAllIabReportsForAStudentByGroupPiiRights() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-10L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-10L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-10L, GroupGrant.builder().id(-10L).build()))
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> reports = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-1L),
                 examQueryParams);
 
         assertThat(reports).hasSize(1);

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/ica/JdbcIcaReportRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/ica/JdbcIcaReportRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.common.report.ica;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,6 +12,9 @@ import org.opentestsystem.rdw.reporting.common.model.ScaleScore;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.StudentEnrollment;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.common.test.support.Instants;
@@ -27,12 +31,18 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.common.model.Subject.ELA;
 import static org.opentestsystem.rdw.common.model.Subject.MATH;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Group;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Individual;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Unknown;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districts;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.groupOf;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.individualOf;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.permissions;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.group;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.individual;
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
@@ -167,9 +177,10 @@ public class JdbcIcaReportRepositoryIT {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .schoolId(-10L)
                 .schoolYear(1997)
+                .queryPermissionType(Individual)
                 .build();
         final Map<Long, Map<Subject, IcaReport>> reports = repository.findAllForStudentsByExamFilter(
-                statewide(),
+                individual(statewide()),
                 of(-1L, -2L),
                 examQueryParams);
 
@@ -187,9 +198,10 @@ public class JdbcIcaReportRepositoryIT {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .groupId(-20L)
                 .schoolYear(1997)
+                .queryPermissionType(Group)
                 .build();
         final Map<Long, Map<Subject, IcaReport>> reports = repository.findAllForStudentsByExamFilter(
-                statewide(),
+                group(statewide()),
                 of(-1L, -2L),
                 examQueryParams);
 
@@ -199,4 +211,47 @@ public class JdbcIcaReportRepositoryIT {
         assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
     }
 
+    @Test
+    public void itShouldFindAllIcaReportsForAStudentByIndividualPiiRights() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-10L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> reports = repository.findAllForStudentsByExamFilter(
+                individual(districts(-10L)),
+                of(-1L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-1L)).hasSize(2);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+    }
+
+    @Test
+    public void itShouldFindAllIabReportsForAStudentByGroupPiiRights() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-10L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-10L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-10L, GroupGrant.builder().id(-10L).build()))
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> reports = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-1L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-1L)).hasSize(2);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+    }
 }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/UserPermissionsTestBuilder.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/UserPermissionsTestBuilder.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.reporting.common.test.support;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
+import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+
+/**
+ * Test utility for creating UserPermissions instances.
+ */
+public class UserPermissionsTestBuilder {
+
+    public static UserPermissions individual(final PermissionScope permissionScope) {
+        return UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(
+                        IndividualPiiRead, new Permission(IndividualPiiRead, permissionScope)))
+                .build();
+    }
+
+    public static UserPermissions group(final PermissionScope permissionScope) {
+        return UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(
+                        GroupPiiRead, new Permission(GroupPiiRead, permissionScope)))
+                .build();
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 
 /**
@@ -9,6 +10,7 @@ public class ReportRequestMessage {
 
     protected long reportId;
     protected PermissionScope permissionScope;
+    protected UserPermissions userPermissions;
 
     /**
      * @return The report id
@@ -22,6 +24,13 @@ public class ReportRequestMessage {
      */
     public PermissionScope getPermissionScope() {
         return permissionScope;
+    }
+
+    /**
+     * @return The user's permissions
+     */
+    public UserPermissions getUserPermissions() {
+        return userPermissions;
     }
 
     /**
@@ -43,6 +52,7 @@ public class ReportRequestMessage {
 
         private long reportId;
         private PermissionScope permissionScope;
+        private UserPermissions userPermissions;
 
         protected abstract A createInstance();
 
@@ -50,6 +60,7 @@ public class ReportRequestMessage {
             final A message = createInstance();
             message.reportId = reportId;
             message.permissionScope = permissionScope;
+            message.userPermissions = userPermissions;
             return message;
         }
 
@@ -60,6 +71,11 @@ public class ReportRequestMessage {
 
         public B permissionScope(final PermissionScope permissionScope) {
             this.permissionScope = permissionScope;
+            return (B) this;
+        }
+
+        public B userPermissions(final UserPermissions userPermissions) {
+            this.userPermissions = userPermissions;
             return (B) this;
         }
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepository.java
@@ -3,7 +3,7 @@ package org.opentestsystem.rdw.reporting.processor.repository;
 import org.opentestsystem.rdw.reporting.common.jdbc.Students;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -21,11 +21,14 @@ import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurit
 @Repository
 public class JdbcStudentRepository implements StudentRepository {
 
-    @Value("${sql.student.findByExamQueryParams}")
-    private String findByExamQueryParams;
+    @Value("${sql.student.findByExamQueryParamsUnknownPermissions}")
+    private String findByExamQueryParamsUnknownPermissions;
 
-    @Value("${sql.student.findByExamQueryParamsWithGroup}")
-    private String findByExamQueryParamsWithGroup;
+    @Value("${sql.student.findByExamQueryParamsIndividualPermissions}")
+    private String findByExamQueryParamsIndividualPermissions;
+
+    @Value("${sql.student.findByExamQueryParamsGroupPermissions}")
+    private String findByExamQueryParamsGroupPermissions;
 
     private final NamedParameterJdbcTemplate template;
 
@@ -35,16 +38,29 @@ public class JdbcStudentRepository implements StudentRepository {
     }
 
     @Override
-    public Collection<Student> findStudentsByExamQueryParams(final PermissionScope permissionScope,
+    public Collection<Student> findStudentsByExamQueryParams(final UserPermissions userPermissions,
                                                              final ExamQueryParams examQueryParams) {
-        final String query = examQueryParams.getGroupId() == null ? findByExamQueryParams : findByExamQueryParamsWithGroup;
+        final String query = getExamFilterQuery(examQueryParams.getQueryPermissionType());
 
         return template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams)),
                 (row, rowNum) -> Students.map(row, Student.builder()).build()
         );
+    }
+
+    private String getExamFilterQuery(final ExamQueryParams.ExamQueryPermissionType queryPermissionType) {
+        switch (queryPermissionType) {
+            case Unknown:
+                return findByExamQueryParamsUnknownPermissions;
+            case Individual:
+                return findByExamQueryParamsIndividualPermissions;
+            case Group:
+                return findByExamQueryParamsGroupPermissions;
+            default:
+                throw new IllegalArgumentException("Unknown query permission type: " + queryPermissionType);
+        }
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/StudentRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/StudentRepository.java
@@ -2,7 +2,7 @@ package org.opentestsystem.rdw.reporting.processor.repository;
 
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 
 import java.util.Collection;
 
@@ -14,10 +14,10 @@ public interface StudentRepository {
     /**
      * Fetch students by ExamQueryParams.
      *
-     * @param permissionScope   The permission scope
+     * @param userPermissions   The user permissions
      * @param examQueryParams   The exam query params
      * @return  The students.
      */
-    Collection<Student> findStudentsByExamQueryParams(final PermissionScope permissionScope,
+    Collection<Student> findStudentsByExamQueryParams(final UserPermissions userPermissions,
                                                       final ExamQueryParams examQueryParams);
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParser.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParser.java
@@ -5,6 +5,8 @@ import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
 import org.springframework.stereotype.Component;
 
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Group;
+
 /**
  * This implementation of an ExamQueryParamsParser is responsible for converting
  * a {@link GroupExamReportRequest} into an {@link ExamQueryParams} instance.
@@ -25,6 +27,7 @@ public class GroupExamQueryParamsParser implements ExamQueryParamsParser {
                 .groupId(request.getGroupGrant().getId())
                 .assessmentType(request.getAssessmentType() == null ? null : request.getAssessmentType().getAssessmentType())
                 .subject(request.getSubject())
+                .queryPermissionType(Group)
                 .build();
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/StudentExamQueryParamsParser.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/StudentExamQueryParamsParser.java
@@ -2,33 +2,31 @@ package org.opentestsystem.rdw.reporting.processor.requesthandler;
 
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
-import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.springframework.stereotype.Component;
 
-import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Individual;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Unknown;
 
 /**
  * This implementation of an ExamQueryParamsParser is responsible for converting
- * a {@link SchoolGradeExamReportRequest} into an {@link ExamQueryParams} instance.
+ * a {@link StudentExamReportRequest} into an {@link ExamQueryParams} instance.
  */
 @Component
-public class SchoolGradeExamQueryParamsParser implements ExamQueryParamsParser {
-
+public class StudentExamQueryParamsParser implements ExamQueryParamsParser {
     @Override
     public boolean accept(final AbstractExamReportRequest reportRequest) {
-        return SchoolGradeExamReportRequest.class.isInstance(reportRequest);
+        return StudentExamReportRequest.class.isInstance(reportRequest);
     }
 
     @Override
     public ExamQueryParams parseQueryParams(final AbstractExamReportRequest reportRequest) {
-        final SchoolGradeExamReportRequest request = (SchoolGradeExamReportRequest) reportRequest;
+        final StudentExamReportRequest request = (StudentExamReportRequest) reportRequest;
         return ExamQueryParams.builder()
                 .schoolYear(request.getSchoolYear())
-                .schoolId(request.getSchoolId())
+                .studentId(request.getStudentId())
                 .assessmentType(request.getAssessmentType() == null ? null : request.getAssessmentType().getAssessmentType())
-                .gradeId(request.getGradeId())
                 .subject(request.getSubject())
-                .queryPermissionType(Individual)
+                .queryPermissionType(Unknown)
                 .build();
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGenerator.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGenerator.java
@@ -68,7 +68,7 @@ public class SpringStreamReportGenerator implements ReportGenerator {
         logger.debug("Publishing report generation request: {}", report.getId());
         final ReportRequestMessage payload = ReportRequestMessage.builder()
                 .reportId(report.getId())
-                .permissionScope(requestHolder.getPermissionScope())
+                .userPermissions(requestHolder.getUserPermissions())
                 .build();
 
         final Message<ReportRequestMessage> message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
@@ -9,7 +9,7 @@ import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportReq
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportOrder;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.processor.configuration.ReportGenerationProperties;
 import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
@@ -68,7 +68,7 @@ public class FetchStudents {
     @ServiceActivator(inputChannel = ReportFetchStudents)
     public void fetchAndPublishStudents(final ReportRequestMessage message) {
         logger.debug("Fetching students for report request: {}", message.getReportId());
-        final PermissionScope permissionScope = message.getPermissionScope();
+        final UserPermissions userPermissions = message.getUserPermissions();
         final Report report = reportService.findOneById(message.getReportId())
                 .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + message.getReportId()));
         if (report.getStatus() == ReportStatus.FAILED) return;
@@ -82,7 +82,7 @@ public class FetchStudents {
 
         //Find the report's students
         final Collection<Student> students = studentRepository.findStudentsByExamQueryParams(
-                permissionScope,
+                userPermissions,
                 queryParams);
 
         //Break the students into ordered chunks
@@ -95,7 +95,7 @@ public class FetchStudents {
         reportService.update(updated);
 
         for (int chunkIdx = 0; chunkIdx < chunks.size(); chunkIdx++) {
-            publishProcessingMessage(permissionScope, message.getReportId(), chunkIdx, chunks.get(chunkIdx));
+            publishProcessingMessage(userPermissions, message.getReportId(), chunkIdx, chunks.get(chunkIdx));
         }
         logger.debug("Dispatched chunks for processing: {}", message.getReportId());
     }
@@ -118,13 +118,13 @@ public class FetchStudents {
         }
     }
 
-    private void publishProcessingMessage(final PermissionScope permissionScope,
+    private void publishProcessingMessage(final UserPermissions userPermissions,
                                           final long reportId,
                                           final int chunkIdx,
                                           final List<Student> students) {
         final ProcessStudentChunkMessage payload = ProcessStudentChunkMessage.builder()
                 .reportId(reportId)
-                .permissionScope(permissionScope)
+                .userPermissions(userPermissions)
                 .index(chunkIdx)
                 .students(students)
                 .build();

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -11,13 +11,13 @@ import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHold
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.ReportViewSupport;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.report.iab.IabReport;
 import org.opentestsystem.rdw.reporting.common.report.iab.IabReportRepository;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReport;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReportRepository;
 import org.opentestsystem.rdw.reporting.common.report.processor.HtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.common.report.processor.TemplateProcessor;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.model.StudentCompositeReport;
@@ -116,10 +116,10 @@ public class StudentReportProcessor {
         final ExamQueryParams queryParams = getQueryParams(message.getReportId(), report.getReportRequest());
 
         if (includeReports(IAB, queryParams)) {
-            appendIABReports(studentReports, message.getPermissionScope(), studentReports.keySet(), queryParams);
+            appendIABReports(studentReports, message.getUserPermissions(), studentReports.keySet(), queryParams);
         }
         if (includeReports(ICA, queryParams)) {
-            appendICAReports(studentReports, message.getPermissionScope(), studentReports.keySet(), queryParams);
+            appendICAReports(studentReports, message.getUserPermissions(), studentReports.keySet(), queryParams);
         }
         //TODO Append Summative Reports
 
@@ -162,12 +162,12 @@ public class StudentReportProcessor {
     }
 
     private void appendIABReports(final Map<Long, StudentCompositeReport> compositeReports,
-                                  final PermissionScope permissionScope,
+                                  final UserPermissions userPermissions,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
         final Map<Long, Map<Subject, IabReport>> iabReports = iabReportRepository
                 .findAllForStudentsByExamFilter(
-                        permissionScope,
+                        userPermissions,
                         studentIds,
                         examQueryParams);
 
@@ -180,12 +180,12 @@ public class StudentReportProcessor {
     }
 
     private void appendICAReports(final Map<Long, StudentCompositeReport> compositeReports,
-                                  final PermissionScope permissionScope,
+                                  final UserPermissions userPermissions,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
         final Map<Long, Map<Subject, IcaReport>> icaReports = icaReportRepository
                 .findAllForStudentsByExamFilter(
-                        permissionScope,
+                        userPermissions,
                         studentIds,
                         examQueryParams);
 

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -72,7 +72,7 @@ sql:
         id = :report_id;
 
   student:
-    findByExamQueryParams: >-
+    findByExamQueryParamsUnknownPermissions: >-
       select
         st.id,
         st.ssid,
@@ -83,7 +83,41 @@ sql:
         join exam e on e.student_id = st.id
         join asmt a on e.asmt_id=a.id
         join school s on e.school_id = s.id
-      where (:school_year is null or e.school_year=:school_year)
+      where (:student_id is null or st.id=:student_id)
+        and (:school_year is null or e.school_year=:school_year)
+        and (:school_id is null or s.id=:school_id)
+        and (:subject_id is null or a.subject_id=:subject_id)
+        and (:grade_id is null or e.grade_id=:grade_id)
+        and (:assessment_type is null or a.type_id=:assessment_type)
+        and ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+              (1 = :individual_statewide OR s.district_id IN (:individual_district_ids) OR e.school_id IN (:individual_school_ids))
+              or (
+                exists(
+                    select 1
+                    from student_group_membership sgm
+                      join student_group sg on sgm.student_group_id = sg.id
+                    where sgm.student_group_id in (:group_ids)
+                          and sgm.student_id=st.id
+                          and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+                )
+                and (1 = :group_statewide or s.district_id in (:group_district_ids) or e.school_id in (:group_school_ids))
+              )
+            )
+      group by st.id
+
+    findByExamQueryParamsIndividualPermissions: >-
+      select
+        st.id,
+        st.ssid,
+        st.first_name,
+        st.last_or_surname as last_name,
+        st.gender_code
+      from student st
+        join exam e on e.student_id = st.id
+        join asmt a on e.asmt_id=a.id
+        join school s on e.school_id = s.id
+      where (:student_id is null or st.id=:student_id)
+        and (:school_year is null or e.school_year=:school_year)
         and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or e.grade_id=:grade_id)
@@ -91,7 +125,7 @@ sql:
         and (1=:statewide or s.district_id in (:district_ids) or e.school_id in (:school_ids))
       group by st.id
 
-    findByExamQueryParamsWithGroup: >-
+    findByExamQueryParamsGroupPermissions: >-
       select
         st.id,
         st.ssid,
@@ -106,6 +140,7 @@ sql:
         join student_group sg on sgm.student_group_id = sg.id
           and (sg.subject_id is null or a.subject_id = sg.subject_id)
       where sg.id=:group_id
+        and (:student_id is null or st.id=:student_id)
         and (:school_year is null or e.school_year=:school_year)
         and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
@@ -1,9 +1,13 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
+import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +19,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.opentestsystem.rdw.reporting.common.security.PermissionScope.STATEWIDE;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Group;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Individual;
+import static org.opentestsystem.rdw.reporting.common.report.ExamQueryParams.ExamQueryPermissionType.Unknown;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.groupOf;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.group;
+import static org.opentestsystem.rdw.reporting.common.test.support.UserPermissionsTestBuilder.individual;
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
@@ -33,8 +45,11 @@ public class JdbcStudentRepositoryIT {
                 .gradeId(-2)
                 .schoolId(-10L)
                 .schoolYear(1997)
+                .queryPermissionType(Individual)
                 .build();
-        final Collection<Student> studentIds = repository.findStudentsByExamQueryParams(STATEWIDE, examQueryParams);
+        final Collection<Student> studentIds = repository.findStudentsByExamQueryParams(
+                individual(statewide()),
+                examQueryParams);
 
         assertThat(studentIds.stream().map(Student::getId)).containsOnly(-2L, -1L);
     }
@@ -45,9 +60,13 @@ public class JdbcStudentRepositoryIT {
                 .gradeId(-2)
                 .schoolId(123L)
                 .schoolYear(1997)
+                .queryPermissionType(Individual)
                 .build();
 
-        assertThat(repository.findStudentsByExamQueryParams(STATEWIDE, examQueryParams)).isEmpty();
+        assertThat(repository.findStudentsByExamQueryParams(
+                individual(statewide()),
+                examQueryParams)
+        ).isEmpty();
     }
 
     @Test
@@ -55,18 +74,55 @@ public class JdbcStudentRepositoryIT {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
                 .groupId(-10L)
                 .schoolYear(1997)
+                .queryPermissionType(Group)
                 .build();
-        final Collection<Student> g1Students = repository.findStudentsByExamQueryParams(STATEWIDE, g1Params);
+        final Collection<Student> g1Students = repository.findStudentsByExamQueryParams(group(statewide()), g1Params);
 
         assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
 
         final ExamQueryParams g2Params = ExamQueryParams.builder()
                 .groupId(-20L)
                 .schoolYear(1997)
+                .queryPermissionType(Group)
                 .build();
-        final Collection<Student> g2Students = repository.findStudentsByExamQueryParams(STATEWIDE, g2Params);
+        final Collection<Student> g2Students = repository.findStudentsByExamQueryParams(group(statewide()), g2Params);
 
         assertThat(g2Students.stream().map(Student::getId)).containsOnly(-1L);
+    }
+
+    @Test
+    public void itShouldFindASingleStudentWithIndividualPermissions() throws Exception {
+        final ExamQueryParams g1Params = ExamQueryParams.builder()
+                .studentId(-1L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+        final Collection<Student> g1Students = repository.findStudentsByExamQueryParams(
+                individual(statewide()),
+                g1Params);
+
+        assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
+    }
+
+    @Test
+    public void itShouldFindASingleStudentWithGroupPermissions() throws Exception {
+        final ExamQueryParams g1Params = ExamQueryParams.builder()
+                .studentId(-1L)
+                .schoolYear(1997)
+                .queryPermissionType(Unknown)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-10L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-10L, GroupGrant.builder().id(-10L).build()))
+                .build();
+
+        final Collection<Student> g1Students = repository.findStudentsByExamQueryParams(
+                specificGroup,
+                g1Params);
+
+        assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
     }
 
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
@@ -73,7 +73,7 @@ public class SpringStreamReportGeneratorTest {
         verify(source.fetchStudents()).send(messageCaptor.capture());
         final ReportRequestMessage payload = messageCaptor.getValue().getPayload();
         assertThat(payload.getReportId()).isEqualTo(report.getId());
-        assertThat(payload.getPermissionScope()).isEqualTo(requestHolder.getPermissionScope());
+        assertThat(payload.getUserPermissions()).isEqualTo(requestHolder.getUserPermissions());
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/FetchStudentsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/FetchStudentsTest.java
@@ -12,6 +12,7 @@ import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.processor.configuration.ReportGenerationProperties;
 import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
@@ -111,7 +112,7 @@ public class FetchStudentsTest {
         queryParamsParsers.add(acceptor());
 
         when(studentRepository.findStudentsByExamQueryParams(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 eq(params)
         )).thenReturn(students);
 
@@ -139,7 +140,7 @@ public class FetchStudentsTest {
         students.add(student(3L).copy().lastName("LastC").build());
         students.add(student(2L).copy().lastName("LastB").build());
         when(studentRepository.findStudentsByExamQueryParams(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 eq(params)
         )).thenReturn(students);
 
@@ -172,7 +173,7 @@ public class FetchStudentsTest {
         students.add(student(3L).copy().ssid("ssidC").build());
         students.add(student(2L).copy().ssid("ssidB").build());
         when(studentRepository.findStudentsByExamQueryParams(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 eq(params)
         )).thenReturn(students);
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/step/StudentReportProcessorTest.java
@@ -18,13 +18,13 @@ import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.ReportViewSupport;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.report.iab.IabReport;
 import org.opentestsystem.rdw.reporting.common.report.iab.IabReportRepository;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReport;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReportRepository;
 import org.opentestsystem.rdw.reporting.common.report.processor.HtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.common.report.processor.TemplateProcessor;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
 import org.opentestsystem.rdw.reporting.processor.model.StudentCompositeReport;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
@@ -137,10 +137,10 @@ public class StudentReportProcessorTest {
                 .thenReturn(params);
         queryParamsParsers.add(accepting);
 
-        when(iabReportRepository.findAllForStudentsByExamFilter(any(PermissionScope.class), anyCollectionOf(Long.class), any(ExamQueryParams.class)))
+        when(iabReportRepository.findAllForStudentsByExamFilter(any(UserPermissions.class), anyCollectionOf(Long.class), any(ExamQueryParams.class)))
                 .thenReturn(new HashMap<>());
 
-        when(icaReportRepository.findAllForStudentsByExamFilter(any(PermissionScope.class), anyCollectionOf(Long.class), any(ExamQueryParams.class)))
+        when(icaReportRepository.findAllForStudentsByExamFilter(any(UserPermissions.class), anyCollectionOf(Long.class), any(ExamQueryParams.class)))
                 .thenReturn(new HashMap<>());
 
         final byte[] htmlContent = "htmlContent".getBytes();
@@ -197,7 +197,7 @@ public class StudentReportProcessorTest {
         writer.generateStudentChunkReport(message);
 
         verify(iabReportRepository).findAllForStudentsByExamFilter(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 studentIdCaptor.capture(),
                 examFilterCaptor.capture());
 
@@ -220,7 +220,7 @@ public class StudentReportProcessorTest {
         queryParamsParsers.add(parser);
 
         when(iabReportRepository.findAllForStudentsByExamFilter(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 anyCollectionOf(Long.class),
                 eq(params)))
                 .thenReturn(reportsByStudent);
@@ -253,7 +253,7 @@ public class StudentReportProcessorTest {
         queryParamsParsers.add(parser);
 
         when(icaReportRepository.findAllForStudentsByExamFilter(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 anyCollectionOf(Long.class),
                 any(ExamQueryParams.class)))
                 .thenReturn(reportsByStudent);
@@ -287,13 +287,13 @@ public class StudentReportProcessorTest {
         queryParamsParsers.add(parser);
 
         when(iabReportRepository.findAllForStudentsByExamFilter(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 anyCollectionOf(Long.class),
                 any(ExamQueryParams.class)))
                 .thenReturn(iabReportsbyStudent);
 
         when(icaReportRepository.findAllForStudentsByExamFilter(
-                any(PermissionScope.class),
+                any(UserPermissions.class),
                 anyCollectionOf(Long.class),
                 any(ExamQueryParams.class)))
                 .thenReturn(icaReportsByStudent);

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -9,8 +9,11 @@ import org.mockito.Captor;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
+import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
 import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.common.web.ReportContentResource;
@@ -28,8 +31,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static com.amazonaws.services.s3.Headers.CONTENT_DISPOSITION;
@@ -45,7 +48,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.security.PermissionScope.STATEWIDE;
-import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -77,21 +80,30 @@ public class ReportControllerIT {
 
     @Test
     public void itShouldGenerateAReport() throws Exception {
+        final StudentExamReportRequest request = StudentExamReportRequest.builder()
+                .language(Locale.US)
+                .options(new PrintOptions(false))
+                .schoolYear(2018)
+                .studentId(1)
+                .build();
         final Report report = Report.builder()
                 .copy(report(123L))
                 .totalChunkCount(10)
                 .completeChunkCount(9)
+                .reportRequest(request)
                 .build();
         when(reportGenerator.generateReport(any(BatchExamReportRequestHolder.class)))
                 .thenReturn(report);
 
         final UserPermissions userPermissions = UserPermissions.builder()
-                .permissionsById(ImmutableMap.of(IndividualPiiRead, new Permission(IndividualPiiRead, STATEWIDE)))
-                .groupsById(Collections.emptyMap())
+                .permissionsById(ImmutableMap.of(GroupPiiRead, new Permission(GroupPiiRead, STATEWIDE)))
+                .groupsById(ImmutableMap.of(1L, GroupGrant.builder()
+                        .id(1)
+                        .build()))
                 .build();
 
         final BatchExamReportRequestHolder requestHolder = new BatchExamReportRequestHolder(
-                (SchoolGradeExamReportRequest)report.getReportRequest(),
+                report.getReportRequest(),
                 PermissionScope.STATEWIDE,
                 userPermissions,
                 "user",

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/DefaultStudentExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/DefaultStudentExamReportService.java
@@ -4,6 +4,7 @@ import org.opentestsystem.rdw.reporting.common.report.AbstractExamReport;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportAssessmentType;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportMessage;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportRepository;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.iab.IabReportRepository;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReportRepository;
 import org.opentestsystem.rdw.reporting.security.User;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportController.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.report.student;
 
 import org.opentestsystem.rdw.reporting.common.report.ExamReportMessage;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequestArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportRequestArgumentResolver.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.report.student;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportAssessmentType;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportService.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.report.student;
 
 import org.opentestsystem.rdw.reporting.common.report.ExamReportMessage;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.security.access.prepost.PreAuthorize;
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/student/StudentExamReportControllerIT.java
@@ -8,6 +8,7 @@ import org.opentestsystem.rdw.reporting.common.report.ExamReportAssessmentType;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportMessage;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportPdfMessageConverter;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
+import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.ica.IcaReport;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
…rmissions

This PR adds support for handling a single-student report request submitted via a StudentExamReportRequest.
Most of the changes revolve around security concerns.  Previously we were able to assume a single PermissionScope was enough security information to find the students and their exams for reporting.  Unfortunately, when submitting a single-student report request, the system does not know whether to submit the INDIVIDUAL_PII_READ or GROUP_PII_READ permissions.  Additionally, if using GROUP_PII_READ permissions, we need to ensure that the user has been granted rights to a group that the student belongs to.

The end result is that we have gone from 2 SQL query implementations each for fetching IAB reports, ICA reports, and students to 3 SQL query implementations each for fetching the data.

NOTE: This PR should not be merged directly to "develop"  We should first consolidate this PR with @esotrope's #457 PR to avoid any down-time due to mis-matched implementations between the webapp and report processor.