### PR TITLE
Handle multiple media types for report contents.

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/MergedReport.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/MergedReport.java
@@ -1,0 +1,33 @@
+package org.opentestsystem.rdw.reporting.processor.model;
+
+import org.springframework.http.MediaType;
+
+import java.io.File;
+
+/**
+ * This model represents a merged report resource.
+ */
+public class MergedReport {
+
+    private final File file;
+    private final MediaType mediaType;
+
+    public MergedReport(final File file, final MediaType mediaType) {
+        this.file = file;
+        this.mediaType = mediaType;
+    }
+
+    /**
+     * @return The merged report file
+     */
+    public File getFile() {
+        return file;
+    }
+
+    /**
+     * @return The merged report mediatype
+     */
+    public MediaType getMediaType() {
+        return mediaType;
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
@@ -5,11 +5,14 @@ import org.opentestsystem.rdw.archive.ArchiveService;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Properties;
+
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.getExtension;
 
 /**
  * This implementation of a ReportContentService is backed by an ArchiveService.
@@ -29,10 +32,14 @@ public class ArchiveBackedReportContentService implements ReportContentService {
     }
 
     @Override
-    public Report writeContent(final Report report, final InputStream content, final long contentLength) {
-        final URI uri = createUri(report);
+    public Report writeContent(final Report report,
+                               final InputStream content,
+                               final long contentLength,
+                               final MediaType mediaType) {
+        final URI uri = createUri(report, mediaType);
         final Properties properties = new Properties();
         properties.put(Headers.CONTENT_LENGTH, contentLength);
+        properties.put(Headers.CONTENT_TYPE, mediaType.toString());
 
         archiveService.writeResource(uri.toASCIIString(), content, properties);
 
@@ -52,11 +59,12 @@ public class ArchiveBackedReportContentService implements ReportContentService {
         final Properties reportProperties = archiveService.readProperties(location);
         if (!reportProperties.containsKey(Headers.CONTENT_LENGTH)) return null;
 
+        final String contentType = reportProperties.getProperty(Headers.CONTENT_TYPE);
         final long reportLength = (Long) reportProperties.get(Headers.CONTENT_LENGTH);
-        return new ReportContentResource(archiveService.openResource(location), reportLength);
+        return new ReportContentResource(archiveService.openResource(location), reportLength, contentType);
     }
 
-    private URI createUri(final Report report) {
-        return URI.create(BasePath + report.getId() + ".pdf");
+    private URI createUri(final Report report, final MediaType mediaType) {
+        return URI.create(BasePath + report.getId() + "." + getExtension(mediaType));
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
@@ -12,7 +12,9 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Properties;
 
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
 import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.getExtension;
+import static org.springframework.util.StringUtils.isEmpty;
 
 /**
  * This implementation of a ReportContentService is backed by an ArchiveService.
@@ -60,8 +62,9 @@ public class ArchiveBackedReportContentService implements ReportContentService {
         if (!reportProperties.containsKey(Headers.CONTENT_LENGTH)) return null;
 
         final String contentType = reportProperties.getProperty(Headers.CONTENT_TYPE);
+        final MediaType mediaType = isEmpty(contentType) ? APPLICATION_PDF_UTF8 : MediaType.parseMediaType(contentType);
         final long reportLength = (Long) reportProperties.get(Headers.CONTENT_LENGTH);
-        return new ReportContentResource(archiveService.openResource(location), reportLength, contentType);
+        return new ReportContentResource(archiveService.openResource(location), reportLength, mediaType);
     }
 
     private URI createUri(final Report report, final MediaType mediaType) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportContentService.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.processor.service;
 
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.http.MediaType;
 
 import java.io.InputStream;
 
@@ -18,9 +19,13 @@ public interface ReportContentService {
      * @param report        The report
      * @param content       The report contents
      * @param contentLength The report content length in bytes
+     * @param mediaType     The report content MediaType
      * @return The Report with persisted content location URI.
      */
-    Report writeContent(Report report, InputStream content, long contentLength);
+    Report writeContent(Report report,
+                        InputStream content,
+                        long contentLength,
+                        MediaType mediaType);
 
     /**
      * Read report contents from persistent storage.

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportMergeService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportMergeService.java
@@ -15,7 +15,9 @@ import java.util.function.Supplier;
 public interface ReportMergeService {
 
     /**
-     * Merge the given source PDFs into a single PDF in order.
+     * Merge the given source PDFs into a single File in order.
+     * The result file may be either a single PDF or a ZIP file containing
+     * multiple PDFs.
      * The File response should be deleted once consumed.
      *
      * @param sourcePdfs The source PDF InputStream suppliers

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportMergeService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportMergeService.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.service;
 
-import java.io.File;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -8,9 +9,10 @@ import java.util.function.Supplier;
 
 /**
  * Implementations of this interface are responsible for merging multiple
- * PDFs into a single PDF.
+ * PDFs into a single Report resource.  The resource may be either a single
+ * PDF or a ZIP containing multiple PDFs.
  */
-public interface PdfMergeService {
+public interface ReportMergeService {
 
     /**
      * Merge the given source PDFs into a single PDF in order.
@@ -20,5 +22,5 @@ public interface PdfMergeService {
      * @return The merged PDF content file
      * @throws IOException If there is a problem merging PDFs
      */
-    File mergePdfs(List<Supplier<InputStream>> sourcePdfs) throws IOException;
+    MergedReport mergePdfs(List<Supplier<InputStream>> sourcePdfs) throws IOException;
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMerger.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMerger.java
@@ -29,12 +29,8 @@ import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICA
 public class TemporaryFilePdfMerger implements ReportMergeService {
     private final static Logger logger = LoggerFactory.getLogger(TemporaryFilePdfMerger.class);
 
-    public TemporaryFilePdfMerger() {
-    }
-
     @Override
     public MergedReport mergePdfs(final List<Supplier<InputStream>> sourcePdfs) throws IOException {
-
         final File mergedReport = Files.createTempFile("mergedPdf", ".pdf").toFile();
         try (final FileOutputStream outputStream = new FileOutputStream(mergedReport)) {
             final MediaType mediaType = doMerge(outputStream, sourcePdfs);

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMerger.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMerger.java
@@ -4,8 +4,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -17,26 +19,30 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
+
 /**
- * This PdfMergeService implementation uses a temporary file
+ * This ReportMergeService implementation uses a temporary file
  * to provide streaming PDF merging.
  */
 @Service
-public class TemporaryFilePdfMerger implements PdfMergeService {
+public class TemporaryFilePdfMerger implements ReportMergeService {
     private final static Logger logger = LoggerFactory.getLogger(TemporaryFilePdfMerger.class);
 
-    @Override
-    public File mergePdfs(final List<Supplier<InputStream>> sourcePdfs) throws IOException {
-
-        final File mergedPdf = Files.createTempFile("mergedPdf", ".pdf").toFile();
-        try (final FileOutputStream outputStream = new FileOutputStream(mergedPdf)) {
-            doMerge(outputStream, sourcePdfs);
-        }
-
-        return mergedPdf;
+    public TemporaryFilePdfMerger() {
     }
 
-    private void doMerge(final OutputStream outputStream,
+    @Override
+    public MergedReport mergePdfs(final List<Supplier<InputStream>> sourcePdfs) throws IOException {
+
+        final File mergedReport = Files.createTempFile("mergedPdf", ".pdf").toFile();
+        try (final FileOutputStream outputStream = new FileOutputStream(mergedReport)) {
+            final MediaType mediaType = doMerge(outputStream, sourcePdfs);
+            return new MergedReport(mergedReport, mediaType);
+        }
+    }
+
+    private MediaType doMerge(final OutputStream outputStream,
                          final List<Supplier<InputStream>> sourcePdfs) {
         PDDocument destinationDocument = null;
 
@@ -53,8 +59,10 @@ public class TemporaryFilePdfMerger implements PdfMergeService {
                 }
             }
             destinationDocument.save(outputStream);
+
+            return APPLICATION_PDF_UTF8;
         } catch (final IOException e) {
-            logger.warn("Unable to merge PDFs", e);
+            throw new RuntimeException("Unable to merge PDFs", e);
         } finally {
             try {
                 if (destinationDocument != null) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
@@ -66,19 +66,19 @@ public class GeneratePdf {
                         mergedReport.getFile().length(),
                         mergedReport.getMediaType());
 
-                if (!mergedReport.getFile().delete()) {
-                    logger.warn("Unable to remove temporary merged report PDF file: {}", mergedReport);
-                }
-
                 final Report completed = Report.builder()
                         .copy(writtenReport)
                         .status(ReportStatus.COMPLETED)
                         .build();
                 reportService.update(completed);
-
-                reportGenerationTemporaryStorage.cleanup(message.getReportId());
-                logger.debug("Report: {} complete", message.getReportId());
             }
+
+            if (!mergedReport.getFile().delete()) {
+                logger.warn("Unable to remove temporary merged report PDF file: {}", mergedReport);
+            }
+
+            reportGenerationTemporaryStorage.cleanup(message.getReportId());
+            logger.debug("Report: {} complete", message.getReportId());
         } catch (final IOException e) {
             throw new IllegalStateException("Unable to collate report: " + message.getReportId(), e);
         }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
@@ -2,10 +2,11 @@ package org.opentestsystem.rdw.reporting.processor.stream;
 
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
-import org.opentestsystem.rdw.reporting.processor.service.PdfMergeService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
+import org.opentestsystem.rdw.reporting.processor.service.ReportMergeService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.stereotype.Component;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,13 +32,13 @@ public class GeneratePdf {
 
     private final ReportContentService reportContentService;
     private final ReportGenerationTemporaryStorage reportGenerationTemporaryStorage;
-    private final PdfMergeService pdfMerger;
+    private final ReportMergeService pdfMerger;
     private final ReportService reportService;
 
     @Autowired
     public GeneratePdf(final ReportContentService reportContentService,
                        final ReportGenerationTemporaryStorage reportGenerationTemporaryStorage,
-                       final PdfMergeService pdfMerger,
+                       final ReportMergeService pdfMerger,
                        final ReportService reportService) {
         this.reportContentService = reportContentService;
         this.reportGenerationTemporaryStorage = reportGenerationTemporaryStorage;
@@ -55,15 +55,19 @@ public class GeneratePdf {
 
         try {
             final List<Supplier<InputStream>> chunkPdfs = reportGenerationTemporaryStorage.getChunks(report.getId(), report.getTotalChunkCount());
-            final File mergedPdf = pdfMerger.mergePdfs(chunkPdfs);
+            final MergedReport mergedReport = pdfMerger.mergePdfs(chunkPdfs);
 
             logger.debug("Merged Report: {}", message.getReportId());
-            try (final FileInputStream pdfStream = new FileInputStream(mergedPdf)) {
+            try (final FileInputStream pdfStream = new FileInputStream(mergedReport.getFile())) {
                 //Store PDF contents
-                final Report writtenReport = reportContentService.writeContent(report, pdfStream, mergedPdf.length());
+                final Report writtenReport = reportContentService.writeContent(
+                        report,
+                        pdfStream,
+                        mergedReport.getFile().length(),
+                        mergedReport.getMediaType());
 
-                if (!mergedPdf.delete()) {
-                    logger.warn("Unable to remove temporary merged report PDF file: {}", mergedPdf);
+                if (!mergedReport.getFile().delete()) {
+                    logger.warn("Unable to remove temporary merged report PDF file: {}", mergedReport);
                 }
 
                 final Report completed = Report.builder()

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
@@ -17,13 +17,13 @@ public class MediaTypes {
 
     public static final MediaType APPLICATION_ZIP = new MediaType("application", "zip");
 
-    public static final Map<String, MediaType> ExtentionToMediaType = ImmutableMap.<String, MediaType>builder()
+    public static final Map<String, MediaType> ExtensionToMediaType = ImmutableMap.<String, MediaType>builder()
             .put("pdf", APPLICATION_PDF_UTF8)
             .put("zip", APPLICATION_ZIP)
             .build();
 
     public static String getExtension(final MediaType mediaType) {
-        final Optional<Map.Entry<String, MediaType>> extension = ExtentionToMediaType.entrySet().stream()
+        final Optional<Map.Entry<String, MediaType>> extension = ExtensionToMediaType.entrySet().stream()
                 .filter(entry -> entry.getValue().isCompatibleWith(mediaType))
                 .findFirst();
         if (!extension.isPresent()) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
@@ -17,18 +17,18 @@ public class MediaTypes {
 
     public static final MediaType APPLICATION_ZIP = new MediaType("application", "zip");
 
-    public static final Map<String, MediaType> ExtensionToMediaType = ImmutableMap.<String, MediaType>builder()
-            .put("pdf", APPLICATION_PDF_UTF8)
-            .put("zip", APPLICATION_ZIP)
+    public static final Map<MediaType, String> MediaTypeToExtension = ImmutableMap.<MediaType, String>builder()
+            .put(APPLICATION_PDF_UTF8, "pdf")
+            .put(APPLICATION_ZIP, "zip")
             .build();
 
     public static String getExtension(final MediaType mediaType) {
-        final Optional<Map.Entry<String, MediaType>> extension = ExtensionToMediaType.entrySet().stream()
-                .filter(entry -> entry.getValue().isCompatibleWith(mediaType))
+        final Optional<Map.Entry<MediaType, String>> extension = MediaTypeToExtension.entrySet().stream()
+                .filter(entry -> entry.getKey().isCompatibleWith(mediaType))
                 .findFirst();
         if (!extension.isPresent()) {
             throw new IllegalArgumentException("Unknown media type: " + mediaType);
         }
-        return extension.get().getKey();
+        return extension.get().getValue();
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/MediaTypes.java
@@ -1,0 +1,34 @@
+package org.opentestsystem.rdw.reporting.processor.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility class for handling custom MediaTypes.
+ */
+public class MediaTypes {
+
+    public static final MediaType APPLICATION_PDF_UTF8 = new MediaType(
+            MediaType.APPLICATION_PDF,
+            ImmutableMap.of("charset", "UTF-8"));
+
+    public static final MediaType APPLICATION_ZIP = new MediaType("application", "zip");
+
+    public static final Map<String, MediaType> ExtentionToMediaType = ImmutableMap.<String, MediaType>builder()
+            .put("pdf", APPLICATION_PDF_UTF8)
+            .put("zip", APPLICATION_ZIP)
+            .build();
+
+    public static String getExtension(final MediaType mediaType) {
+        final Optional<Map.Entry<String, MediaType>> extension = ExtentionToMediaType.entrySet().stream()
+                .filter(entry -> entry.getValue().isCompatibleWith(mediaType))
+                .findFirst();
+        if (!extension.isPresent()) {
+            throw new IllegalArgumentException("Unknown media type: " + mediaType);
+        }
+        return extension.get().getKey();
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
@@ -10,14 +10,25 @@ import java.io.InputStream;
 public class ReportContentResource extends InputStreamResource {
 
     private final long contentLength;
+    private final String contentType;
 
-    public ReportContentResource(final InputStream inputStream, final long contentLength) {
+    public ReportContentResource(final InputStream inputStream,
+                                 final long contentLength,
+                                 final String contentType) {
         super(inputStream);
         this.contentLength = contentLength;
+        this.contentType = contentType;
     }
 
     @Override
     public long contentLength() {
         return contentLength;
+    }
+
+    /**
+     * @return The Content-Type/MediaType of this resource
+     */
+    public String getContentType() {
+        return contentType;
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.web;
 
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 
 import java.io.InputStream;
 
@@ -10,11 +11,11 @@ import java.io.InputStream;
 public class ReportContentResource extends InputStreamResource {
 
     private final long contentLength;
-    private final String contentType;
+    private final MediaType contentType;
 
     public ReportContentResource(final InputStream inputStream,
                                  final long contentLength,
-                                 final String contentType) {
+                                 final MediaType contentType) {
         super(inputStream);
         this.contentLength = contentLength;
         this.contentType = contentType;
@@ -26,9 +27,9 @@ public class ReportContentResource extends InputStreamResource {
     }
 
     /**
-     * @return The Content-Type/MediaType of this resource
+     * @return The MediaType of this resource
      */
-    public String getContentType() {
+    public MediaType getMediaType() {
         return contentType;
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
@@ -27,12 +27,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
 import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.getExtension;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.util.StringUtils.isEmpty;
 
 /**
  * This controller is responsible for providing access to Reports.
@@ -102,7 +100,7 @@ public class ReportController {
 
         final ReportContentResource resource = reportContentService.openContent(report);
 
-        final MediaType mediaType = isEmpty(resource.getContentType()) ? APPLICATION_PDF_UTF8 : MediaType.valueOf(resource.getContentType());
+        final MediaType mediaType = resource.getMediaType();
         final String filename = report.getLabel().replaceAll("\\s", "_") + "." + getExtension(mediaType);
         final String contentDisposition = Headers.formatContentDispositionAttachment(filename, Charset.forName("UTF-8"));
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
@@ -9,6 +9,7 @@ import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,9 +27,12 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.getExtension;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.util.StringUtils.isEmpty;
 
 /**
  * This controller is responsible for providing access to Reports.
@@ -84,11 +88,10 @@ public class ReportController {
      * @param reportId A report id
      * @throws IOException If there is a problem reading/writing the response
      */
-    @GetMapping("{reportId}/content")
+    @GetMapping(path = "{reportId}/content")
     @ResponseBody
     public ResponseEntity<ReportContentResource> getReportContent(@PathVariable final Long reportId,
                                                                   @RequestParam("user") final String user) throws IOException {
-
         final Report report = reportService.findOneById(reportId)
                 .orElseThrow(NoSuchElementException::new);
 
@@ -99,11 +102,12 @@ public class ReportController {
 
         final ReportContentResource resource = reportContentService.openContent(report);
 
-        final String filename = report.getLabel().replaceAll("\\s", "_") + ".pdf";
+        final MediaType mediaType = isEmpty(resource.getContentType()) ? APPLICATION_PDF_UTF8 : MediaType.valueOf(resource.getContentType());
+        final String filename = report.getLabel().replaceAll("\\s", "_") + "." + getExtension(mediaType);
         final String contentDisposition = Headers.formatContentDispositionAttachment(filename, Charset.forName("UTF-8"));
 
         final HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set(CONTENT_TYPE, "application/pdf; charset=UTF-8");
+        responseHeaders.set(CONTENT_TYPE, mediaType.toString());
         responseHeaders.set(CONTENT_DISPOSITION, contentDisposition);
 
         return new ResponseEntity<>(resource, responseHeaders, HttpStatus.OK);

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArchiveBackedReportContentServiceTest {
@@ -62,6 +63,7 @@ public class ArchiveBackedReportContentServiceTest {
             if (!archive.containsKey(location)) return properties;
 
             properties.put(Headers.CONTENT_LENGTH, (long) archive.get(location).length);
+            properties.put(Headers.CONTENT_TYPE, APPLICATION_PDF_UTF8.toString());
             return properties;
         });
 
@@ -76,13 +78,14 @@ public class ArchiveBackedReportContentServiceTest {
         final Report original = MockBuilder.report();
 
         try (final InputStream contents = new ByteArrayInputStream("Contents".getBytes())) {
-            final Report updated = service.writeContent(original, contents, 123L);
+            final Report updated = service.writeContent(original, contents, 123L, APPLICATION_PDF_UTF8);
 
             final ReportContentResource resource = service.openContent(updated);
             try (final InputStream retrievedContents = resource.getInputStream()) {
                 assertThat(IOUtils.toString(retrievedContents)).isEqualTo("Contents");
             }
             assertThat(resource.contentLength()).isGreaterThan(0);
+            assertThat(resource.getContentType()).isEqualTo(APPLICATION_PDF_UTF8.toString());
         }
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
@@ -85,7 +85,7 @@ public class ArchiveBackedReportContentServiceTest {
                 assertThat(IOUtils.toString(retrievedContents)).isEqualTo("Contents");
             }
             assertThat(resource.contentLength()).isGreaterThan(0);
-            assertThat(resource.getContentType()).isEqualTo(APPLICATION_PDF_UTF8.toString());
+            assertThat(resource.getMediaType()).isEqualTo(APPLICATION_PDF_UTF8);
         }
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMergerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/TemporaryFilePdfMergerIT.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,9 +41,9 @@ public class TemporaryFilePdfMergerIT {
             sources.add(supplier(file));
         }
 
-        final File mergedPdf = merger.mergePdfs(sources);
+        final MergedReport mergedReport = merger.mergePdfs(sources);
 
-        try (final FileInputStream mergedContent = new FileInputStream(mergedPdf)) {
+        try (final FileInputStream mergedContent = new FileInputStream(mergedReport.getFile())) {
             final PDDocument document = PDDocument.load(mergedContent);
             assertThat(document.getNumberOfPages()).isEqualTo(4);
             document.close();

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
@@ -11,11 +11,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.report.AbstractBatchExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
-import org.opentestsystem.rdw.reporting.processor.service.PdfMergeService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
+import org.opentestsystem.rdw.reporting.processor.service.ReportMergeService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
+import org.springframework.http.MediaType;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GeneratePdfTest {
@@ -52,13 +55,13 @@ public class GeneratePdfTest {
     private ReportGenerationTemporaryStorage reportGenerationTemporaryStorage;
 
     @Mock
-    private PdfMergeService pdfMerger;
+    private ReportMergeService pdfMerger;
 
     @Mock
     private ReportService reportService;
 
     private ReportRequestMessage message;
-    private File mergedPdfContents;
+    private MergedReport mergedReport;
     private Report report;
     private GeneratePdf component;
 
@@ -78,11 +81,12 @@ public class GeneratePdfTest {
         final List<Supplier<InputStream>> chunkContents = Collections.emptyList();
         when(reportGenerationTemporaryStorage.getChunks(eq(ReportId), eq(3))).thenReturn(chunkContents);
 
-        mergedPdfContents = temporaryFolder.newFile();
-        try (final FileOutputStream data = new FileOutputStream(mergedPdfContents)) {
+        final File mergedContents = temporaryFolder.newFile();
+        try (final FileOutputStream data = new FileOutputStream(mergedContents)) {
             data.write("PDF Content".getBytes());
         }
-        when(pdfMerger.mergePdfs(eq(chunkContents))).thenReturn(mergedPdfContents);
+        mergedReport = new MergedReport(mergedContents, APPLICATION_PDF_UTF8);
+        when(pdfMerger.mergePdfs(eq(chunkContents))).thenReturn(mergedReport);
 
         final AbstractBatchExamReportRequest reportRequest = mock(AbstractBatchExamReportRequest.class);
         final PrintOptions printOptions = new PrintOptions(false);
@@ -90,7 +94,7 @@ public class GeneratePdfTest {
         when(reportRequest.getLanguage()).thenReturn(Locale.US);
         when(report.getReportRequest()).thenReturn(reportRequest);
 
-        when(reportContentService.writeContent(any(Report.class), any(InputStream.class), anyLong()))
+        when(reportContentService.writeContent(any(Report.class), any(InputStream.class), anyLong(), any(MediaType.class)))
                 .thenAnswer(invocation -> {
                     final Report report = invocation.getArgumentAt(0, Report.class);
                     return Report.builder()
@@ -108,13 +112,13 @@ public class GeneratePdfTest {
 
     @Test
     public void itShouldMergeAndStorePdfContents() throws Exception {
-        final long mergedPdfLength = mergedPdfContents.length();
+        final long mergedPdfLength = mergedReport.getFile().length();
 
         component.collateReportPdf(message);
 
-        assertThat(mergedPdfContents.exists()).isFalse();
+        assertThat(mergedReport.getFile().exists()).isFalse();
 
-        verify(reportContentService).writeContent(eq(report), any(FileInputStream.class), eq(mergedPdfLength));
+        verify(reportContentService).writeContent(eq(report), any(FileInputStream.class), eq(mergedPdfLength), eq(APPLICATION_PDF_UTF8));
 
         final ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
         verify(reportService).update(reportCaptor.capture());

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -38,6 +38,7 @@ import static com.amazonaws.services.s3.Headers.CONTENT_LENGTH;
 import static com.amazonaws.services.s3.Headers.CONTENT_TYPE;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
@@ -47,6 +48,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.security.PermissionScope.STATEWIDE;
 import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
+import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_ZIP;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -169,14 +172,15 @@ public class ReportControllerIT {
     }
 
     @Test
-    public void itShouldRetrieveReportContents() throws Exception {
+    public void itShouldRetrievePDFReportContents() throws Exception {
         final Report report = report(123L);
         when(service.findOneById(report.getId())).thenReturn(Optional.of(report));
 
         final byte[] contents = "PDF CONTENTS".getBytes();
         final ReportContentResource resource = new ReportContentResource(
                 new ByteArrayInputStream(contents),
-                (long)contents.length
+                (long)contents.length,
+                APPLICATION_PDF_UTF8.toString()
         );
 
         when(reportContentService.openContent(eq(report)))
@@ -187,10 +191,38 @@ public class ReportControllerIT {
 
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
-                .andExpect(header().string(CONTENT_TYPE, "application/pdf; charset=UTF-8"))
+                .andExpect(header().string(CONTENT_TYPE, "application/pdf;charset=UTF-8"))
                 .andExpect(header().string(CONTENT_DISPOSITION, startsWith("attachment;")))
+                .andExpect(header().string(CONTENT_DISPOSITION, containsString(".pdf")))
                 .andExpect(header().longValue(CONTENT_LENGTH, contents.length))
                 .andExpect(content().string("PDF CONTENTS"));
+    }
+
+    @Test
+    public void itShouldRetrieveZipReportContents() throws Exception {
+        final Report report = report(123L);
+        when(service.findOneById(report.getId())).thenReturn(Optional.of(report));
+
+        final byte[] contents = "ZIP CONTENTS".getBytes();
+        final ReportContentResource resource = new ReportContentResource(
+                new ByteArrayInputStream(contents),
+                (long)contents.length,
+                APPLICATION_ZIP.toString()
+        );
+
+        when(reportContentService.openContent(eq(report)))
+                .thenAnswer((id) -> resource);
+
+        mvc.perform(get("/api/reports/123/content")
+                .param("user", report.getUser()))
+
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(header().string(CONTENT_TYPE, "application/zip"))
+                .andExpect(header().string(CONTENT_DISPOSITION, startsWith("attachment;")))
+                .andExpect(header().string(CONTENT_DISPOSITION, containsString(".zip")))
+                .andExpect(header().longValue(CONTENT_LENGTH, contents.length))
+                .andExpect(content().string("ZIP CONTENTS"));
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -180,7 +180,7 @@ public class ReportControllerIT {
         final ReportContentResource resource = new ReportContentResource(
                 new ByteArrayInputStream(contents),
                 (long)contents.length,
-                APPLICATION_PDF_UTF8.toString()
+                APPLICATION_PDF_UTF8
         );
 
         when(reportContentService.openContent(eq(report)))
@@ -207,7 +207,7 @@ public class ReportControllerIT {
         final ReportContentResource resource = new ReportContentResource(
                 new ByteArrayInputStream(contents),
                 (long)contents.length,
-                APPLICATION_ZIP.toString()
+                APPLICATION_ZIP
         );
 
         when(reportContentService.openContent(eq(report)))


### PR DESCRIPTION
This PR adds support for handling multiple media types for a Report.  Currently it only supports "application/pdf;charset=UTF-8" and "application/zip" but can easily be extended to include others.