### PR TITLE
Add transfer-access configuration and SQL parameter injection

### DIFF
--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/Application.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/Application.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.admin;
 
 import org.opentestsystem.rdw.admin.repository.DataSourceConfiguration;
 import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.security.SecurityConfiguration;
 import org.opentestsystem.rdw.security.repository.JdbcOrganizationRepository;
 import org.opentestsystem.rdw.utils.ResourceLoaderConfiguration;
@@ -28,7 +29,8 @@ import org.springframework.context.annotation.PropertySource;
         YamlPropertiesConfigurator.class,
         DataSourceConfiguration.class,
         SecurityConfiguration.class,
-        JdbcOrganizationRepository.class
+        JdbcOrganizationRepository.class,
+        SecurityParameterProvider.class
 })
 public class Application {
 

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/DataSourceConfiguration.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/DataSourceConfiguration.java
@@ -1,8 +1,11 @@
 package org.opentestsystem.rdw.admin.repository;
 
 
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -16,6 +19,7 @@ import javax.sql.DataSource;
  * Configuration for DataSource.
  */
 @Configuration
+@EnableConfigurationProperties(TenantProperties.class)
 @EnableTransactionManagement
 public class DataSourceConfiguration {
 
@@ -35,5 +39,10 @@ public class DataSourceConfiguration {
     @Bean
     public PlatformTransactionManager txManager() {
         return new DataSourceTransactionManager(dataSource());
+    }
+
+    @Bean
+    public SecurityParameterProvider securityParameterProvider(final TenantProperties tenantProperties) {
+        return new SecurityParameterProvider(tenantProperties);
     }
 }

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/DataSourceConfiguration.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/DataSourceConfiguration.java
@@ -1,11 +1,8 @@
 package org.opentestsystem.rdw.admin.repository;
 
 
-import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
-import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -19,7 +16,6 @@ import javax.sql.DataSource;
  * Configuration for DataSource.
  */
 @Configuration
-@EnableConfigurationProperties(TenantProperties.class)
 @EnableTransactionManagement
 public class DataSourceConfiguration {
 
@@ -41,8 +37,4 @@ public class DataSourceConfiguration {
         return new DataSourceTransactionManager(dataSource());
     }
 
-    @Bean
-    public SecurityParameterProvider securityParameterProvider(final TenantProperties tenantProperties) {
-        return new SecurityParameterProvider(tenantProperties);
-    }
 }

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
@@ -1,11 +1,12 @@
 package org.opentestsystem.rdw.admin.repository.impl;
 
 import com.google.common.collect.ImmutableMap;
-import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.admin.model.Group;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.repository.GroupRepository;
 import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -21,11 +22,11 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 
 @Repository
 public class JdbcGroupRepository implements GroupRepository {
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.group.findAllByQuery}")
     private String findAllQuery;
@@ -37,8 +38,10 @@ public class JdbcGroupRepository implements GroupRepository {
     private String deleteSql;
 
     @Autowired
-    JdbcGroupRepository(final NamedParameterJdbcTemplate template) {
+    JdbcGroupRepository(final NamedParameterJdbcTemplate template,
+                        final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -46,7 +49,7 @@ public class JdbcGroupRepository implements GroupRepository {
         return template.query(
                 findAllQuery,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(securityParameterProvider.getSecurityParameters(permissionScope))
                         .addValues(getQueryParameters(query)),
                 (row, index) -> mapResultToGroup(row)
         );
@@ -56,7 +59,7 @@ public class JdbcGroupRepository implements GroupRepository {
     public List<Integer> findAllDistinctSchoolYears(@NotNull final PermissionScope permissionScope) {
         return template.query(
                 findAllDistinctSchoolYears,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) -> row.getInt("school_year")
         );
     }
@@ -68,7 +71,7 @@ public class JdbcGroupRepository implements GroupRepository {
         final int result = template.update(
                 deleteSql,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(securityParameterProvider.getSecurityParameters(permissionScope))
                         .addValue("id", id)
                         .addValue("import_id", importId)
         );

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolRepository.java
@@ -1,8 +1,9 @@
 package org.opentestsystem.rdw.admin.repository.impl;
 
 import org.opentestsystem.rdw.admin.model.Organization;
-import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.admin.repository.SchoolRepository;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -11,26 +12,27 @@ import org.springframework.stereotype.Repository;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
-
 @Repository("schoolGradeJdbcSchoolRepository")
 class JdbcSchoolRepository implements SchoolRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.school.findAll}")
     private String findAllQuery;
 
     @Autowired
-    JdbcSchoolRepository(final NamedParameterJdbcTemplate template) {
+    JdbcSchoolRepository(final NamedParameterJdbcTemplate template,
+                         final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
     public List<Organization> findAll(@NotNull final PermissionScope permissionScope) {
         return template.query(
                 findAllQuery,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) -> new Organization(
                         row.getLong("id"),
                         row.getString("name"),

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/RepositoryIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/RepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.admin.repository;
 
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,7 +28,8 @@ import java.lang.annotation.Target;
 @SpringBootTest(classes = {
         DataSourceAutoConfiguration.class,
         DataSourceConfiguration.class,
-        YamlPropertiesConfigurator.class}
+        YamlPropertiesConfigurator.class,
+        SecurityParameterProvider.class}
 )
 @Transactional
 @ActiveProfiles("test")

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.reporting.common.configuration;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Tenant/state configuration properties.
+ */
+@ConfigurationProperties(prefix = "tenant")
+public class TenantProperties {
+
+    private boolean transferAccessEnabled;
+
+    /**
+     * True if users with access to the students' most recent schools grant access
+     * to the entire student exam history.
+     *
+     * @return True if transfer access is enabled
+     */
+    public boolean isTransferAccessEnabled() {
+        return transferAccessEnabled;
+    }
+
+    public void setTransferAccessEnabled(final boolean transferAccessEnabled) {
+        this.transferAccessEnabled = transferAccessEnabled;
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
@@ -2,19 +2,13 @@ package org.opentestsystem.rdw.reporting.common.jdbc;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.opentestsystem.rdw.security.Permission;
-import org.opentestsystem.rdw.security.PermissionScope;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.GroupPiiRead;
-import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.IndividualPiiRead;
 
 /**
  * Holds common methods for preparing SQL queries and parsing their results
@@ -22,11 +16,6 @@ import static org.opentestsystem.rdw.reporting.common.security.ReportingPermissi
 public class QueryUtils {
 
     public static final List<Long> UNMATCHABLE_IDS = ImmutableList.of(-1L);
-    private static final Map<String, String> PERMISSION_PREFIXES = ImmutableMap
-            .<String, String>builder()
-            .put(GroupPiiRead, "group_")
-            .put(IndividualPiiRead, "individual_")
-            .build();
 
     private QueryUtils() {
     }
@@ -44,55 +33,6 @@ public class QueryUtils {
             return defaultValue;
         }
         return collection;
-    }
-
-    /**
-     * Creates map of SQL query parameters for the given permissions based on the defined permission prefixes
-     *
-     * @param permissionsById the security information to prepare the SQL query parameters for
-     * @return map of SQL query parameters for the given permission scope
-     */
-    public static Map<String, Object> getSecurityParameters(final Map<String, Permission> permissionsById) {
-        final ImmutableMap.Builder<String, Object> securityParameters = ImmutableMap.builder();
-
-        PERMISSION_PREFIXES
-                .forEach((key, value) -> {
-                    final Permission permission = permissionsById.get(key);
-                    final PermissionScope scope = permission == null
-                            ? PermissionScope.EMPTY
-                            : permission.getScope();
-
-                    securityParameters.putAll(getSecurityParameters(scope, value));
-                });
-
-        return securityParameters.build();
-    }
-
-    /**
-     * Creates map of SQL query parameters for the given permission scope
-     *
-     * @param permissionScope the security information to prepare the SQL query parameters for
-     * @return map of SQL query parameters for the given permission scope
-     */
-    public static Map<String, Object> getSecurityParameters(final PermissionScope permissionScope) {
-        return getSecurityParameters(permissionScope, "");
-    }
-
-    /**
-     * Creates map of SQL query parameters for the given permission scope
-     *
-     * @param permissionScope the security information to prepare the SQL query parameters for
-     * @param prefix          parameter prefix to apply for this permissionScope
-     * @return map of SQL query parameters for the given permission scope
-     */
-    public static Map<String, Object> getSecurityParameters(final PermissionScope permissionScope, final String prefix) {
-        return ImmutableMap.<String, Object>builder()
-                .put(prefix + "statewide", permissionScope.isStatewide())
-                .put(prefix + "district_group_ids", nullOrEmptyToDefault(permissionScope.getDistrictGroupIds(), UNMATCHABLE_IDS))
-                .put(prefix + "district_ids", nullOrEmptyToDefault(permissionScope.getDistrictIds(), UNMATCHABLE_IDS))
-                .put(prefix + "school_group_ids", nullOrEmptyToDefault(permissionScope.getInstitutionGroupIds(), UNMATCHABLE_IDS))
-                .put(prefix + "school_ids", nullOrEmptyToDefault(permissionScope.getInstitutionIds(), UNMATCHABLE_IDS))
-                .build();
     }
 
     /**

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
@@ -1,0 +1,81 @@
+package org.opentestsystem.rdw.reporting.common.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
+
+import java.util.Map;
+
+import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.UNMATCHABLE_IDS;
+import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.GroupPiiRead;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.IndividualPiiRead;
+
+/**
+ * This bean is responsible for providing SQL security parameters.
+ */
+public class SecurityParameterProvider {
+
+    private static final Map<String, String> PERMISSION_PREFIXES = ImmutableMap
+            .<String, String>builder()
+            .put(GroupPiiRead, "group_")
+            .put(IndividualPiiRead, "individual_")
+            .build();
+
+    private final TenantProperties tenantProperties;
+
+    public SecurityParameterProvider(final TenantProperties tenantProperties) {
+        this.tenantProperties = tenantProperties;
+    }
+
+    /**
+     * Creates map of SQL query parameters for the given permissions based on the defined permission prefixes
+     *
+     * @param permissionsById the security information to prepare the SQL query parameters for
+     * @return map of SQL query parameters for the given permission scope
+     */
+    public Map<String, Object> getSecurityParameters(final Map<String, Permission> permissionsById) {
+        final ImmutableMap.Builder<String, Object> securityParameters = ImmutableMap.builder();
+
+        PERMISSION_PREFIXES
+                .forEach((key, value) -> {
+                    final Permission permission = permissionsById.get(key);
+                    final PermissionScope scope = permission == null
+                            ? PermissionScope.EMPTY
+                            : permission.getScope();
+
+                    securityParameters.putAll(getSecurityParameters(scope, value));
+                });
+
+        return securityParameters.build();
+    }
+
+    /**
+     * Creates map of SQL query parameters for the given permission scope
+     *
+     * @param permissionScope the security information to prepare the SQL query parameters for
+     * @return map of SQL query parameters for the given permission scope
+     */
+    public Map<String, Object> getSecurityParameters(final PermissionScope permissionScope) {
+        return getSecurityParameters(permissionScope, "");
+    }
+
+    /**
+     * Creates map of SQL query parameters for the given permission scope
+     *
+     * @param permissionScope the security information to prepare the SQL query parameters for
+     * @param prefix          parameter prefix to apply for this permissionScope
+     * @return map of SQL query parameters for the given permission scope
+     */
+    public Map<String, Object> getSecurityParameters(final PermissionScope permissionScope, final String prefix) {
+        return ImmutableMap.<String, Object>builder()
+                .put(prefix + "statewide", permissionScope.isStatewide())
+                .put(prefix + "district_group_ids", nullOrEmptyToDefault(permissionScope.getDistrictGroupIds(), UNMATCHABLE_IDS))
+                .put(prefix + "district_ids", nullOrEmptyToDefault(permissionScope.getDistrictIds(), UNMATCHABLE_IDS))
+                .put(prefix + "school_group_ids", nullOrEmptyToDefault(permissionScope.getInstitutionGroupIds(), UNMATCHABLE_IDS))
+                .put(prefix + "school_ids", nullOrEmptyToDefault(permissionScope.getInstitutionIds(), UNMATCHABLE_IDS))
+                .put(prefix + "allow_transfer_access", tenantProperties.isTransferAccessEnabled())
+                .build();
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
@@ -4,6 +4,9 @@ import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
@@ -15,6 +18,8 @@ import static org.opentestsystem.rdw.reporting.common.security.ReportingPermissi
 /**
  * This bean is responsible for providing SQL security parameters.
  */
+@Service
+@EnableConfigurationProperties(TenantProperties.class)
 public class SecurityParameterProvider {
 
     private static final Map<String, String> PERMISSION_PREFIXES = ImmutableMap
@@ -25,6 +30,7 @@ public class SecurityParameterProvider {
 
     private final TenantProperties tenantProperties;
 
+    @Autowired
     public SecurityParameterProvider(final TenantProperties tenantProperties) {
         this.tenantProperties = tenantProperties;
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
@@ -1,9 +1,12 @@
 package org.opentestsystem.rdw.reporting.common.repository;
 
 
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,6 +17,7 @@ import javax.sql.DataSource;
  * Configuration for the common data mart data source.
  */
 @Configuration
+@EnableConfigurationProperties(TenantProperties.class)
 public class DataSourceConfiguration {
 
     /**
@@ -35,4 +39,8 @@ public class DataSourceConfiguration {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
+    @Bean
+    public SecurityParameterProvider securityParameterProvider(final TenantProperties tenantProperties) {
+        return new SecurityParameterProvider(tenantProperties);
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
@@ -1,12 +1,9 @@
 package org.opentestsystem.rdw.reporting.common.repository;
 
 
-import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
-import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -17,7 +14,6 @@ import javax.sql.DataSource;
  * Configuration for the common data mart data source.
  */
 @Configuration
-@EnableConfigurationProperties(TenantProperties.class)
 public class DataSourceConfiguration {
 
     /**
@@ -39,8 +35,4 @@ public class DataSourceConfiguration {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
-    @Bean
-    public SecurityParameterProvider securityParameterProvider(final TenantProperties tenantProperties) {
-        return new SecurityParameterProvider(tenantProperties);
-    }
 }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/ITDataSourceConfiguration.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/ITDataSourceConfiguration.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.common.test;
 
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,10 @@ import javax.sql.DataSource;
 @Profile("test")
 @Configuration
 @EnableTransactionManagement
-@Import({DataSourceConfiguration.class})
+@Import({
+        DataSourceConfiguration.class,
+        SecurityParameterProvider.class
+})
 public class ITDataSourceConfiguration {
 
     @Bean

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplication.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplication.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.processor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentestsystem.rdw.common.status.StatusConfiguration;
 import org.opentestsystem.rdw.reporting.common.i18n.TranslationConfiguration;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.processor.service.WkhtmltopdfWebServiceClient;
 import org.opentestsystem.rdw.utils.ResourceLoaderConfiguration;
@@ -40,7 +41,8 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
         StatusConfiguration.class,
         YamlPropertiesConfigurator.class,
         DataSourceConfiguration.class,
-        TranslationConfiguration.class
+        TranslationConfiguration.class,
+        SecurityParameterProvider.class
 })
 public class ReportProcessorApplication {
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcExamRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcExamRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.report.ExportExamReportRequest;
 import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,6 @@ import java.sql.PreparedStatement;
 import java.util.Map;
 
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.UNMATCHABLE_IDS;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
 
 @Repository
@@ -23,11 +23,14 @@ public class JdbcExamRepository implements ExamRepository {
     @Value("${sql.export.exam}")
     private String exportExam;
 
-    private NamedParameterJdbcTemplate template;
+    private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Autowired
-    JdbcExamRepository(final NamedParameterJdbcTemplate template) {
+    JdbcExamRepository(final NamedParameterJdbcTemplate template,
+                       final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -37,7 +40,7 @@ public class JdbcExamRepository implements ExamRepository {
         template.execute(
                 exportExam.replace(ExportDestination, isDestinationS3 ? "S3" : ""),
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissionScope, "individual_"))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissionScope, "individual_"))
                         .putAll(getQueryParameters(request))
                         .put("export_location", uriLocation)
                         .build(),

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepository.java
@@ -7,16 +7,16 @@ import com.google.common.collect.MultimapBuilder;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.jdbc.Assessments;
 import org.opentestsystem.rdw.reporting.common.jdbc.Exams;
-import org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.jdbc.Students;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.processor.model.IabReport;
 import org.opentestsystem.rdw.reporting.processor.util.StudentEnrollments;
+import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -40,6 +40,7 @@ import static org.opentestsystem.rdw.reporting.processor.util.ReportProcessorUti
 class JdbcIabReportRepository implements IabReportRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.exam.findAllIabsByStudentIdAndSchoolYearAndSubject}")
     private String findAllIabsByStudentIdAndSchoolYearAndSubject;
@@ -57,8 +58,10 @@ class JdbcIabReportRepository implements IabReportRepository {
     private String stateCode;
 
     @Autowired
-    JdbcIabReportRepository(final NamedParameterJdbcTemplate template) {
+    JdbcIabReportRepository(final NamedParameterJdbcTemplate template,
+                            final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -79,7 +82,7 @@ class JdbcIabReportRepository implements IabReportRepository {
         template.query(
                 findAllIabsByStudentIdAndSchoolYearAndSubject,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(QueryUtils.getSecurityParameters(permissions))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissions))
                         .put("group_ids", nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
                         .put("student_id", studentId)
                         .put("school_year", schoolYear)
@@ -121,7 +124,7 @@ class JdbcIabReportRepository implements IabReportRepository {
         template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
+                        .addValues(getSecurityParameters(securityParameterProvider, userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams))
                         .addValue("student_ids", studentIds),
                 (row) -> {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaReportRepository.java
@@ -4,15 +4,16 @@ import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.jdbc.Assessments;
 import org.opentestsystem.rdw.reporting.common.jdbc.Exams;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.jdbc.Students;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
-import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.processor.model.IcaReport;
 import org.opentestsystem.rdw.reporting.processor.util.StudentEnrollments;
+import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -27,9 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.UNMATCHABLE_IDS;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.safeSplit;
 import static org.opentestsystem.rdw.reporting.processor.util.ReportProcessorUtils.getExamFilterParameters;
 import static org.opentestsystem.rdw.reporting.processor.util.ReportProcessorUtils.getSecurityParameters;
 
@@ -37,6 +36,7 @@ import static org.opentestsystem.rdw.reporting.processor.util.ReportProcessorUti
 class JdbcIcaReportRepository implements IcaReportRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.exam.findLatestIcaByStudentIdAndSchoolYearAndSubject}")
     private String findLatestIcaByStudentIdAndSchoolYearAndSubject;
@@ -54,8 +54,10 @@ class JdbcIcaReportRepository implements IcaReportRepository {
     private String stateCode;
 
     @Autowired
-    JdbcIcaReportRepository(final NamedParameterJdbcTemplate template) {
+    JdbcIcaReportRepository(final NamedParameterJdbcTemplate template,
+                            final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -70,7 +72,7 @@ class JdbcIcaReportRepository implements IcaReportRepository {
             return template.queryForObject(
                     findLatestIcaByStudentIdAndSchoolYearAndSubject,
                     ImmutableMap.<String, Object>builder()
-                            .putAll(getSecurityParameters(permissions))
+                            .putAll(securityParameterProvider.getSecurityParameters(permissions))
                             .put("group_ids", nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
                             .put("student_id", studentId)
                             .put("subject_id", subjectId)
@@ -100,7 +102,7 @@ class JdbcIcaReportRepository implements IcaReportRepository {
         template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
+                        .addValues(getSecurityParameters(securityParameterProvider, userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams))
                         .addValue("student_ids", studentIds),
                 (row) -> {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepository.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.jdbc.Students;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
@@ -31,10 +32,13 @@ public class JdbcStudentRepository implements StudentRepository {
     private String findByExamQueryParamsGroupPermissions;
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Autowired
-    public JdbcStudentRepository(final NamedParameterJdbcTemplate template) {
+    public JdbcStudentRepository(final NamedParameterJdbcTemplate template,
+                                 final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -45,7 +49,7 @@ public class JdbcStudentRepository implements StudentRepository {
         return template.query(
                 query,
                 new MapSqlParameterSource()
-                        .addValues(getSecurityParameters(userPermissions, examQueryParams.getQueryPermissionType()))
+                        .addValues(getSecurityParameters(securityParameterProvider, userPermissions, examQueryParams.getQueryPermissionType()))
                         .addValues(getExamFilterParameters(examQueryParams)),
                 (row, rowNum) -> Students.map(row, Student.builder()).build()
         );

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/ReportProcessorUtils.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/ReportProcessorUtils.java
@@ -1,10 +1,10 @@
 package org.opentestsystem.rdw.reporting.processor.util;
 
-import org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.security.PermissionScope;
-import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 import java.util.HashMap;
@@ -24,29 +24,31 @@ public class ReportProcessorUtils {
      * Retrieve the correct security parameters for the given user permissions
      * and exam query permission type.
      *
-     * @param userPermissions       The requesting user's permissions
-     * @param queryPermissionType   The query permission type
+     * @param securityParameterProvider The security parameter provider
+     * @param userPermissions           The requesting user's permissions
+     * @param queryPermissionType       The query permission type
      * @return The appropriate security parameters
      */
-    public static Map<String, Object> getSecurityParameters(final UserPermissions userPermissions,
+    public static Map<String, Object> getSecurityParameters(final SecurityParameterProvider securityParameterProvider,
+                                                            final UserPermissions userPermissions,
                                                             final ExamQueryParams.PermissionType queryPermissionType) {
         switch (queryPermissionType) {
             case Unknown:
                 return new MapSqlParameterSource()
-                        .addValues(QueryUtils.getSecurityParameters(userPermissions.getPermissionsById()))
+                        .addValues(securityParameterProvider.getSecurityParameters(userPermissions.getPermissionsById()))
                         .addValue("group_ids", nullOrEmptyToDefault(userPermissions.getGroupsById().keySet(), UNMATCHABLE_IDS))
                         .getValues();
             case Individual:
                 final Permission individualPiiPermission = userPermissions.getPermissionsById().get(IndividualPiiRead);
                 final PermissionScope individualScope = individualPiiPermission == null ? PermissionScope.EMPTY : individualPiiPermission.getScope();
                 return new MapSqlParameterSource()
-                        .addValues(QueryUtils.getSecurityParameters(individualScope))
+                        .addValues(securityParameterProvider.getSecurityParameters(individualScope))
                         .getValues();
             case Group:
                 final Permission groupPiiPermission = userPermissions.getPermissionsById().get(GroupPiiRead);
                 final PermissionScope groupScope = groupPiiPermission == null ? PermissionScope.EMPTY : groupPiiPermission.getScope();
                 return new MapSqlParameterSource()
-                        .addValues(QueryUtils.getSecurityParameters(groupScope))
+                        .addValues(securityParameterProvider.getSecurityParameters(groupScope))
                         .getValues();
             default:
                 throw new IllegalArgumentException("Unknown query permission type: " + queryPermissionType);

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/Application.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/Application.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting;
 
 import org.opentestsystem.rdw.common.status.StatusConfiguration;
 import org.opentestsystem.rdw.reporting.common.i18n.TranslationConfiguration;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.security.SecurityConfiguration;
 import org.opentestsystem.rdw.reporting.report.ReportConfiguration;
@@ -32,7 +33,8 @@ import org.springframework.context.annotation.PropertySource;
         TranslationConfiguration.class,
         ReportConfiguration.class,
         SecurityConfiguration.class,
-        JdbcOrganizationRepository.class
+        JdbcOrganizationRepository.class,
+        SecurityParameterProvider.class
 })
 public class Application {
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/organization/JdbcOrganizationRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/organization/JdbcOrganizationRepository.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.organization;
 
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.organization.model.District;
 import org.opentestsystem.rdw.reporting.organization.model.DistrictGroup;
 import org.opentestsystem.rdw.reporting.organization.model.School;
@@ -14,12 +15,12 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 
 @Repository()
 class JdbcOrganizationRepository implements OrganizationRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.organization.school.findAll}")
     private String findAllSchoolsQuery;
@@ -34,15 +35,17 @@ class JdbcOrganizationRepository implements OrganizationRepository {
     private String findAllDistrictGroupsQuery;
 
     @Autowired
-    JdbcOrganizationRepository(final NamedParameterJdbcTemplate template) {
+    JdbcOrganizationRepository(final NamedParameterJdbcTemplate template,
+                               final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
     public List<School> findAllSchools(@NotNull final PermissionScope permissionScope) {
         return template.query(
                 findAllSchoolsQuery,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) ->
                         School
                                 .builder()
@@ -59,7 +62,7 @@ class JdbcOrganizationRepository implements OrganizationRepository {
     public List<SchoolGroup> findAllSchoolGroups(final PermissionScope permissionScope) {
         return template.query(
                 findAllSchoolGroupsQuery,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) ->
                         SchoolGroup
                                 .builder()
@@ -74,7 +77,7 @@ class JdbcOrganizationRepository implements OrganizationRepository {
     public List<District> findAllDistricts(@NotNull final PermissionScope permissionScope) {
         return template.query(
                 findAllDistrictsQuery,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) ->
                         District
                                 .builder()
@@ -88,7 +91,7 @@ class JdbcOrganizationRepository implements OrganizationRepository {
     public List<DistrictGroup> findAllDistrictGroups(@NotNull final PermissionScope permissionScope) {
         return template.query(
                 findAllDistrictGroupsQuery,
-                getSecurityParameters(permissionScope),
+                securityParameterProvider.getSecurityParameters(permissionScope),
                 (row, index) -> new DistrictGroup(row.getLong("id"), row.getString("name"))
         );
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/assessmentgrade/JdbcAssessmentGradeRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/assessmentgrade/JdbcAssessmentGradeRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.assessmentgrade;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.exam.Grade;
 import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,19 +12,20 @@ import org.springframework.stereotype.Repository;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
-
 @Repository("schoolGradeJdbcGradeRepository")
 class JdbcAssessmentGradeRepository implements AssessmentGradeRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.assessment.grade.findAllForSchool}")
     private String findAllForSchoolQuery;
 
     @Autowired
-    public JdbcAssessmentGradeRepository(@NotNull final NamedParameterJdbcTemplate template) {
+    public JdbcAssessmentGradeRepository(final NamedParameterJdbcTemplate template,
+                                         final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
@@ -31,7 +33,7 @@ class JdbcAssessmentGradeRepository implements AssessmentGradeRepository {
         return template.query(
                 findAllForSchoolQuery,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissionScope))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissionScope))
                         .put("school_id", schoolId)
                         .build(),
                 (row, index) -> new Grade(

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractAssessmentRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractAssessmentRepository.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.search.exam;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.jdbc.Assessments;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -14,20 +15,20 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
-
-
 public abstract class AbstractAssessmentRepository<T extends AbstractAssessmentSearch> implements AssessmentRepository<T> {
 
     protected final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
     private final String findLatestQuery;
     private final String findAllQuery;
 
     protected AbstractAssessmentRepository(
             @NotNull final NamedParameterJdbcTemplate template,
+            @NotNull final SecurityParameterProvider securityParameterProvider,
             @NotNull final String findLatestQuery,
             @NotNull final String findAllQuery) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
         this.findLatestQuery = findLatestQuery;
         this.findAllQuery = findAllQuery;
     }
@@ -36,7 +37,7 @@ public abstract class AbstractAssessmentRepository<T extends AbstractAssessmentS
 
     private Map<String, Object> createParameters(final PermissionScope permissionScope, final T search) {
         return ImmutableMap.<String, Object>builder()
-                .putAll(getSecurityParameters(permissionScope))
+                .putAll(securityParameterProvider.getSecurityParameters(permissionScope))
                 .put("school_year", search.getSchoolYear())
                 .putAll(getParameters(search))
                 .build();

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamItemRepository.java
@@ -1,26 +1,28 @@
 package org.opentestsystem.rdw.reporting.search.exam;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.exam.ExamItem;
-import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.reporting.exam.ExamItems;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
-
 public abstract class AbstractExamItemRepository<T extends AbstractExamSearch> implements ExamItemRepository<T> {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
     private final String findAllExamItemScoresForAssessmentQuery;
 
     protected AbstractExamItemRepository(
             @NotNull final NamedParameterJdbcTemplate template,
+            @NotNull final SecurityParameterProvider securityParameterProvider,
             @NotNull final String findAllExamItemScoresForAssessmentQuery) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
         this.findAllExamItemScoresForAssessmentQuery = findAllExamItemScoresForAssessmentQuery;
     }
 
@@ -34,7 +36,7 @@ public abstract class AbstractExamItemRepository<T extends AbstractExamSearch> i
         return template.query(
                 findAllExamItemScoresForAssessmentQuery,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissionScope))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissionScope))
                         .put("school_year", search.getSchoolYear())
                         .put("assessment_id", search.getAssessmentId())
                         .putAll(getParameters(search))

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/AbstractExamRepository.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.search.exam;
 
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.jdbc.Exams;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.jdbc.StudentContexts;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
@@ -22,13 +23,11 @@ import java.util.Set;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
-
 
 public abstract class AbstractExamRepository<T extends AbstractExamSearch> implements ExamRepository<T> {
 
-
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
     private final String findAllForAssessmentQuery;
 
     @Value("${sql.ethnicity.findEthnicityCodesByStudentIds}")
@@ -36,8 +35,10 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
 
     protected AbstractExamRepository(
             @NotNull final NamedParameterJdbcTemplate template,
+            @NotNull final SecurityParameterProvider securityParameterProvider,
             @NotNull final String findAllForAssessmentQuery) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
         this.findAllForAssessmentQuery = findAllForAssessmentQuery;
     }
 
@@ -47,7 +48,7 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
         return template.query(
                 findAllForAssessmentQuery,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissionScope))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissionScope))
                         .put("school_year", search.getSchoolYear())
                         .put("assessment_id", search.getAssessmentId())
                         .putAll(getParameters(search))

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupAssessmentRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupAssessmentRepository.java
@@ -1,13 +1,13 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractAssessmentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 @Repository
@@ -15,10 +15,11 @@ class JdbcGroupAssessmentRepository extends AbstractAssessmentRepository<GroupAs
 
     @Autowired
     JdbcGroupAssessmentRepository(
-            @NotNull final NamedParameterJdbcTemplate template,
+            final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.group.exam.findLatest}") final String findLatestQuery,
             @Value("${sql.group.assessment.findAll}") final String findAllQuery) {
-        super(template, findLatestQuery, findAllQuery);
+        super(template, securityParameterProvider, findLatestQuery, findAllQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamItemRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractExamItemRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +16,9 @@ class JdbcGroupExamItemRepository extends AbstractExamItemRepository<GroupExamSe
     @Autowired
     JdbcGroupExamItemRepository(
             final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.group.exam.item.findAllExamItemScoresForAssessment}") final String findAllExamItemScoresForAssessmentQuery) {
-        super(template, findAllExamItemScoresForAssessmentQuery);
+        super(template, securityParameterProvider, findAllExamItemScoresForAssessmentQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractExamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +16,9 @@ class JdbcGroupExamRepository extends AbstractExamRepository<GroupExamSearch> im
     @Autowired
     JdbcGroupExamRepository(
             final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.group.exam.findAllForAssessment}") final String findAllForAssessmentQuery) {
-        super(template, findAllForAssessmentQuery);
+        super(template, securityParameterProvider, findAllForAssessmentQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeAssessmentRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeAssessmentRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractAssessmentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,9 +16,10 @@ class JdbcSchoolGradeAssessmentRepository extends AbstractAssessmentRepository<S
     @Autowired
     JdbcSchoolGradeAssessmentRepository(
             final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.schoolgrade.exam.findLatest}") final String findLatestQuery,
             @Value("${sql.schoolgrade.assessment.findAll}") final String findAllQuery) {
-        super(template, findLatestQuery, findAllQuery);
+        super(template, securityParameterProvider, findLatestQuery, findAllQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamItemRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractExamItemRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +16,9 @@ class JdbcSchoolGradeExamItemRepository extends AbstractExamItemRepository<Schoo
     @Autowired
     JdbcSchoolGradeExamItemRepository(
             final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.schoolgrade.exam.item.findAllExamItemScoresForAssessment}") final String findAllExamItemScoresForAssessmentQuery) {
-        super(template, findAllExamItemScoresForAssessmentQuery);
+        super(template, securityParameterProvider, findAllExamItemScoresForAssessmentQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepository.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.search.exam.AbstractExamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,8 +16,9 @@ class JdbcSchoolGradeExamRepository extends AbstractExamRepository<SchoolGradeEx
     @Autowired
     JdbcSchoolGradeExamRepository(
             final NamedParameterJdbcTemplate template,
+            final SecurityParameterProvider securityParameterProvider,
             @Value("${sql.schoolgrade.exam.findAllForAssessment}") final String findAllForAssessmentQuery) {
-        super(template, findAllForAssessmentQuery);
+        super(template, securityParameterProvider, findAllForAssessmentQuery);
     }
 
     @Override

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcExamItemRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcExamItemRepository.java
@@ -1,9 +1,10 @@
 package org.opentestsystem.rdw.reporting.search.exam.student;
 
 import com.google.common.collect.ImmutableMap;
-import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.exam.ExamItem;
 import org.opentestsystem.rdw.reporting.exam.ExamItems;
+import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -15,28 +16,32 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.UNMATCHABLE_IDS;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
 
 @Repository
 class JdbcExamItemRepository implements ExamItemRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.exam.item.findAllForExam}")
     private String findAllByExamAndStudentQuery;
 
     @Autowired
-    JdbcExamItemRepository(final NamedParameterJdbcTemplate template) {
+    JdbcExamItemRepository(final NamedParameterJdbcTemplate template,
+                           final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
-    public List<ExamItem> findAllByExamId(@NotNull final Map<String, Permission> permissions, Set<Long> groupIds, final long examId) {
+    public List<ExamItem> findAllByExamId(@NotNull final Map<String, Permission> permissions,
+                                          final Set<Long> groupIds,
+                                          final long examId) {
         return template.query(
                 findAllByExamAndStudentQuery,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissions))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissions))
                         .put("group_ids", nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
                         .put("exam_id", examId)
                         .build(),

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepository.java
@@ -3,11 +3,12 @@ package org.opentestsystem.rdw.reporting.search.exam.student;
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.jdbc.Assessments;
 import org.opentestsystem.rdw.reporting.common.jdbc.Exams;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
-import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.reporting.organization.model.Organization;
+import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -20,13 +21,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.UNMATCHABLE_IDS;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getSecurityParameters;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
 
 @Repository
 class JdbcStudentExamRepository implements StudentExamRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
 
     @Value("${sql.exam.findAllByStudentId}")
     private String findAllByStudentIdQuery;
@@ -35,16 +36,20 @@ class JdbcStudentExamRepository implements StudentExamRepository {
     private String existsForStudentIdQuery;
 
     @Autowired
-    JdbcStudentExamRepository(final NamedParameterJdbcTemplate template) {
+    JdbcStudentExamRepository(final NamedParameterJdbcTemplate template,
+                              final SecurityParameterProvider securityParameterProvider) {
         this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
     }
 
     @Override
-    public List<StudentHistoryExamWrapper> findAllForStudent(@NotNull final Map<String, Permission> permissions, Set<Long> groupIds, final long studentId) {
+    public List<StudentHistoryExamWrapper> findAllForStudent(@NotNull final Map<String, Permission> permissions,
+                                                             final Set<Long> groupIds,
+                                                             final long studentId) {
         return template.query(
                 findAllByStudentIdQuery,
                 ImmutableMap.<String, Object>builder()
-                        .putAll(getSecurityParameters(permissions))
+                        .putAll(securityParameterProvider.getSecurityParameters(permissions))
                         .put("group_ids",  nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
                         .put("student_id", studentId)
                         .build(),
@@ -74,12 +79,14 @@ class JdbcStudentExamRepository implements StudentExamRepository {
     }
 
     @Override
-    public Student findStudentWithExams(@NotNull final Map<String, Permission> permissions, Set<Long> groupIds, final String ssid) {
+    public Student findStudentWithExams(@NotNull final Map<String, Permission> permissions,
+                                        final Set<Long> groupIds,
+                                        final String ssid) {
         try {
             return template.queryForObject(
                     existsForStudentIdQuery,
                     ImmutableMap.<String, Object>builder()
-                            .putAll(getSecurityParameters(permissions))
+                            .putAll(securityParameterProvider.getSecurityParameters(permissions))
                             .put("group_ids",  nullOrEmptyToDefault(groupIds, UNMATCHABLE_IDS))
                             .put("student_ssid", ssid)
                             .build(),


### PR DESCRIPTION
This is a follow-on to #536 that uses an injected SecurityParametersProvider to translate a user's permissions into SQL security parameters.