### PR TITLE
Bump schema dependency version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.0.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-43"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.0.0-206"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-210"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {


### PR DESCRIPTION
With the recent permission changes, we need to bump the schema dependency version that includes the new required tables.