### PR TITLE
Add transfer access support to report-processor queries.

### DIFF
--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -41,20 +41,36 @@ sql:
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
         join district d on s.district_id=d.id
+        join school isch on st.inferred_school_id = isch.id
       where e.student_id in (:student_ids)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
       and
       ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
-        (1 = :individual_statewide
-          or s.district_group_id in (:individual_district_group_ids)
-          or s.district_id in (:individual_district_ids)
-          or s.school_group_id in (:individual_school_group_ids)
-          or e.school_id in (:individual_school_ids))
-        or (
+        # Individual permissions test
+        (
+          (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+          )
+        )
+        or
+        # Group permissions test
+        (
           exists(
               select 1
               from student_group_membership sgm
@@ -63,11 +79,15 @@ sql:
                     and sgm.student_id in (:student_ids)
                     and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
           )
-          and (1 = :group_statewide
-            or s.district_group_id in (:group_district_group_ids)
-            or s.district_id in (:group_district_ids)
-            or s.school_group_id in (:group_school_group_ids)
-            or e.school_id in (:group_school_ids))
+          and
+          (
+            (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+            or
+            (
+              1 = :allow_transfer_access
+              and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+            )
+          )
         )
       )
       order by e.completed_at desc
@@ -113,13 +133,32 @@ sql:
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
         join district d on s.district_id=d.id
+        join school isch on st.inferred_school_id = isch.id
       where e.student_id in (:student_ids)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+          (
+            :school_id is null
+            or
+            (
+              s.id=:school_id
+              or
+              (1 = :allow_transfer_access and isch.id = :school_id)
+            )
+          )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and
+            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       order by e.completed_at desc
 
     findAllIabsByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -162,6 +201,7 @@ sql:
         left join instructional_resource ir on ir.name = a.name
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
+        join school isch on st.inferred_school_id = isch.id
         join district d on s.district_id=d.id
         join student_group_membership sgm on st.id = sgm.student_id
         join student_group sg on sgm.student_group_id = sg.id
@@ -169,11 +209,29 @@ sql:
       where e.student_id in (:student_ids)
         and sg.id=:group_id
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and
+            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       order by e.completed_at desc
 
     findAllIcasByStudentIdsAndQueryParamsUnknownPermissions: >-
@@ -237,35 +295,55 @@ sql:
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
         join district d on s.district_id=d.id
+        join school isch on st.inferred_school_id = isch.id
       where e.student_id in (:student_ids)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-      and
-      ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
-        (1 = :individual_statewide
-          or s.district_group_id in (:individual_district_group_ids)
-          or s.district_id in (:individual_district_ids)
-          or s.school_group_id in (:individual_school_group_ids)
-          or e.school_id in (:individual_school_ids))
-        or (
-          exists(
-              select 1
-              from student_group_membership sgm
-                join student_group sg on sgm.student_group_id = sg.id
-              where sgm.student_group_id in (:group_ids)
-                    and sgm.student_id in (:student_ids)
-                    and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
           )
-          and (1 = :group_statewide
-            or s.district_group_id in (:group_district_group_ids)
-            or s.district_id in (:group_district_ids)
-            or s.school_group_id in (:group_school_group_ids)
-            or e.school_id in (:group_school_ids))
         )
-      )
+        and
+        ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+          # Individual permissions test
+          (
+            (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+            or
+            (
+              1 = :allow_transfer_access
+              and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+            )
+          )
+          or
+          # Group permissions test
+          (
+            exists(
+                select 1
+                from student_group_membership sgm
+                  join student_group sg on sgm.student_group_id = sg.id
+                where sgm.student_group_id in (:group_ids)
+                      and sgm.student_id in (:student_ids)
+                      and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+            )
+            and
+            (
+              (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+              or
+              (
+                1 = :allow_transfer_access
+                and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+              )
+            )
+          )
+        )
       order by e.completed_at asc
 
     findAllIcasByStudentIdsAndQueryParamsIndividualPermissions: >-
@@ -329,13 +407,31 @@ sql:
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
         join district d on s.district_id=d.id
+        join school isch on st.inferred_school_id = isch.id
       where e.student_id in (:student_ids)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       order by e.completed_at asc
 
     findAllIcasByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -399,17 +495,35 @@ sql:
         join student st on e.student_id=st.id
         join school s on e.school_id=s.id
         join district d on s.district_id=d.id
+        join school isch on st.inferred_school_id = isch.id
         join student_group_membership sgm on st.id = sgm.student_id
         join student_group sg on sgm.student_group_id = sg.id
           and (sg.subject_id is null or a.subject_id = sg.subject_id)
       where e.student_id in (:student_ids)
         and sg.id=:group_id
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       order by e.completed_at asc
 
   export:
@@ -529,15 +643,23 @@ sql:
         join asmt_type at on at.id = a.type_id
         join school s on e.school_id = s.id
         join district d on d.id = s.district_id
-      where e.school_year = :school_year and
+        join school isch on st.inferred_school_id = isch.id
+      where
+        e.school_year = :school_year
+        and
+        (
           (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
           and
-          (
-            s.district_group_id in (:query_district_group_ids)
-            or s.district_id in (:query_district_ids)
-            or s.school_group_id in (:query_school_group_ids)
-            or e.school_id in (:query_school_ids)
-          )
+          (s.district_group_id in (:query_district_group_ids) or s.district_id in (:query_district_ids) or s.school_group_id in (:query_school_group_ids) or e.school_id in (:query_school_ids))
+        )
+        or
+        (
+          1 = :individual_allow_transfer_access
+          and
+          (1 = :individual_statewide or isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+          and
+          (isch.district_group_id in (:query_district_group_ids) or isch.district_id in (:query_district_ids) or isch.school_group_id in (:query_school_group_ids) or isch.id in (:query_school_ids))
+        )
 
   report:
 
@@ -623,34 +745,55 @@ sql:
         join exam e on e.student_id = st.id
         join asmt a on e.asmt_id=a.id
         join school s on e.school_id = s.id
+        join school isch on st.inferred_school_id = isch.id
       where (:student_id is null or st.id=:student_id)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
-              (1 = :individual_statewide
-                or s.district_group_id in (:individual_district_group_ids)
-                or s.district_id in (:individual_district_ids)
-                or s.school_group_id in (:individual_school_group_ids)
-                or e.school_id in (:individual_school_ids))
-              or (
-                exists(
-                    select 1
-                    from student_group_membership sgm
-                      join student_group sg on sgm.student_group_id = sg.id
-                    where sgm.student_group_id in (:group_ids)
-                          and sgm.student_id=st.id
-                          and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
-                )
-                and (1 = :group_statewide
-                  or s.district_group_id in (:group_district_group_ids)
-                  or s.district_id in (:group_district_ids)
-                  or s.school_group_id in (:group_school_group_ids)
-                  or e.school_id in (:group_school_ids))
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
+        and
+        ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+          # Individual permissions test
+          (
+            (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+            or
+            (
+              1 = :allow_transfer_access
+              and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+            )
+          )
+          or
+          # Group permissions test
+          (
+            exists(
+                select 1
+                from student_group_membership sgm
+                  join student_group sg on sgm.student_group_id = sg.id
+                where sgm.student_group_id in (:group_ids)
+                      and sgm.student_id = st.id
+                      and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+            )
+            and
+            (
+              (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+              or
+              (
+                1 = :allow_transfer_access
+                and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
               )
             )
+          )
+        )
       group by st.id
 
     findByExamQueryParamsIndividualPermissions: >-
@@ -664,13 +807,32 @@ sql:
         join exam e on e.student_id = st.id
         join asmt a on e.asmt_id=a.id
         join school s on e.school_id = s.id
+        join school isch on st.inferred_school_id = isch.id
       where (:student_id is null or st.id=:student_id)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+        (
+          :school_id is null
+          or
+          (
+            s.id=:school_id
+            or
+            (1 = :allow_transfer_access and isch.id = :school_id)
+          )
+        )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and
+            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       group by st.id
 
     findByExamQueryParamsGroupPermissions: >-
@@ -684,15 +846,34 @@ sql:
         join exam e on e.student_id = st.id
         join asmt a on e.asmt_id=a.id
         join school s on e.school_id = s.id
+        join school isch on st.inferred_school_id = isch.id
         join student_group_membership sgm on st.id = sgm.student_id
         join student_group sg on sgm.student_group_id = sg.id
           and (sg.subject_id is null or a.subject_id = sg.subject_id)
       where sg.id=:group_id
         and (:student_id is null or st.id=:student_id)
         and (:school_year is null or e.school_year=:school_year)
-        and (:school_id is null or s.id=:school_id)
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+        and
+          (
+            :school_id is null
+            or
+            (
+              s.id=:school_id
+              or
+              (1 = :allow_transfer_access and isch.id = :school_id)
+            )
+          )
+        and
+        (
+          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+          or
+          (
+            1 = :allow_transfer_access
+            and
+            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+          )
+        )
       group by st.id

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcExamRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcExamRepositoryIT.java
@@ -7,6 +7,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.report.ExportExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
@@ -43,11 +44,25 @@ public class JdbcExamRepositoryIT {
     private static final int HeaderRowCountOnly = 1;
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcExamRepository repository;
 
     @Before
-    public void Setup() {
+    public void setup() {
         testCsv = String.format(TestCsvFormat, new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss:SSS").format(new Date()));
+    }
+
+    @After
+    public void cleanUp() throws IOException {
+        tenantProperties.setTransferAccessEnabled(false);
+        try {
+            Files.delete(Paths.get(testCsv));
+        } catch (final Exception welpAtLeastItried) {
+            // This will always throw an exception in TeamCity because the java user can't delete a file created by
+            // the mysql account.  This should work locally though, so at least I'm not polluting your local /tmp/
+        }
     }
 
     @Test
@@ -205,14 +220,22 @@ public class JdbcExamRepositoryIT {
         assertThat(row).containsExactlyElementsOf(csvFields);
     }
 
-    @After
-    public void cleanUp() throws IOException {
-        try {
-            Files.delete(Paths.get(testCsv));
-        } catch (Exception welpAtLeastItried) {
-            // This will always throw an exception in TeamCity because the java user can't delete a file created by
-            // the mysql account.  This should work locally though, so at least I'm not polluting your local /tmp/
-        }
+    @Test
+    public void itShouldRespectTransferAccess() throws IOException {
+        final ExportExamReportRequest query = ExportExamReportRequest
+                .builder()
+                .schoolIds(ImmutableSet.of(-13L))
+                .schoolYear(1998)
+                .build();
+
+        repository.export(statewide(), query, testCsv);
+        assertThat(getCsvLineCount()).isEqualTo(3);
+        cleanUp();
+        setup();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        repository.export(statewide(), query, testCsv);
+        assertThat(getCsvLineCount()).isEqualTo(5);
     }
 
     private int getCsvLineCount() throws IOException {

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepositoryIT.java
@@ -1,9 +1,12 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
+import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
@@ -17,7 +20,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +47,15 @@ import static org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams.P
 public class JdbcIabReportRepositoryIT {
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcIabReportRepository repository;
+
+    @After
+    public void cleanup() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     @Test
     public void itShouldFindAllIabReportsForStudentsBySchoolAndYear() throws Exception {
@@ -67,6 +80,33 @@ public class JdbcIabReportRepositoryIT {
     }
 
     @Test
+    public void itShouldFindAllIabReportsForStudentsBySchoolAndYearRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Individual)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-103L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IabReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-101L, -103L);
+    }
+
+    @Test
     public void itShouldFindAllIabReportsForStudentsByGroupAndYear() throws Exception {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .groupId(-20L)
@@ -83,6 +123,33 @@ public class JdbcIabReportRepositoryIT {
         assertThat(reports.get(-1L)).hasSize(2);
         assertThat(reports.get(-1L).get(MATH).getExamsByAssessment()).hasSize(1);
         assertThat(reports.get(-1L).get(ELA).getExamsByAssessment()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldFindAllIabReportsForStudentsByGroupAndYearRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .groupId(-100L)
+                .schoolYear(1998)
+                .queryPermissionType(Group)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                group(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-103L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IabReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                group(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-101L, -103L);
     }
 
     @Test
@@ -103,6 +170,33 @@ public class JdbcIabReportRepositoryIT {
         assertThat(reports.get(-1L)).hasSize(2);
         assertThat(reports.get(-1L).get(MATH).getExamsByAssessment()).hasSize(1);
         assertThat(reports.get(-1L).get(ELA).getExamsByAssessment()).hasSize(2);
+    }
+
+    @Test
+    public void itShouldFindAllIabReportsForAStudentByIndividualPiiRightsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-103L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IabReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-101L, -103L);
     }
 
     @Test
@@ -131,4 +225,46 @@ public class JdbcIabReportRepositoryIT {
         assertThat(reports.get(-1L).get(ELA).getExamsByAssessment()).hasSize(2);
     }
 
+    @Test
+    public void itShouldFindAllIabReportsForAStudentByGroupPiiRightsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-13L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-100L, new GroupGrant(-100L, 0)))
+                .build();
+
+        final Map<Long, Map<Subject, IabReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-103L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IabReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-101L, -103L);
+    }
+
+    private Collection<Long> getExamIds(final Map<Long, Map<Subject, IabReport>> reports) {
+        return reports.values().stream()
+                .flatMap(map -> map.values().stream())
+                .map(IabReport::getExamsByAssessment)
+                .flatMap(map -> map.values().stream())
+                .flatMap(Collection::stream)
+                .map(Exam::getId)
+                .collect(Collectors.toSet());
+    }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaReportRepositoryIT.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
@@ -17,7 +19,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +46,15 @@ import static org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams.P
 public class JdbcIcaReportRepositoryIT {
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcIcaReportRepository repository;
+
+    @After
+    public void cleanup() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     @Test
     public void itShouldFindAllIcaReportsForStudentsBySchoolAndYear() {
@@ -67,6 +79,33 @@ public class JdbcIcaReportRepositoryIT {
     }
 
     @Test
+    public void itShouldFindAllIcaReportsForStudentsBySchoolAndYearRespectingTransferAccess() {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Individual)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-102L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IcaReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-100L, -102L);
+
+    }
+
+    @Test
     public void itShouldFindAllIcaReportsForStudentsByGroup() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .groupId(-20L)
@@ -83,6 +122,32 @@ public class JdbcIcaReportRepositoryIT {
         assertThat(reports.get(-1L)).hasSize(2);
         assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
         assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+    }
+
+    @Test
+    public void itShouldFindAllIcaReportsForStudentsByGroupRespectingTransferAccess() {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .groupId(-100L)
+                .schoolYear(1998)
+                .queryPermissionType(Group)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                group(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-102L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IcaReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                group(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-100L, -102L);
     }
 
     @Test
@@ -106,7 +171,34 @@ public class JdbcIcaReportRepositoryIT {
     }
 
     @Test
-    public void itShouldFindAllIabReportsForAStudentByGroupPiiRights() throws Exception {
+    public void itShouldFindAllIcaReportsForAStudentByIndividualPiiRightsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-102L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IcaReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                individual(schools(-13L)),
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-100L, -102L);
+    }
+
+    @Test
+    public void itShouldFindAllIcaReportsForAStudentByGroupPiiRights() throws Exception {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .schoolId(-10L)
                 .schoolYear(1997)
@@ -129,5 +221,45 @@ public class JdbcIcaReportRepositoryIT {
         assertThat(reports.get(-1L)).hasSize(2);
         assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
         assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+    }
+
+    @Test
+    public void itShouldFindAllIcaReportsForAStudentByGroupPiiRightsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-13L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-100L, new GroupGrant(-100L, 0)))
+                .build();
+
+        final Map<Long, Map<Subject, IcaReport>> withoutTransfer = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withoutTransfer))
+                .containsOnly(-102L);
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Map<Long, Map<Subject, IcaReport>> withTransfer = repository.findAllForStudentsByExamFilter(
+                specificGroup,
+                of(-100L),
+                examQueryParams);
+
+        assertThat(getExamIds(withTransfer))
+                .containsOnly(-100L, -102L);
+    }
+
+    private Collection<Long> getExamIds(final Map<Long, Map<Subject, IcaReport>> reports) {
+        return reports.values().stream()
+                .flatMap(map -> map.values().stream())
+                .map(icaReport -> icaReport.getExam().getId())
+                .collect(Collectors.toSet());
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
@@ -1,8 +1,11 @@
 package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
@@ -17,6 +20,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.GroupPiiRead;
@@ -37,7 +41,15 @@ import static org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams.P
 public class JdbcStudentRepositoryIT {
 
     @Autowired
+    private TenantProperties tenantProperties;
+
+    @Autowired
     private JdbcStudentRepository repository;
+
+    @After
+    public void tearDown() {
+        tenantProperties.setTransferAccessEnabled(false);
+    }
 
     @Test
     public void itShouldFindStudentsBySchoolAndGradeAndYear() throws Exception {
@@ -52,6 +64,29 @@ public class JdbcStudentRepositoryIT {
                 examQueryParams);
 
         assertThat(studentIds.stream().map(Student::getId)).containsOnly(-2L, -1L);
+    }
+
+    @Test
+    public void itShouldFindStudentsBySchoolAndGradeAndYearRespectingTransferAccess() throws Exception {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .gradeId(-1)
+                .schoolId(-13L)
+                .schoolYear(1998)
+                .queryPermissionType(Individual)
+                .subject(Subject.MATH)
+                .build();
+
+        final Collection<Student> withoutTransfer = repository.findStudentsByExamQueryParams(
+                individual(schools(-13L)),
+                examQueryParams);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Collection<Student> withTransfer = repository.findStudentsByExamQueryParams(
+                individual(schools(-13L)),
+                examQueryParams);
+        assertThat(getStudentIds(withTransfer))
+                .containsOnly(-100L);
     }
 
     @Test
@@ -93,6 +128,28 @@ public class JdbcStudentRepositoryIT {
     }
 
     @Test
+    public void itShouldFindStudentIdsByGroupIdRespectingTransferAccess() throws Exception {
+        final ExamQueryParams g1Params = ExamQueryParams.builder()
+                .groupId(-100L)
+                .schoolYear(1998)
+                .queryPermissionType(Group)
+                .gradeId(-1)
+                .subject(Subject.MATH)
+                .build();
+        final Collection<Student> withoutTransfer = repository.findStudentsByExamQueryParams(
+                group(schools(-13L)),
+                g1Params);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Collection<Student> withTransfer = repository.findStudentsByExamQueryParams(
+                group(schools(-13L)),
+                g1Params);
+        assertThat(getStudentIds(withTransfer))
+                .containsOnly(-100L);
+    }
+
+    @Test
     public void itShouldFindASingleStudentWithIndividualPermissions() throws Exception {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
                 .studentId(-1L)
@@ -105,6 +162,29 @@ public class JdbcStudentRepositoryIT {
                 g1Params);
 
         assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
+    }
+
+    @Test
+    public void itShouldFindASingleStudentWithIndividualPermissionsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams g1Params = ExamQueryParams.builder()
+                .studentId(-100L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .subject(Subject.MATH)
+                .build();
+
+        final Collection<Student> withoutTransfer = repository.findStudentsByExamQueryParams(
+                individual(schools(-13L)),
+                g1Params);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Collection<Student> withTransfer = repository.findStudentsByExamQueryParams(
+                individual(schools(-13L)),
+                g1Params);
+        assertThat(getStudentIds(withTransfer))
+                .containsOnly(-100L);
     }
 
     @Test
@@ -127,6 +207,41 @@ public class JdbcStudentRepositoryIT {
                 g1Params);
 
         assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
+    }
+
+    @Test
+    public void itShouldFindASingleStudentWithGroupPermissionsRespectingTransferAccess() throws Exception {
+        final ExamQueryParams g1Params = ExamQueryParams.builder()
+                .studentId(-100L)
+                .schoolYear(1998)
+                .queryPermissionType(Unknown)
+                .gradeId(-1)
+                .subject(Subject.MATH)
+                .build();
+
+        final Permission groupPermission = groupOf(schools(-13L));
+        final UserPermissions specificGroup = UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(GroupPiiRead, groupPermission))
+                .groupsById(ImmutableMap.of(-100L, new GroupGrant(-100L, 0)))
+                .build();
+
+        final Collection<Student> withoutTransfer = repository.findStudentsByExamQueryParams(
+                specificGroup,
+                g1Params);
+        assertThat(withoutTransfer).isEmpty();
+
+        tenantProperties.setTransferAccessEnabled(true);
+        final Collection<Student> withTransfer = repository.findStudentsByExamQueryParams(
+                specificGroup,
+                g1Params);
+        assertThat(getStudentIds(withTransfer))
+                .containsOnly(-100L);
+    }
+
+    private Collection<Long> getStudentIds(final Collection<Student> students) {
+        return students.stream()
+                .map(Student::getId)
+                .collect(Collectors.toSet());
     }
 
 }

--- a/report-processor/src/test/resources/integration-test-data.sql
+++ b/report-processor/src/test/resources/integration-test-data.sql
@@ -11,7 +11,8 @@ insert into school_group (id, natural_id, name) values
 insert into school (id, district_group_id, district_id, school_group_id, natural_id, name, update_import_id, updated, migrate_id) VALUES
   (-10, -9, -10, -11, 'schoolNat1', 'school1', -1, '1997-07-18 20:14:34.000000', -1),
   (-11, -9, -10, null, 'schoolNat2', 'school2', -1, '1997-07-18 20:14:34.000000', -1),
-  (-12, -9, -10, -20, 'schoolNat3', 'school3', -1, '1997-07-18 20:14:34.000000', -1);
+  (-12, -9, -10, -20, 'schoolNat3', 'school3', -1, '1997-07-18 20:14:34.000000', -1),
+  (-13, -9, -10, -20, 'schoolNat4', 'school4', -1, '1997-07-18 20:14:34.000000', -1);
 
 insert into grade (id, code, name) values
   (-1, 'g1', 'grade1'),
@@ -23,11 +24,12 @@ insert into gender (id, code) values
 insert into school_year (year) values
   (1995),
   (1996),
-  (1997);
+  (1997),
+  (1998);
 
-insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, update_import_id, updated, migrate_id) values
-  (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -1, '1997-07-18 20:14:34.000000', -1),
-  (-2, 'student2_ssid', 'student2_lastName', 'student2_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -1, '1997-07-18 20:14:34.000000', -1);
+insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, inferred_school_id, update_import_id, updated, migrate_id) values
+  (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -10, -1, '1997-07-18 20:14:34.000000', -1),
+  (-2, 'student2_ssid', 'student2_lastName', 'student2_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -12, -1, '1997-07-18 20:14:34.000000', -1);
 
 insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, school_year, name, label, version,
   claim1_score_code, claim2_score_code, claim3_score_code, claim4_score_code,
@@ -39,6 +41,21 @@ insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, sch
   (-5, 1, 'ica2', -1, 'g1', 2, 1997, 'ica2', 'ica2', 'v1', 'ica_claim1', 'ica_claim2', 'ica_claim3', 'ica_claim4', 100, 200, 300, 400, 500, -1, '1997-07-18 20:14:34.000000', -1),
   (-6, 2, 'iab4', -1, 'g1', 2, 1997, 'iab2', 'iab4', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
   (-7, 2, 'iab5', -1, 'g1', 2, 1997, 'iab3', 'iab5', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into claim (id, subject_id, code, name, description) values
+  (-1, 1, 'c1', 'c1', 'c1');
+
+insert into target (id, claim_id, code, description) values
+  (-1, -1, 't1', 't1');
+
+insert into math_practice (practice, description, code) values
+  (-1, 'mp1', '-1');
+
+insert into depth_of_knowledge (id, level, subject_id, description, reference) values
+  (-1, 1, 1, 'dok1', 'dok1');
+
+insert into item (id, natural_id, claim_id, claim_code, target_id, target_code, asmt_id, math_practice, math_practice_code, dok_id, dok_level_subject_id, difficulty_code, max_points, common_core_standard_ids) values
+  (-1, '200-3391', -1, 'c1', -1, 't1', -1, -1, '-1', -1,'-1_1', 'E', 3, 'S-ID.1');
 
 insert into exam (id, type_id, grade_id, grade_code, student_id, school_id, opportunity, migrant_status, iep, lep, section504, economic_disadvantage,
   school_year, asmt_id, asmt_version, completeness_id, completeness_code, administration_condition_id, administration_condition_code, session_id,
@@ -82,3 +99,33 @@ insert into ethnicity (id, code) values
 
 insert into student_ethnicity (ethnicity_id, ethnicity_code, student_id) values
   (8, 'Filipino', -2);
+
+-- transfer student test data
+insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code,
+                     birthday, inferred_school_id, update_import_id, updated, migrate_id) values
+  (-100, 'transfer_1', 'from_school3', 'to_school4', -1, 'g1', '1997-01-01 00:00:00.000000', -13, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into exam (id, type_id, grade_id, grade_code, student_id, school_id, opportunity, iep, lep, section504, economic_disadvantage,
+                  school_year, asmt_id, asmt_version, completeness_id, completeness_code, administration_condition_id, administration_condition_code, session_id,
+                  scale_score, scale_score_std_err, performance_level, completed_at,
+                  claim1_category, claim1_scale_score, claim1_scale_score_std_err,
+                  claim2_category, claim2_scale_score, claim2_scale_score_std_err,
+                  claim3_category, claim3_scale_score, claim3_scale_score_std_err,
+                  claim4_category, claim4_scale_score, claim4_scale_score_std_err,
+                  update_import_id, updated, migrate_id) values
+  (-100, 1, -1, 'g1', -100, -12, 0, 0, 0, 0, 0, 1998, -1, 'v1', 2, 'Complete', 1, 'Valid', 'session1', 2000, 20, 1, '1998-10-01 00:00:00.000000', 1, 100, 10, 2, 200, 20, 3, 300, 30, 4, 400, 40, -1, '1997-07-18 20:14:34.000000', -1),
+  (-101, 2, -1, 'g1', -100, -12, 1, 0, 0, 0, 0, 1998, -3, 'v1', 2, 'Complete', 1, 'Valid', 'session1', 2100, 21, 2, '1998-10-02 00:00:00.000000', null, null, null, null, null, null, null, null, null, null, null, null, -1, '1997-07-18 20:14:34.000000', -1),
+  (-102, 1, -1, 'g1', -100, -13, 0, 0, 0, 0, 0, 1998, -5, 'v1', 2, 'Complete', 1, 'Valid', 'session1', 2000, 20, 1, '1999-02-01 00:00:00.000000', 1, 100, 10, 2, 200, 20, 3, 300, 30, 4, 400, 40, -1, '1997-07-18 20:14:34.000000', -1),
+  (-103, 2, -1, 'g1', -100, -13, 1, 0, 0, 0, 0, 1998, -6, 'v1', 2, 'Complete', 1, 'Valid', 'session1', 2100, 21, 2, '1999-02-02 00:00:00.000000', null, null, null, null, null, null, null, null, null, null, null, null, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into exam_item (id, exam_id, item_id, score, position, response) values
+  (-100, -100, -1, 0, 1, 'A'),
+  (-101, -101, -1, 1, 1, 'D'),
+  (-102, -102, -1, 0, 1, 'A'),
+  (-103, -103, -1, 1, 1, 'D');
+
+insert into student_group (id, name, school_id, school_year, subject_id, update_import_id, updated, migrate_id) values
+  (-100, 'transfer group', -13, 1998, null, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into student_group_membership (student_group_id, student_id) values
+  (-100, -100);


### PR DESCRIPTION
Updating the report-processor queries to support transfer access was a bit more work than I had anticipated.  Most of the effort came from our duplicate queries based upon whether a user is reporting via individual, group, or unknown permissions.

The queries updated are for:
finding ICA exams
finding IAB exams
custom CSV exam export
finding Students by filter criteria