### PR TITLE
Support transfer student access when querying by student

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/SecurityParameterProvider.java
@@ -54,7 +54,9 @@ public class SecurityParameterProvider {
                     securityParameters.putAll(getSecurityParameters(scope, value));
                 });
 
-        return securityParameters.build();
+        return securityParameters
+                .put("allow_transfer_access", tenantProperties.isTransferAccessEnabled())
+                .build();
     }
 
     /**

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -56,17 +56,24 @@ sql:
       from exam e
         join student st on st.id = e.student_id
         join asmt a on e.asmt_id=a.id
-        left join instructional_resource ir on ir.name = a.name
         join school s on e.school_id=s.id
+        join school isch on st.inferred_school_id = isch.id
+        left join instructional_resource ir on ir.name = a.name
       where e.student_id=:student_id
         and
         (
-          (1 = :individual_statewide
-            or s.district_group_id in (:individual_district_group_ids)
-            or s.district_id in (:individual_district_ids)
-            or s.school_group_id in (:individual_school_group_ids)
-            or e.school_id in (:individual_school_ids))
-          or (
+          # Individual permissions test
+          (
+            (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+            or
+            (
+              1 = :allow_transfer_access
+              and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+            )
+          )
+          or
+          # Group permissions test
+          (
             exists(
                 select 1
                 from student_group_membership sgm
@@ -75,14 +82,20 @@ sql:
                       and sgm.student_id = st.id
                       and (sg.subject_id is null or sg.subject_id = a.subject_id)
             )
-            and (1 = :group_statewide
-              or s.district_group_id in (:group_district_group_ids)
-              or s.district_id in (:group_district_ids)
-              or s.school_group_id in (:group_school_group_ids)
-              or e.school_id in (:group_school_ids))
+            and
+            (
+              (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+              or
+              (
+                1 = :allow_transfer_access
+                and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+              )
+            )
           )
         )
 
+    # NOTE that existsForStudentId does not sample the students' inferred schools
+    # because a student's inferred school is determined by their latest exam.
     existsForStudentId: >-
       select st.id,
         st.ssid,
@@ -109,11 +122,7 @@ sql:
                       and sgm.student_id = st.id
                       and (sg.subject_id is null or sg.subject_id = a.subject_id)
             )
-            and (1 = :group_statewide
-              or s.district_group_id in (:group_district_group_ids)
-              or s.district_id in (:group_district_ids)
-              or s.school_group_id in (:group_school_group_ids)
-              or e.school_id in (:group_school_ids))
+            and (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
           )
         )
       limit 1
@@ -131,15 +140,22 @@ sql:
           join student st on st.id = e.student_id
           join asmt a on a.id = e.asmt_id
           join school s on e.school_id=s.id
+          join school isch on st.inferred_school_id = isch.id
         where e.id=:exam_id
           and
           (
-            (1 = :individual_statewide
-              or s.district_group_id in (:individual_district_group_ids)
-              or s.district_id in (:individual_district_ids)
-              or s.school_group_id in (:individual_school_group_ids)
-              or e.school_id in (:individual_school_ids))
-            or (
+            # Individual permissions test
+            (
+              (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+              or
+              (
+                1 = :allow_transfer_access
+                and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+              )
+            )
+            or
+            # Group permissions test
+            (
               exists(
                   select 1
                   from student_group_membership sgm
@@ -148,11 +164,15 @@ sql:
                         and sgm.student_id = st.id
                         and (sg.subject_id is null or sg.subject_id = a.subject_id)
               )
-              and (1 = :group_statewide
-                or s.district_group_id in (:group_district_group_ids)
-                or s.district_id in (:group_district_ids)
-                or s.school_group_id in (:group_school_group_ids)
-                or e.school_id in (:group_school_ids))
+              and
+              (
+                (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+                or
+                (
+                  1 = :allow_transfer_access
+                  and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+                )
+              )
             )
           )
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupAssessmentRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupAssessmentRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
@@ -31,6 +32,11 @@ public class JdbcGroupAssessmentRepositoryIT {
 
     @Autowired
     private JdbcGroupAssessmentRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private GroupAssessmentSearch.Builder search() {
         return GroupAssessmentSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamItemRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamItemRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
@@ -32,6 +33,11 @@ public class JdbcGroupExamItemRepositoryIT {
 
     @Autowired
     private JdbcGroupExamItemRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private GroupExamSearch.Builder search() {
         return GroupExamSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/group/JdbcGroupExamRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.search.exam.group;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
@@ -31,6 +32,11 @@ public class JdbcGroupExamRepositoryIT {
 
     @Autowired
     private JdbcGroupExamRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private GroupExamSearch.Builder search() {
         return GroupExamSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeAssessmentRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeAssessmentRepositoryIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
@@ -31,6 +32,11 @@ public class JdbcSchoolGradeAssessmentRepositoryIT {
 
     @Autowired
     private JdbcSchoolGradeAssessmentRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private SchoolGradeAssessmentSearch.Builder search() {
         return SchoolGradeAssessmentSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamItemRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamItemRepositoryIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
@@ -31,6 +32,11 @@ public class JdbcSchoolGradeExamItemRepositoryIT {
 
     @Autowired
     private JdbcSchoolGradeExamItemRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private SchoolGradeExamSearch.Builder search() {
         return SchoolGradeExamSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.search.exam.schoolgrade;
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
@@ -31,6 +32,11 @@ public class JdbcSchoolGradeExamRepositoryIT {
 
     @Autowired
     private JdbcSchoolGradeExamRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     private SchoolGradeExamSearch.Builder search() {
         return SchoolGradeExamSearch.builder()

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcExamItemRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcExamItemRepositoryIT.java
@@ -1,17 +1,21 @@
 package org.opentestsystem.rdw.reporting.search.exam.student;
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.security.PermissionScope;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.exam.ExamItem;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.groupOf;
@@ -26,7 +30,15 @@ import static org.opentestsystem.rdw.reporting.common.test.support.PermissionSco
 public class JdbcExamItemRepositoryIT {
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcExamItemRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     @Test
     public void itShouldReturnAnEmptyListIfNoResultsFound() throws Exception {
@@ -74,4 +86,33 @@ public class JdbcExamItemRepositoryIT {
                                 .build());
     }
 
+    @Test
+    public void itShouldFindAllExamItemsRespectingTransferAccessIndividual() {
+        final PermissionScope school4Scope = PermissionScope.builder()
+                .addSchoolId(-40)
+                .build();
+
+        final List<ExamItem> withoutTransfer = repository.findAllByExamId(permissions(individualOf(school4Scope)), ImmutableSet.of(), -100);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final List<ExamItem> withTransfer = repository.findAllByExamId(permissions(individualOf(school4Scope)), ImmutableSet.of(), -100);
+        assertThat(withTransfer.stream().map(ExamItem::getExamId))
+                .containsOnly(-100L);
+    }
+
+    @Test
+    public void itShouldFindAllExamItemsRespectingTransferAccessGroup() {
+        final PermissionScope school4Scope = PermissionScope.builder()
+                .addSchoolId(-40)
+                .build();
+
+        final List<ExamItem> withoutTransfer = repository.findAllByExamId(permissions(groupOf(school4Scope)), ImmutableSet.of(-100L), -100);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final List<ExamItem> withTransfer = repository.findAllByExamId(permissions(groupOf(school4Scope)), ImmutableSet.of(-100L), -100);
+        assertThat(withTransfer.stream().map(ExamItem::getExamId))
+                .containsOnly(-100L);
+    }
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/search/exam/student/JdbcStudentExamRepositoryIT.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.reporting.search.exam.student;
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.TestData;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
@@ -32,7 +34,15 @@ import static org.opentestsystem.rdw.reporting.common.test.support.PermissionSco
 public class JdbcStudentExamRepositoryIT {
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcStudentExamRepository repository;
+
+    @After
+    public void clearState() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     @Test
     public void findAllForStudentShouldReturnEmptyForMissingStudent() throws Exception {
@@ -82,6 +92,38 @@ public class JdbcStudentExamRepositoryIT {
                 .isNotEmpty()
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT_ASSESSMENTS);
+    }
+
+    @Test
+    public void itShouldFindAllForStudentRespectingTransferAccessIndividual() {
+        final PermissionScope school4Scope = PermissionScope.builder()
+                .addSchoolId(-40)
+                .build();
+
+        final List<StudentHistoryExamWrapper> withoutTransfer = repository.findAllForStudent(permissions(individualOf(school4Scope)), ImmutableSet.of(), -100L);
+        assertThat(withoutTransfer.stream().map(history -> history.getExam().getId()))
+                .containsOnly(-101L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final List<StudentHistoryExamWrapper> withTransfer = repository.findAllForStudent(permissions(individualOf(school4Scope)), ImmutableSet.of(), -100L);
+        assertThat(withTransfer.stream().map(history -> history.getExam().getId()))
+                .containsOnly(-100L, -101L);
+    }
+
+    @Test
+    public void itShouldFindAllForStudentRespectingTransferAccessGroup() {
+        final PermissionScope school4Scope = PermissionScope.builder()
+                .addSchoolId(-40)
+                .build();
+
+        final List<StudentHistoryExamWrapper> withoutTransfer = repository.findAllForStudent(permissions(groupOf(school4Scope)), ImmutableSet.of(-100L), -100L);
+        assertThat(withoutTransfer.stream().map(history -> history.getExam().getId()))
+                .containsOnly(-101L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final List<StudentHistoryExamWrapper> withTransfer = repository.findAllForStudent(permissions(groupOf(school4Scope)), ImmutableSet.of(-100L), -100L);
+        assertThat(withTransfer.stream().map(history -> history.getExam().getId()))
+                .containsOnly(-100L, -101L);
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for student transfer access when querying by student.

This is slightly different from the two previous PRs, since we can query by student using both individual PII rights as well as group PII rights.