### PR TITLE
Remove now-unused PermissionScope property from message models

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/BatchExamReportRequestHolder.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/BatchExamReportRequestHolder.java
@@ -1,14 +1,12 @@
 package org.opentestsystem.rdw.reporting.common.report;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 
 import java.util.UUID;
 
 public class BatchExamReportRequestHolder {
 
     private String id;
-    private PermissionScope permissionScope;
     private UserPermissions userPermissions;
     private String user;
     private String label;
@@ -22,12 +20,10 @@ public class BatchExamReportRequestHolder {
     private BatchExamReportRequestHolder() {}
 
     public BatchExamReportRequestHolder(final AbstractExamReportRequest<PrintOptions> request,
-                                        final PermissionScope permissionScope,
                                         final UserPermissions userPermissions,
                                         final String user,
                                         final String label) {
         this.id = UUID.randomUUID().toString();
-        this.permissionScope = permissionScope;
         this.userPermissions = userPermissions;
         this.request = request;
         this.user = user;
@@ -36,10 +32,6 @@ public class BatchExamReportRequestHolder {
 
     public String getId() {
         return id;
-    }
-
-    public PermissionScope getPermissionScope() {
-        return permissionScope;
     }
 
     public UserPermissions getUserPermissions() {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
@@ -1,7 +1,6 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 
 /**
  * This message represents a basic report processing message.
@@ -9,7 +8,6 @@ import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 public class ReportRequestMessage {
 
     protected long reportId;
-    protected PermissionScope permissionScope;
     protected UserPermissions userPermissions;
 
     /**
@@ -17,13 +15,6 @@ public class ReportRequestMessage {
      */
     public long getReportId() {
         return reportId;
-    }
-
-    /**
-     * @return The report permission scope
-     */
-    public PermissionScope getPermissionScope() {
-        return permissionScope;
     }
 
     /**
@@ -51,7 +42,6 @@ public class ReportRequestMessage {
     public abstract static class BaseBuilder<A extends ReportRequestMessage, B extends ReportRequestMessage.BaseBuilder<A, B>> {
 
         private long reportId;
-        private PermissionScope permissionScope;
         private UserPermissions userPermissions;
 
         protected abstract A createInstance();
@@ -59,18 +49,12 @@ public class ReportRequestMessage {
         public A build() {
             final A message = createInstance();
             message.reportId = reportId;
-            message.permissionScope = permissionScope;
             message.userPermissions = userPermissions;
             return message;
         }
 
         public B reportId(final long reportId) {
             this.reportId = reportId;
-            return (B) this;
-        }
-
-        public B permissionScope(final PermissionScope permissionScope) {
-            this.permissionScope = permissionScope;
             return (B) this;
         }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
@@ -111,7 +111,6 @@ public class SpringStreamReportGeneratorTest {
 
         return new BatchExamReportRequestHolder(
                 reportRequest,
-                STATEWIDE,
                 userPermissions,
                 "user",
                 "label"

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
@@ -12,7 +12,6 @@ import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.processor.configuration.ReportGenerationProperties;
 import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
@@ -69,7 +68,7 @@ public class FetchStudentsTest {
     public void setup() throws Exception {
         message = ReportRequestMessage.builder()
                 .reportId(123L)
-                .permissionScope(PermissionScope.STATEWIDE)
+                .userPermissions(mock(UserPermissions.class))
                 .build();
 
         when(reportService.findOneById(123L)).thenReturn(Optional.of(report));

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -15,7 +15,6 @@ import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.security.GroupGrant;
 import org.opentestsystem.rdw.reporting.common.security.Permission;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerator;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
@@ -103,7 +102,6 @@ public class ReportControllerIT {
 
         final BatchExamReportRequestHolder requestHolder = new BatchExamReportRequestHolder(
                 report.getReportRequest(),
-                PermissionScope.STATEWIDE,
                 userPermissions,
                 "user",
                 "label"
@@ -127,7 +125,7 @@ public class ReportControllerIT {
         final ArgumentCaptor<BatchExamReportRequestHolder> captor = ArgumentCaptor.forClass(BatchExamReportRequestHolder.class);
         verify(reportGenerator).generateReport(captor.capture());
         final BatchExamReportRequestHolder submitted = captor.getValue();
-        assertThat(submitted.getPermissionScope().isStatewide()).isTrue();
+        assertThat(submitted.getUserPermissions().getPermissionsById().get(GroupPiiRead).getScope().isStatewide()).isTrue();
         assertThat(submitted.getLabel()).isEqualTo(requestHolder.getLabel());
         assertThat(submitted.getUser()).isEqualTo(requestHolder.getUser());
         assertThat(submitted.getRequest().getSchoolYear()).isEqualTo(requestHolder.getRequest().getSchoolYear());

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/DefaultExamReportService.java
@@ -2,25 +2,20 @@ package org.opentestsystem.rdw.reporting.report;
 
 import com.google.common.collect.ImmutableSet;
 import org.opentestsystem.rdw.reporting.common.model.Report;
-import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
 import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
-import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.reporting.common.security.PermissionScope;
-import org.opentestsystem.rdw.reporting.report.client.ReportWebServiceClient;
 import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.report.client.ReportWebServiceClient;
 import org.opentestsystem.rdw.reporting.security.User;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
 import java.util.List;
-
-import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
-import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.IndividualPiiRead;
 
 @Service
 class DefaultExamReportService implements ExamReportService {
@@ -34,19 +29,17 @@ class DefaultExamReportService implements ExamReportService {
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final StudentExamReportRequest request) {
-        return createReport(user, request, null);
+        return createReportInternal(user, request);
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final SchoolGradeExamReportRequest request) {
-        final PermissionScope permissionScope = user.getPermissionsById().get(IndividualPiiRead).getScope();
-        return createReport(user, request, permissionScope);
+        return createReportInternal(user, request);
     }
 
     @Override
     public Report createReport(@NotNull final User user, @NotNull final GroupExamReportRequest request) {
-        final PermissionScope permissionScope = user.getPermissionsById().get(GroupPiiRead).getScope();
-        return createReport(user, request, permissionScope);
+        return createReportInternal(user, request);
     }
 
     @Override
@@ -64,10 +57,9 @@ class DefaultExamReportService implements ExamReportService {
         client.streamReport(user.getUsername(), reportId, response);
     }
 
-    private <T extends AbstractExamReportRequest<PrintOptions>> Report createReport(
+    private <T extends AbstractExamReportRequest<PrintOptions>> Report createReportInternal(
             @NotNull final User user,
-            @NotNull final T request,
-            @NotNull final PermissionScope permissionScope) {
+            @NotNull final T request) {
 
         final UserPermissions userPermissions = UserPermissions.builder()
                 .permissionsById(user.getPermissionsById())
@@ -75,7 +67,7 @@ class DefaultExamReportService implements ExamReportService {
                 .build();
 
         final BatchExamReportRequestHolder holder = new BatchExamReportRequestHolder(
-                request, permissionScope, userPermissions, user.getUsername(), request.getName());
+                request, userPermissions, user.getUsername(), request.getName());
 
         return client.createReport(holder);
     }


### PR DESCRIPTION
Final cleanup of the report-processor.  This removes the vestigial PermissionScope from the DTO model instances.