### PR TITLE
Add additional details to Report payload.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Report.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Report.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
 
 import java.net.URI;
@@ -60,7 +61,7 @@ public class Report {
     /**
      * @return The report request parameters
      */
-    @JsonIgnore
+    @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="@class")
     public AbstractExamReportRequest getReportRequest() {
         return reportRequest;
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequest.java
@@ -18,6 +18,8 @@ public abstract class AbstractExamReportRequest<T> {
         return assessmentType;
     }
 
+    public abstract ReportType getReportType();
+
     public Subject getSubject() {
         return subject;
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequest.java
@@ -12,6 +12,5 @@ public class ExportExamReportRequest extends AbstractExamReportRequest<ExamExpor
     }
 
     public static class Builder extends AbstractExamReportRequest.Builder<ExamExportQueryOptions, ExportExamReportRequest, ExportExamReportRequest.Builder> {
-
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequest.java
@@ -1,4 +1,17 @@
 package org.opentestsystem.rdw.reporting.common.report;
 
 public class ExportExamReportRequest extends AbstractExamReportRequest<ExamExportQueryOptions> {
+
+    @Override
+    public ReportType getReportType() {
+        return ReportType.ExamExport;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends AbstractExamReportRequest.Builder<ExamExportQueryOptions, ExportExamReportRequest, ExportExamReportRequest.Builder> {
+
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/GroupExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/GroupExamReportRequest.java
@@ -18,6 +18,11 @@ public class GroupExamReportRequest extends AbstractBatchExamReportRequest<Print
         return new Builder();
     }
 
+    @Override
+    public ReportType getReportType() {
+        return ReportType.Group;
+    }
+
     public static class Builder extends AbstractBatchExamReportRequest.Builder<PrintOptions, GroupExamReportRequest, Builder> {
 
         private GroupGrant groupGrant;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ReportType.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/ReportType.java
@@ -1,0 +1,11 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+/**
+ * This enum represents a Report type.
+ */
+public enum ReportType {
+    SchoolGrade,
+    Group,
+    Student,
+    ExamExport
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/SchoolGradeExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/SchoolGradeExamReportRequest.java
@@ -5,6 +5,11 @@ public class SchoolGradeExamReportRequest extends AbstractBatchExamReportRequest
     private long schoolId;
     private int gradeId;
 
+    @Override
+    public ReportType getReportType() {
+        return ReportType.SchoolGrade;
+    }
+
     public long getSchoolId() {
         return schoolId;
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequest.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequest.java
@@ -4,6 +4,11 @@ public class StudentExamReportRequest extends AbstractExamReportRequest<PrintOpt
 
     private long studentId;
 
+    @Override
+    public ReportType getReportType() {
+        return ReportType.Student;
+    }
+
     public long getStudentId() {
         return studentId;
     }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/AbstractBatchExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/AbstractBatchExamReportRequestTest.java
@@ -1,0 +1,21 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.reporting.common.report.ExamReportOrder.STUDENT_SSID;
+
+public abstract class AbstractBatchExamReportRequestTest<T, A extends AbstractBatchExamReportRequest<T>, B extends AbstractBatchExamReportRequest.Builder<T, A, B>> extends AbstractExamReportRequestTest<T, A, B> {
+
+    @Override
+    public abstract AbstractBatchExamReportRequest.Builder<T, A, B> createBuilder();
+
+    @Test
+    public void itShouldStoreSortOrder() {
+        final A request = createBuilder()
+                .order(STUDENT_SSID)
+                .build(createRequest());
+
+        assertThat(request.getOrder()).isEqualTo(STUDENT_SSID);
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/AbstractExamReportRequestTest.java
@@ -1,0 +1,47 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.common.model.Subject;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractExamReportRequestTest<T, A extends AbstractExamReportRequest<T>, B extends AbstractExamReportRequest.Builder<T, A, B>> {
+
+    public abstract T createOptions();
+
+    public abstract A createRequest();
+
+    public abstract ReportType getReportType();
+
+    public abstract AbstractExamReportRequest.Builder<T, A, B> createBuilder();
+
+    @Test
+    public void itShouldStoreBaseValues() {
+        final T options = createOptions();
+
+        final A request = createBuilder()
+                .accommodationsVisible(true)
+                .assessmentType(ExamReportAssessmentType.ICA)
+                .language(Locale.US)
+                .name("my name")
+                .schoolYear(1234)
+                .subject(Subject.ELA)
+                .options(options)
+                .build(createRequest());
+
+        assertThat(request.isAccommodationsVisible()).isTrue();
+        assertThat(request.assessmentType).isEqualTo(ExamReportAssessmentType.ICA);
+        assertThat(request.getLanguage()).isEqualTo(Locale.US);
+        assertThat(request.getName()).isEqualTo("my name");
+        assertThat(request.getSchoolYear()).isEqualTo(1234);
+        assertThat(request.getSubject()).isEqualTo(Subject.ELA);
+        assertThat(request.getOptions()).isEqualTo(options);
+    }
+
+    @Test
+    public void itShouldAdvertiseTheReportType() {
+        assertThat(createRequest().getReportType()).isEqualTo(getReportType());
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/ExportExamReportRequestTest.java
@@ -1,0 +1,32 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import com.google.common.collect.ImmutableSet;
+
+public class ExportExamReportRequestTest extends AbstractExamReportRequestTest<ExamExportQueryOptions, ExportExamReportRequest, ExportExamReportRequest.Builder> {
+
+    @Override
+    public ExamExportQueryOptions createOptions() {
+        return ExamExportQueryOptions.builder()
+                .schoolYear(123)
+                .districtIds(ImmutableSet.of(1L, 2L))
+                .schoolGroupIds(ImmutableSet.of(3L, 4L))
+                .schoolIds(ImmutableSet.of(5L, 6L))
+                .districtGroupIds(ImmutableSet.of(7L, 8L))
+                .build();
+    }
+
+    @Override
+    public ExportExamReportRequest createRequest() {
+        return new ExportExamReportRequest();
+    }
+
+    @Override
+    public ReportType getReportType() {
+        return ReportType.ExamExport;
+    }
+
+    @Override
+    public ExportExamReportRequest.Builder createBuilder() {
+        return ExportExamReportRequest.builder();
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/GroupExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/GroupExamReportRequestTest.java
@@ -1,0 +1,39 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.security.GroupGrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroupExamReportRequestTest extends AbstractBatchExamReportRequestTest<PrintOptions, GroupExamReportRequest, GroupExamReportRequest.Builder> {
+
+    @Override
+    public PrintOptions createOptions() {
+        return new PrintOptions(false);
+    }
+
+    @Override
+    public GroupExamReportRequest createRequest() {
+        return new GroupExamReportRequest();
+    }
+
+    @Override
+    public ReportType getReportType() {
+        return ReportType.Group;
+    }
+
+    @Override
+    public GroupExamReportRequest.Builder createBuilder() {
+        return GroupExamReportRequest.builder();
+    }
+
+    @Test
+    public void itShouldStoreGroupGrant() {
+        final GroupGrant grant = new GroupGrant(123L, 1);
+        final GroupExamReportRequest request = createBuilder()
+                .groupGrant(grant)
+                .build();
+
+        assertThat(request.getGroupGrant()).isEqualTo(grant);
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/SchoolGradeExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/SchoolGradeExamReportRequestTest.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SchoolGradeExamReportRequestTest extends AbstractBatchExamReportRequestTest<PrintOptions, SchoolGradeExamReportRequest, SchoolGradeExamReportRequest.Builder> {
+
+    @Override
+    public PrintOptions createOptions() {
+        return new PrintOptions(false);
+    }
+
+    @Override
+    public SchoolGradeExamReportRequest createRequest() {
+        return new SchoolGradeExamReportRequest();
+    }
+
+    @Override
+    public ReportType getReportType() {
+        return ReportType.SchoolGrade;
+    }
+
+    @Override
+    public SchoolGradeExamReportRequest.Builder createBuilder() {
+        return SchoolGradeExamReportRequest.builder();
+    }
+
+    @Test
+    public void itShouldStoreSchoolAndGrade() {
+        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder()
+                .schoolId(123)
+                .gradeId(3)
+                .build();
+        assertThat(request.getSchoolId()).isEqualTo(123);
+        assertThat(request.getGradeId()).isEqualTo(3);
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequestTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/report/StudentExamReportRequestTest.java
@@ -1,0 +1,37 @@
+package org.opentestsystem.rdw.reporting.common.report;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StudentExamReportRequestTest extends AbstractExamReportRequestTest<PrintOptions, StudentExamReportRequest, StudentExamReportRequest.Builder> {
+
+    @Override
+    public PrintOptions createOptions() {
+        return new PrintOptions(true);
+    }
+
+    @Override
+    public StudentExamReportRequest createRequest() {
+        return new StudentExamReportRequest();
+    }
+
+    @Override
+    public ReportType getReportType() {
+        return ReportType.Student;
+    }
+
+    @Override
+    public StudentExamReportRequest.Builder createBuilder() {
+        return StudentExamReportRequest.builder();
+    }
+
+    @Test
+    public void itShouldStoreStudentId() {
+        final StudentExamReportRequest request = createBuilder()
+                .studentId(123L)
+                .build();
+
+        assertThat(request.getStudentId()).isEqualTo(123L);
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
@@ -77,8 +77,7 @@ public class ReportController {
     public List<Report> getReports(
             @RequestParam("user") final String user,
             @RequestParam(value = "id", required = false) final Set<Long> reportIds) {
-        final List<Report> reports = reportService.findAllByUserAndId(user, reportIds != null ? reportIds : ImmutableSet.of());
-        return reports;
+        return reportService.findAllByUserAndId(user, reportIds != null ? reportIds : ImmutableSet.of());
     }
 
     /**

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportController.java
@@ -77,7 +77,8 @@ public class ReportController {
     public List<Report> getReports(
             @RequestParam("user") final String user,
             @RequestParam(value = "id", required = false) final Set<Long> reportIds) {
-        return reportService.findAllByUserAndId(user, reportIds != null ? reportIds : ImmutableSet.of());
+        final List<Report> reports = reportService.findAllByUserAndId(user, reportIds != null ? reportIds : ImmutableSet.of());
+        return reports;
     }
 
     /**

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -13,11 +13,11 @@ import org.opentestsystem.rdw.reporting.common.report.PrintOptions;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.StudentExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.security.GroupGrant;
-import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerator;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
+import org.opentestsystem.rdw.security.GroupGrant;
+import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -46,10 +46,10 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opentestsystem.rdw.security.PermissionScope.STATEWIDE;
 import static org.opentestsystem.rdw.reporting.common.security.ReportingRoles.GroupPiiRead;
 import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_PDF_UTF8;
 import static org.opentestsystem.rdw.reporting.processor.util.MediaTypes.APPLICATION_ZIP;
+import static org.opentestsystem.rdw.security.PermissionScope.STATEWIDE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -115,13 +115,14 @@ public class ReportControllerIT {
                 .content(serializedPayload))
 
                 .andExpect(status().isAccepted())
-                .andExpect(jsonPath("$.*", hasSize(6)))
+                .andExpect(jsonPath("$.*", hasSize(7)))
                 .andExpect(jsonPath("$.id").value(report.getId()))
                 .andExpect(jsonPath("$.status").value(report.getStatus().name()))
                 .andExpect(jsonPath("$.label").value(report.getLabel()))
                 .andExpect(jsonPath("$.totalChunkCount").value(10))
                 .andExpect(jsonPath("$.completeChunkCount").value(9))
-                .andExpect(jsonPath("$.created").isNotEmpty());
+                .andExpect(jsonPath("$.created").isNotEmpty())
+                .andExpect(jsonPath("$.reportRequest").isNotEmpty());
 
         final ArgumentCaptor<BatchExamReportRequestHolder> captor = ArgumentCaptor.forClass(BatchExamReportRequestHolder.class);
         verify(reportGenerator).generateReport(captor.capture());

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ExamReportController.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.reporting.report;
 
-import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.report.ExportExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.report.SchoolGradeExamReportRequest;
@@ -26,20 +25,22 @@ import java.util.Set;
 public class ExamReportController {
 
     private final ExamReportService service;
+    private final ReportResourceAssembler assembler;
 
     @Autowired
     ExamReportController(final ExamReportService service) {
         this.service = service;
+        assembler = new ReportResourceAssembler();
     }
 
     @GetMapping("/api/reports")
-    public List<Report> getReports(
+    public List<ReportResource> getReports(
             @AuthenticationPrincipal final User user,
             @RequestParam(value = "id", required = false) final Set<Long> reportIds) {
 
-        return reportIds != null
+        return assembler.toResources(reportIds != null
                 ? service.getReports(user, reportIds)
-                : service.getReports(user);
+                : service.getReports(user));
     }
 
     @GetMapping("/api/reports/{reportId}")
@@ -53,28 +54,28 @@ public class ExamReportController {
 
     @PostMapping("/api/students/{studentId}/report")
     @ResponseStatus(HttpStatus.CREATED)
-    public Report createReport(
+    public ReportResource createReport(
             @PathVariable final long studentId,
             @AuthenticationPrincipal final User user,
             @RequestBody final StudentExamReportRequest request) throws IOException {
 
-        return service.createReport(user, request.copy().studentId(studentId).build());
+        return assembler.toResource(service.createReport(user, request.copy().studentId(studentId).build()));
     }
 
     @PostMapping("/api/schools/{schoolId}/assessmentGrades/{gradeId}/reports")
     @ResponseStatus(HttpStatus.CREATED)
-    public Report createReport(
+    public ReportResource createReport(
             @AuthenticationPrincipal final User user,
             @PathVariable final long schoolId,
             @PathVariable final int gradeId,
             @RequestBody final SchoolGradeExamReportRequest request) throws IOException {
 
-        return service.createReport(user, request.copy().schoolId(schoolId).gradeId(gradeId).build());
+        return assembler.toResource(service.createReport(user, request.copy().schoolId(schoolId).gradeId(gradeId).build()));
     }
 
     @PostMapping("/api/groups/{groupId}/reports")
     @ResponseStatus(HttpStatus.CREATED)
-    public Report createReport(
+    public ReportResource createReport(
             @PathVariable final long groupId,
             @AuthenticationPrincipal final User user,
             @RequestBody final GroupExamReportRequest request) throws IOException {
@@ -85,16 +86,16 @@ public class ExamReportController {
                 .groupGrant(user.getGroupsById().get(groupId))
                 .build();
 
-        return service.createReport(user, requestWithGroup);
+        return assembler.toResource(service.createReport(user, requestWithGroup));
     }
 
     @PostMapping("/api/exams/export")
     @ResponseStatus(HttpStatus.CREATED)
-    public Report createReport(
+    public ReportResource createReport(
             @AuthenticationPrincipal final User user,
             @RequestBody final ExportExamReportRequest request) throws IOException {
 
-        return service.createReport(user, request);
+        return assembler.toResource(service.createReport(user, request));
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ReportResource.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ReportResource.java
@@ -1,0 +1,88 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.opentestsystem.rdw.common.model.AssessmentType;
+import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.common.report.ReportType;
+
+import java.time.Instant;
+
+/**
+ * This resource contains {@link org.opentestsystem.rdw.reporting.common.model.Report}
+ * properties.
+ */
+public class ReportResource {
+
+    private Long id;
+    private ReportStatus status;
+    private String label;
+    private ReportType reportType;
+    private AssessmentType assessmentType;
+    private Subject subject;
+    private Integer schoolYear;
+    private Instant created;
+
+    public Long getId() {
+        return id;
+    }
+
+    void setId(final Long id) {
+        this.id = id;
+    }
+
+    public ReportStatus getStatus() {
+        return status;
+    }
+
+    void setStatus(final ReportStatus status) {
+        this.status = status;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    void setLabel(final String label) {
+        this.label = label;
+    }
+
+    public ReportType getReportType() {
+        return reportType;
+    }
+
+    void setReportType(final ReportType reportType) {
+        this.reportType = reportType;
+    }
+
+    public AssessmentType getAssessmentType() {
+        return assessmentType;
+    }
+
+    void setAssessmentType(final AssessmentType assessmentType) {
+        this.assessmentType = assessmentType;
+    }
+
+    public Subject getSubject() {
+        return subject;
+    }
+
+    void setSubject(final Subject subject) {
+        this.subject = subject;
+    }
+
+    public Integer getSchoolYear() {
+        return schoolYear;
+    }
+
+    void setSchoolYear(final Integer schoolYear) {
+        this.schoolYear = schoolYear;
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    void setCreated(final Instant created) {
+        this.created = created;
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ReportResourceAssembler.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/ReportResourceAssembler.java
@@ -1,0 +1,37 @@
+package org.opentestsystem.rdw.reporting.report;
+
+import org.opentestsystem.rdw.reporting.common.model.Report;
+import org.opentestsystem.rdw.reporting.common.report.AbstractExamReportRequest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Assembler for converting {@link Report} instances to {@link ReportResource} instances.
+ */
+public class ReportResourceAssembler {
+
+    public ReportResource toResource(final Report report) {
+        final ReportResource resource = new ReportResource();
+        resource.setId(report.getId());
+        resource.setStatus(report.getStatus());
+        resource.setLabel(report.getLabel());
+        resource.setCreated(report.getCreated());
+
+        final AbstractExamReportRequest request = report.getReportRequest();
+        if (request != null) {
+            resource.setReportType(request.getReportType());
+            resource.setAssessmentType(request.getAssessmentType() == null ? null : request.getAssessmentType().getAssessmentType());
+            resource.setSubject(request.getSubject());
+            resource.setSchoolYear(request.getSchoolYear());
+        }
+
+        return resource;
+    }
+
+    public List<ReportResource> toResources(final List<Report> reports) {
+        return reports.stream()
+                .map(this::toResource)
+                .collect(Collectors.toList());
+    }
+}

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/ExamReportControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/ExamReportControllerIT.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.model.Report;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportAssessmentType;
 import org.opentestsystem.rdw.reporting.common.report.ExamReportOrder;
 import org.opentestsystem.rdw.reporting.common.report.GroupExamReportRequest;
@@ -22,9 +23,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.net.URI;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -97,14 +101,33 @@ public class ExamReportControllerIT {
     public void getStudentExamReportShouldReturnHandle() throws Exception {
 
         when(service.createReport(any(User.class), any(StudentExamReportRequest.class)))
-                .thenReturn(Report.builder().id(1L).build());
+                .thenReturn(Report.builder()
+                        .id(1L)
+                        .status(ReportStatus.PENDING)
+                        .reportResourceUri(URI.create("/somewhere.pdf"))
+                        .completeChunkCount(0)
+                        .totalChunkCount(123)
+                        .user("my-user")
+                        .label("my-label")
+                        .created(Instant.now())
+                        .reportRequest(studentRequest)
+                        .build());
 
         mvc.perform(post("/api/students/1/report")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(studentRequest))
                 .with(user(user)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1L));
+                .andExpect(jsonPath("$.*", hasSize(8)))
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.label").value("my-label"))
+                .andExpect(jsonPath("$.reportType").value("Student"))
+                .andExpect(jsonPath("$.assessmentType").value("ICA"))
+                .andExpect(jsonPath("$.subject").value("MATH"))
+                .andExpect(jsonPath("$.schoolYear").value(2))
+                .andExpect(jsonPath("$.created").isNotEmpty());
+
     }
 
     @Test


### PR DESCRIPTION
This PR adds additional properties to the Report payload sent to the front-end via a ReportResource assembled from a saturated Report model instance.

This is the first step in updating the "My Reports" page to contain additional information when displaying the user's report history.

On a good note, the front-end currently only requires/uses three properties "label," "status," and "created," so these changes can be merged without requiring any associated front-end changes.