### PR TITLE
Do not execute unit tests when running integration test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,7 @@ subprojects {
     //This task for for manually running the integration tests against schemas being developed simultaneously with this
     // project, versus the schemas that are "fixed" under the RDW_Schema submodule in this project
     task manualIT(type: Test) {
+        exclude '**/*Test.*'
         outputs.upToDateWhen { false }
         doFirst {
             println "Running Manual Integration Tests..."
@@ -187,6 +188,7 @@ subprojects {
 
     //The omission of the ':' in manualIT is on purpose - we need the relative path to manualIT
     task IT(type: Test, dependsOn:[":cleanReportingTest", ":migrateReportingTest"]) {
+        exclude '**/*Test.*'
         outputs.upToDateWhen { false }
         doLast {
             println "Running Integration Tests..."
@@ -195,6 +197,7 @@ subprojects {
 
     //Specific integration test task that will automatically migrate the test database schemas
     task moIT(type: Test, dependsOn:[":migrateReportingTest"]) {
+        exclude '**/*Test.*'
         outputs.upToDateWhen { false }
         doFirst {
             println "Running Integration Tests without cleaning database (flyway migrate only)..."

--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ subprojects {
     //This task for for manually running the integration tests against schemas being developed simultaneously with this
     // project, versus the schemas that are "fixed" under the RDW_Schema submodule in this project
     task manualIT(type: Test) {
-        exclude '**/*Test.*'
+        include '**/*IT.*'
         outputs.upToDateWhen { false }
         doFirst {
             println "Running Manual Integration Tests..."
@@ -188,7 +188,7 @@ subprojects {
 
     //The omission of the ':' in manualIT is on purpose - we need the relative path to manualIT
     task IT(type: Test, dependsOn:[":cleanReportingTest", ":migrateReportingTest"]) {
-        exclude '**/*Test.*'
+        include '**/*IT.*'
         outputs.upToDateWhen { false }
         doLast {
             println "Running Integration Tests..."
@@ -197,7 +197,7 @@ subprojects {
 
     //Specific integration test task that will automatically migrate the test database schemas
     task moIT(type: Test, dependsOn:[":migrateReportingTest"]) {
-        exclude '**/*Test.*'
+        include '**/*IT.*'
         outputs.upToDateWhen { false }
         doFirst {
             println "Running Integration Tests without cleaning database (flyway migrate only)..."


### PR DESCRIPTION
While working on DWR-1048 I found that our integration test task is *also* executing unit tests.  This means that our unit tests are being executed 3 times during the current build process:
'build' task, 'coverage->test' task, 'coverage->IT' task

This PR changes our IT integration test task to *not* run unit tests.