### PR TITLE
Now passing the student data to the StudentReportDownloadComponent so…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -358,6 +358,7 @@ export class AssessmentResultsComponent implements OnInit {
           options.assessmentType = this._assessmentExam.assessment.type;
           options.subject = this._assessmentExam.assessment.assessmentSubjectType;
           options.schoolYear = exam.schoolYear;
+          downloader.student = exam.student;
           downloader.title = this.translate.instant('labels.reports.form.title.single-prepopulated', {
             name: exam.student.firstName,
             schoolYear: exam.schoolYear,


### PR DESCRIPTION
… that the suggested report name can populate correctly

![image](https://user-images.githubusercontent.com/5771116/31566851-5be25ec6-b021-11e7-892b-f2d3a17d6311.png)

is now:
![image](https://user-images.githubusercontent.com/5771116/31566913-a32a2e3a-b021-11e7-9ea6-8d7bacfc8fdb.png)
