### PR TITLE
Add school column to exam result display tables.

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -16,6 +16,7 @@
       {{ score.enrolledGrade | gradeDisplay:'enrolled-name' }}
     </ng-template>
   </p-column>
+  <p-column field="school.name" header="{{'labels.groups.results.assessment.exams.cols.school' | translate }}" sortable="true"></p-column>
   <p-column *ngIf="includeResponse" field="response" header="{{'labels.assessments.items.tabs.scores.response' | translate}}" [sortable]="true"></p-column>
   <p-column field="score" header="{{'labels.assessments.items.tabs.scores.score' | translate}}" [sortable]="true"></p-column>
   <p-column field="maxScore" header="{{'labels.assessments.items.tabs.scores.max' | translate}}" [sortable]="true"></p-column>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
@@ -1,10 +1,12 @@
 import { Student } from "../../../student/model/student.model";
+import { School } from "../../../user/model/school.model";
 
 export class StudentScore {
   student: Student;
   date: Date;
   session: string;
   enrolledGrade: string;
+  school: School;
   score: number;
   maxScore: number;
   correctness: number;

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.service.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.service.ts
@@ -21,6 +21,7 @@ export class StudentScoreService {
     score.date = exam.date;
     score.session = exam.session;
     score.enrolledGrade = exam.enrolledGrade;
+    score.school = exam.school;
     score.score = itemScore.points;
     score.maxScore = maxPoints;
 

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
@@ -51,6 +51,7 @@
       {{ exam.enrolledGrade | gradeDisplay:'enrolled-name' }}
     </ng-template>
   </p-column>
+  <p-column field="school.name" header="{{'labels.groups.results.assessment.exams.cols.school' | translate }}" sortable="true"></p-column>
   <p-column field="administrativeCondition" [sortable]="true" [hidden]="isClaimScoreSelected">
     <ng-template pTemplate="header">
       <span info-label title="{{'labels.groups.results.assessment.exams.cols.status' | translate}}"

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -271,6 +271,7 @@
               "date": "Date",
               "session": "Session",
               "grade": "Enrolled Grade",
+              "school": "School",
               "status": "Status",
               "status-info": "Refers to whether an assessment has been flagged as standardized/nonstandardized, complete/partial, and valid/invalid.",
               "score": "Scale Score / Error Band",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/617828/32077330-e6b75d18-ba57-11e7-89be-658899e9ca27.png)

![image](https://user-images.githubusercontent.com/617828/32077336-f07ebcce-ba57-11e7-8df2-939a154aad86.png)

This PR adds a "School" column to the assessment tables in both the school-grade search results and group search results.  I'm also including the school in the item results table, since results are broken down by exam/student.