### PR TITLE
rename admin webapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 1.1.x
+
+* Rename rdw-admin-webapp to rdw-reporting-admin-webapp (affects configuration files).
+
 #### 1.0.4 - 2017-10-17
 
 * Use assessment grade when filtering results for printed student reports (DWR-1101).

--- a/admin-webapp/docker-compose.yml
+++ b/admin-webapp/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - SPRING_RABBITMQ_PASSWORD=guest
 
   webapp:
-    image: smarterbalanced/rdw-admin-webapp
+    image: smarterbalanced/rdw-reporting-admin-webapp
     ports:
       - 8080:8080
       - 8081:8008

--- a/admin-webapp/src/main/resources/bootstrap.yml
+++ b/admin-webapp/src/main/resources/bootstrap.yml
@@ -3,7 +3,7 @@
 # (https://github.com/spring-cloud/spring-cloud-commons/blob/master/docs/src/main/asciidoc/spring-cloud-commons.adoc#the-bootstrap-application-context)
 spring:
   application:
-    name: rdw-admin-webapp
+    name: rdw-reporting-admin-webapp
 
   cloud:
     config:

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
      *  which doesn't have a docker image
      ***************************************************************/
 
-    if (it.name != "rdw-reporting-common") {
+    if (!it.hasProperty('skipDocker')) {
         apply plugin: 'com.bmuschko.docker-remote-api'
 
         // trigger creation of build-info.properties

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,0 +1,1 @@
+skipDocker=true


### PR DESCRIPTION
Add `skipDocker` technique (same as RDW_Ingest).

Along with this change, i need to make changes in sbac-config-repo and RDW_Deployment to use the new admin webapp with its new name.

@esotrope i don't want to mess up any PR merge you have in play so let me know so we can coordinate the checkin. It's a lot easier for me to redo my stuff.