### PR TITLE
Add transferAccessEnabled tenant configuration properties.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.reporting.common.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Tenant/state configuration properties.
+ */
+@ConfigurationProperties(prefix = "tenant")
+public class TenantProperties {
+
+    private boolean transferAccessEnabled;
+
+    /**
+     * True if users with access to the students' most recent schools grant access
+     * to the entire student exam history.
+     *
+     * @return True if transfer access is enabled
+     */
+    public boolean isTransferAccessEnabled() {
+        return transferAccessEnabled;
+    }
+
+    public void setTransferAccessEnabled(final boolean transferAccessEnabled) {
+        this.transferAccessEnabled = transferAccessEnabled;
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.common.jdbc;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.security.PermissionScope;
 
@@ -27,6 +28,8 @@ public class QueryUtils {
             .put(GroupPiiRead, "group_")
             .put(IndividualPiiRead, "individual_")
             .build();
+
+    private static TenantProperties tenantProperties;
 
     private QueryUtils() {
     }
@@ -92,6 +95,7 @@ public class QueryUtils {
                 .put(prefix + "district_ids", nullOrEmptyToDefault(permissionScope.getDistrictIds(), UNMATCHABLE_IDS))
                 .put(prefix + "school_group_ids", nullOrEmptyToDefault(permissionScope.getInstitutionGroupIds(), UNMATCHABLE_IDS))
                 .put(prefix + "school_ids", nullOrEmptyToDefault(permissionScope.getInstitutionIds(), UNMATCHABLE_IDS))
+                .put(prefix + "transfer_access", tenantProperties.isTransferAccessEnabled())
                 .build();
     }
 
@@ -130,4 +134,7 @@ public class QueryUtils {
         return ImmutableList.copyOf(Splitter.on(delimiter).split(delimitedValues));
     }
 
+    private static void setTenantProperties(final TenantProperties properties) {
+        tenantProperties = properties;
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
@@ -1,9 +1,13 @@
 package org.opentestsystem.rdw.reporting.common.repository;
 
 
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
+import org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,6 +18,7 @@ import javax.sql.DataSource;
  * Configuration for the common data mart data source.
  */
 @Configuration
+@EnableConfigurationProperties(TenantProperties.class)
 public class DataSourceConfiguration {
 
     /**
@@ -35,4 +40,12 @@ public class DataSourceConfiguration {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
+    @Bean
+    public MethodInvokingFactoryBean tenantPropertiesQueryUtilSetter(final TenantProperties tenantProperties) {
+        final MethodInvokingFactoryBean setter = new MethodInvokingFactoryBean();
+        setter.setTargetClass(QueryUtils.class);
+        setter.setTargetMethod("setTenantProperties");
+        setter.setArguments(new Object[] {tenantProperties});
+        return setter;
+    }
 }


### PR DESCRIPTION
Inject transfer access value into SQL security param provider.

This PR is more for gathering thoughts than a ready-for-production patch.

*The problem:*
The issue is that we want to conditionally enable "transfer access" for an installation/environment.  This means that when querying for a student's exams we allow a user that has access to the student's *most recent school* to see the students entire exam history.
For example, a high school teacher with a student in their class has access to that student's entire exam history down to kindergarten.

This solution implements that configuration value as a standard spring property.  Since this is a security concern I want it injected as a standard SQL "security parameter."  We have a static utility class that already provides SQL security parameters, so I'd like to inject it there.  Unfortunately, we're using public static methods rather than an injected provider which means there's some nastiness with regards to DI.
This option is to inject the TenantProperties configuration bean into a static property on the utility class at application startup.
Another option would be to pull the three "getSecurityParameters" methods out of the QueryUtils class and into an injectable, singleton SecurityParameterProvider class that would then need to be injected to all repositories.
Another option would be to inject the TenantProperties into all repositories and set the "transfer_access" manually in each of them...

Thoughts?

(Just as an aside this has happened to me on every single project where we've used public static utility methods...)