### PR TITLE
Send current language as report request language

### DIFF
--- a/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
@@ -5,6 +5,7 @@ import { NotificationService } from "../shared/notification/notification.service
 import { Report } from "./report.model";
 import { Group } from "../user/model/group.model";
 import { Observable } from "rxjs";
+import { TranslateService } from "@ngx-translate/core";
 
 /**
  * Component used for single-student exam report download
@@ -19,8 +20,9 @@ export class GroupReportDownloadComponent extends ReportDownloadComponent {
   group: Group;
 
   constructor(notificationService: NotificationService,
+              translateService: TranslateService,
               private service: ReportService) {
-    super(notificationService);
+    super(notificationService, translateService);
   }
 
   createReport(): Observable<Report> {

--- a/webapp/src/main/webapp/src/app/report/report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.ts
@@ -7,6 +7,7 @@ import { ReportOrder } from "./report-order.enum";
 import { ModalDirective } from "ngx-bootstrap";
 import { Observable } from "rxjs";
 import { Report } from "./report.model";
+import { TranslateService } from "@ngx-translate/core";
 
 /**
  * Abstract class used to carry the common logic between all exam report download components
@@ -54,11 +55,11 @@ export abstract class ReportDownloadComponent implements OnInit {
   AssessmentType: any = AssessmentType;
   assessmentTypes: AssessmentType[] = [ null, AssessmentType.IAB, AssessmentType.ICA ];
   subjectTypes: AssessmentSubjectType[] = [ null, AssessmentSubjectType.MATH, AssessmentSubjectType.ELA ];
-  languages: string[] = [ 'eng', 'spa', 'vie' ];
   orders: ReportOrder[] = [ ReportOrder.STUDENT_NAME, ReportOrder.STUDENT_SSID ];
   options: ReportOptions;
 
-  constructor(protected notificationService: NotificationService) {
+  constructor(protected notificationService: NotificationService,
+              protected translateService: TranslateService) {
   }
 
   ngOnInit(): void {
@@ -66,7 +67,7 @@ export abstract class ReportDownloadComponent implements OnInit {
     defaultOptions.assessmentType = this.assessmentType != null ? this.assessmentType : this.assessmentTypes[ 0 ];
     defaultOptions.subject = this.subject != null ? this.getSubjectFromString(this.subject) : this.subjectTypes[ 0 ];
     defaultOptions.schoolYear = this.schoolYear != null ? this.schoolYear : this.schoolYears[ 0 ];
-    defaultOptions.language = this.languages[ 0 ];
+    defaultOptions.language = this.translateService.currentLang;
     defaultOptions.accommodationsVisible = false;
     defaultOptions.order = this.orders[ 0 ];
     defaultOptions.grayscale = false;

--- a/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
@@ -24,9 +24,9 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
   grade: Grade;
 
   constructor(notificationService: NotificationService,
-              private service: ReportService,
-              private translate: TranslateService) {
-    super(notificationService);
+              translate: TranslateService,
+              private service: ReportService) {
+    super(notificationService, translate);
   }
 
   createReport(): Observable<Report> {
@@ -34,7 +34,7 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
   }
 
   generateName(): string {
-    let gradeLabel: string = this.translate.instant(`labels.grades.${this.grade.code}.short-name`);
+    let gradeLabel: string = this.translateService.instant(`labels.grades.${this.grade.code}.short-name`);
     return `${this.school.name} ${gradeLabel}`;
   }
 

--- a/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
@@ -20,9 +20,9 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
   student: Student;
 
   constructor(notificationService: NotificationService,
-              private service: ReportService,
-              private translate: TranslateService) {
-    super(notificationService);
+              translate: TranslateService,
+              private service: ReportService) {
+    super(notificationService, translate);
     this.displayOrder = false;
   }
 
@@ -31,7 +31,7 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
   }
 
   generateName(): string {
-    return this.translate.instant('labels.personName', this.student);
+    return this.translateService.instant('labels.personName', this.student);
   }
 
 }


### PR DESCRIPTION
While working on installing a new language, I ran into a small issue with the reporting webapp not sending the current language as the report generation language.