### PR TITLE
Support generating a report in multiple languages.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/TenantProperties.java
@@ -10,6 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class TenantProperties {
 
     private boolean transferAccessEnabled;
+    private String translationLocation;
 
     /**
      * True if users with access to the students' most recent schools grant access
@@ -24,5 +25,18 @@ public class TenantProperties {
 
     public void setTransferAccessEnabled(final boolean transferAccessEnabled) {
         this.transferAccessEnabled = transferAccessEnabled;
+    }
+
+    /**
+     * This is the location/prefix of translation files (messages_es.properties, es.json, etc)
+     * (ex: 'binary-${spring.cloud.config.uri}/*&#47;*&#47;master/')
+     * @return The prefix for translation resources.
+     */
+    public String getTranslationLocation() {
+        return translationLocation;
+    }
+
+    public void setTranslationLocation(final String translationLocation) {
+        this.translationLocation = translationLocation;
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationConfiguration.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.reporting.common.i18n;
 
+import org.opentestsystem.rdw.reporting.common.configuration.TenantProperties;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.MessageSource;
@@ -7,7 +8,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.core.io.ResourceLoader;
+
+import static org.springframework.util.StringUtils.isEmpty;
 
 @Configuration
 @EnableCaching
@@ -19,7 +24,9 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 public class TranslationConfiguration {
 
     @Bean
-    public MessageSource messageSource(final InternalTranslationService translationService) {
+    public MessageSource messageSource(final InternalTranslationService translationService,
+                                       final ResourceLoader resourceLoader,
+                                       final TenantProperties tenantProperties) {
 
         final ResourceBundleMessageSource baseMessages = new ResourceBundleMessageSource();
         baseMessages.setBasenames("messages");
@@ -27,7 +34,16 @@ public class TranslationConfiguration {
 
         final AbstractMessageSource databaseMessages = new TranslationServiceMessageSource(translationService);
         databaseMessages.setParentMessageSource(baseMessages);
-        return databaseMessages;
+
+        if (isEmpty(tenantProperties.getTranslationLocation())) {
+            return databaseMessages;
+        }
+
+        final ReloadableResourceBundleMessageSource configMessages = new ReloadableResourceBundleMessageSource();
+        configMessages.setResourceLoader(resourceLoader);
+        configMessages.setBasename(tenantProperties.getTranslationLocation() + "messages");
+        configMessages.setParentMessageSource(databaseMessages);
+        return configMessages;
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/ApplicationConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/ApplicationConfiguration.java
@@ -6,12 +6,14 @@ import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.web.WebConfiguration;
 import org.opentestsystem.rdw.reporting.common.web.security.SecurityConfiguration;
+import org.opentestsystem.rdw.reporting.configuration.ApplicationProperties;
 import org.opentestsystem.rdw.reporting.iris.IrisConfiguration;
 import org.opentestsystem.rdw.reporting.report.ReportConfiguration;
 import org.opentestsystem.rdw.security.repository.JdbcOrganizationRepository;
 import org.opentestsystem.rdw.utils.ResourceLoaderConfiguration;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -32,6 +34,7 @@ import org.springframework.context.annotation.Import;
         SecurityParameterProvider.class,
         IrisConfiguration.class
 })
+@EnableConfigurationProperties(ApplicationProperties.class)
 public class ApplicationConfiguration {
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/configuration/ApplicationProperties.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/configuration/ApplicationProperties.java
@@ -1,0 +1,170 @@
+package org.opentestsystem.rdw.reporting.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  Reporting Web Application Properties
+ */
+@ConfigurationProperties(prefix = "app")
+public class ApplicationProperties {
+
+    private IrisProperties iris = new IrisProperties();
+    private AnalyticsProperties analytics = new AnalyticsProperties();
+    private ReportServiceProperties reportservice = new ReportServiceProperties();
+    private String adminWebappUrl;
+    private ExternalLinksProperties externalLinks = new ExternalLinksProperties();
+    private int minItemDataYear;
+    private List<String> uiLanguages = new ArrayList<>();
+
+    /**
+     * @return Iris configuration properties
+     */
+    public IrisProperties getIris() {
+        return iris;
+    }
+
+    /**
+     * @return Google Analytics properties
+     */
+    public AnalyticsProperties getAnalytics() {
+        return analytics;
+    }
+
+    /**
+     * @return Report processor properties
+     */
+    public ReportServiceProperties getReportservice() {
+        return reportservice;
+    }
+
+    /**
+     * @return The reporting admin url
+     */
+    public String getAdminWebappUrl() {
+        return adminWebappUrl;
+    }
+
+    public void setAdminWebappUrl(final String adminWebappUrl) {
+        this.adminWebappUrl = adminWebappUrl;
+    }
+
+    /**
+     * @return External link properties
+     */
+    public ExternalLinksProperties getExternalLinks() {
+        return externalLinks;
+    }
+
+    /**
+     * @return The minimum year with data
+     */
+    public int getMinItemDataYear() {
+        return minItemDataYear;
+    }
+
+    public void setMinItemDataYear(final int minItemDataYear) {
+        this.minItemDataYear = minItemDataYear;
+    }
+
+    /**
+     * @return The available webapp UI languages in addition to English ("en")
+     */
+    public List<String> getUiLanguages() {
+        return uiLanguages;
+    }
+
+    public static class IrisProperties {
+        private String url;
+        private String vendorId;
+
+        /**
+         * @return The iris server URL
+         */
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(final String url) {
+            this.url = url;
+        }
+
+        /**
+         * @return The iris vendor id
+         */
+        public String getVendorId() {
+            return vendorId;
+        }
+
+        public void setVendorId(final String vendorId) {
+            this.vendorId = vendorId;
+        }
+    }
+
+    public static class AnalyticsProperties {
+        private String trackingId;
+
+        /**
+         * @return The Google Analytics tracking id
+         */
+        public String getTrackingId() {
+            return trackingId;
+        }
+
+        public void setTrackingId(final String trackingId) {
+            this.trackingId = trackingId;
+        }
+    }
+
+    public static class ReportServiceProperties {
+        private String url;
+        private List<String> languages = new ArrayList<>();
+
+        /**
+         * @return The report processor url
+         */
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(final String url) {
+            this.url = url;
+        }
+
+        /**
+         * @return The available reporting languages
+         */
+        public List<String> getLanguages() {
+            return languages;
+        }
+    }
+
+    public static class ExternalLinksProperties {
+        private String interpretiveGuide;
+        private String userGuide;
+
+        /**
+         * @return The interpretive guide url
+         */
+        public String getInterpretiveGuide() {
+            return interpretiveGuide;
+        }
+
+        public void setInterpretiveGuide(final String interpretiveGuide) {
+            this.interpretiveGuide = interpretiveGuide;
+        }
+
+        /**
+         * @return The user guide url
+         */
+        public String getUserGuide() {
+            return userGuide;
+        }
+
+        public void setUserGuide(final String userGuide) {
+            this.userGuide = userGuide;
+        }
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/configuration/ApplicationProperties.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/configuration/ApplicationProperties.java
@@ -18,6 +18,7 @@ public class ApplicationProperties {
     private ExternalLinksProperties externalLinks = new ExternalLinksProperties();
     private int minItemDataYear;
     private List<String> uiLanguages = new ArrayList<>();
+    private List<String> reportLanguages = new ArrayList<>();
 
     /**
      * @return Iris configuration properties
@@ -76,6 +77,13 @@ public class ApplicationProperties {
         return uiLanguages;
     }
 
+    /**
+     * @return The available report generation languages in addition to English
+     */
+    public List<String> getReportLanguages() {
+        return reportLanguages;
+    }
+
     public static class IrisProperties {
         private String url;
         private String vendorId;
@@ -120,7 +128,6 @@ public class ApplicationProperties {
 
     public static class ReportServiceProperties {
         private String url;
-        private List<String> languages = new ArrayList<>();
 
         /**
          * @return The report processor url
@@ -131,13 +138,6 @@ public class ApplicationProperties {
 
         public void setUrl(final String url) {
             this.url = url;
-        }
-
-        /**
-         * @return The available reporting languages
-         */
-        public List<String> getLanguages() {
-            return languages;
         }
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
@@ -4,9 +4,9 @@ import com.google.common.base.Joiner;
 import org.apache.commons.io.IOUtils;
 import org.opentestsystem.rdw.reporting.common.model.Report;
 import org.opentestsystem.rdw.reporting.common.report.BatchExamReportRequestHolder;
+import org.opentestsystem.rdw.reporting.configuration.ApplicationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -22,21 +22,20 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 
 @Service
 class DefaultReportWebServiceClient implements ReportWebServiceClient {
 
-    private final String url;
+    private final ApplicationProperties applicationProperties;
     private final RestTemplate template;
 
     @Autowired
     DefaultReportWebServiceClient(
-            @Value("${app.reportservice.url}") final String url,
+            final ApplicationProperties applicationProperties,
             @Qualifier("pdfAcceptingRestTemplate") final RestTemplate template) {
-        this.url = url;
+        this.applicationProperties = applicationProperties;
         this.template = template;
     }
 
@@ -44,7 +43,7 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
     public List<Report> getReports(final String userId) {
         final ResponseEntity<List<Report>> response = template.exchange(
                 "{url}/api/reports?user={userId}", HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<Report>>() {}, url, userId);
+                new ParameterizedTypeReference<List<Report>>() {}, applicationProperties.getReportservice().getUrl(), userId);
         return checkSuccess(response).getBody();
     }
 
@@ -53,7 +52,7 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
         final String expandedReportIds = StreamSupport.stream(reportIds.spliterator(), false)
                 .map(a -> "&id=" + a.toString()).reduce("", String::concat);
         final ResponseEntity<List<Report>> response = template.exchange(
-                url + "/api/reports?user={userId}" + expandedReportIds, HttpMethod.GET, null,
+                applicationProperties.getReportservice().getUrl() + "/api/reports?user={userId}" + expandedReportIds, HttpMethod.GET, null,
                 new ParameterizedTypeReference<List<Report>>() {}, userId);
         return checkSuccess(response).getBody();
     }
@@ -61,13 +60,13 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
     @Override
     public void streamReport(final String userId, final long reportId, final HttpServletResponse response) {
         template.execute("{url}/api/reports/{reportId}/content?user={userId}",
-                HttpMethod.GET, request -> {}, new StreamExtractor(response), url, reportId, userId);
+                HttpMethod.GET, request -> {}, new StreamExtractor(response), applicationProperties.getReportservice().getUrl(), reportId, userId);
     }
 
     @Override
     public Report createReport(final BatchExamReportRequestHolder request) {
         final ResponseEntity<Report> response = template.exchange(
-                "{url}/api/reports", HttpMethod.POST, new HttpEntity<>(request), Report.class, url);
+                "{url}/api/reports", HttpMethod.POST, new HttpEntity<>(request), Report.class, applicationProperties.getReportservice().getUrl());
 
         checkNotFound(response);
         return checkSuccess(response).getBody();

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClient.java
@@ -28,14 +28,14 @@ import java.util.stream.StreamSupport;
 @Service
 class DefaultReportWebServiceClient implements ReportWebServiceClient {
 
-    private final ApplicationProperties applicationProperties;
+    private final ApplicationProperties.ReportServiceProperties reportProperties;
     private final RestTemplate template;
 
     @Autowired
     DefaultReportWebServiceClient(
             final ApplicationProperties applicationProperties,
             @Qualifier("pdfAcceptingRestTemplate") final RestTemplate template) {
-        this.applicationProperties = applicationProperties;
+        this.reportProperties = applicationProperties.getReportservice();
         this.template = template;
     }
 
@@ -43,7 +43,7 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
     public List<Report> getReports(final String userId) {
         final ResponseEntity<List<Report>> response = template.exchange(
                 "{url}/api/reports?user={userId}", HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<Report>>() {}, applicationProperties.getReportservice().getUrl(), userId);
+                new ParameterizedTypeReference<List<Report>>() {}, reportProperties.getUrl(), userId);
         return checkSuccess(response).getBody();
     }
 
@@ -52,7 +52,7 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
         final String expandedReportIds = StreamSupport.stream(reportIds.spliterator(), false)
                 .map(a -> "&id=" + a.toString()).reduce("", String::concat);
         final ResponseEntity<List<Report>> response = template.exchange(
-                applicationProperties.getReportservice().getUrl() + "/api/reports?user={userId}" + expandedReportIds, HttpMethod.GET, null,
+                reportProperties.getUrl() + "/api/reports?user={userId}" + expandedReportIds, HttpMethod.GET, null,
                 new ParameterizedTypeReference<List<Report>>() {}, userId);
         return checkSuccess(response).getBody();
     }
@@ -60,13 +60,13 @@ class DefaultReportWebServiceClient implements ReportWebServiceClient {
     @Override
     public void streamReport(final String userId, final long reportId, final HttpServletResponse response) {
         template.execute("{url}/api/reports/{reportId}/content?user={userId}",
-                HttpMethod.GET, request -> {}, new StreamExtractor(response), applicationProperties.getReportservice().getUrl(), reportId, userId);
+                HttpMethod.GET, request -> {}, new StreamExtractor(response), reportProperties.getUrl(), reportId, userId);
     }
 
     @Override
     public Report createReport(final BatchExamReportRequestHolder request) {
         final ResponseEntity<Report> response = template.exchange(
-                "{url}/api/reports", HttpMethod.POST, new HttpEntity<>(request), Report.class, applicationProperties.getReportservice().getUrl());
+                "{url}/api/reports", HttpMethod.POST, new HttpEntity<>(request), Report.class, reportProperties.getUrl());
 
         checkNotFound(response);
         return checkSuccess(response).getBody();

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
@@ -62,7 +62,7 @@ class AppSettings {
      * @return The available report languages
      */
     public List<String> getReportLanguages() {
-        return applicationProperties.getReportservice().getLanguages();
+        return applicationProperties.getReportLanguages();
     }
 
     /**

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/search/user/AppSettings.java
@@ -1,72 +1,75 @@
 package org.opentestsystem.rdw.reporting.search.user;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.opentestsystem.rdw.reporting.configuration.ApplicationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 class AppSettings {
 
-    @Value("${app.iris.vendorId}")
-    private String irisVendorId;
+    private final ApplicationProperties applicationProperties;
 
-    @Value("${app.analytics.trackingId}")
-    private String analyticsTrackingId;
-
-    @Value("${app.external-links.interpretive-guide}")
-    private String interpretiveGuideUrl;
-
-    @Value("${app.external-links.user-guide}")
-    private String userGuideUrl;
-
-    @Value("${app.min-item-data-year}")
-    private int minItemDataYear;
-
-    @Value("${app.admin-webapp-url}")
-    private String adminWebappUrl;
-
-    private AppSettings() {
+    @Autowired
+    private AppSettings(final ApplicationProperties applicationProperties) {
+        this.applicationProperties = applicationProperties;
     }
 
     /**
      * @return the Iris vendor id passed to the Iris iframe
      */
     public String getIrisVendorId() {
-        return irisVendorId;
+        return applicationProperties.getIris().getVendorId();
     }
 
     /**
      * @return the Google Analytics tracking ID
      */
     public String getAnalyticsTrackingId() {
-        return analyticsTrackingId;
+        return applicationProperties.getAnalytics().getTrackingId();
     }
 
     /**
      * @return external link to the Intepretive Guide and Best Practices Guidance
      */
     public String getInterpretiveGuideUrl() {
-        return interpretiveGuideUrl;
+        return applicationProperties.getExternalLinks().getInterpretiveGuide();
     }
 
     /**
      * @return external link to the User Guide
      */
     public String getUserGuideUrl() {
-        return userGuideUrl;
+        return applicationProperties.getExternalLinks().getUserGuide();
     }
 
     /**
      * @return minimum year where there is item level response data
      */
     public int getMinItemDataYear() {
-        return minItemDataYear;
+        return applicationProperties.getMinItemDataYear();
     }
 
     /**
      * @return the admin web application URL
      */
     public String getAdminWebappUrl() {
-        return adminWebappUrl;
+        return applicationProperties.getAdminWebappUrl();
+    }
+
+    /**
+     * @return The available report languages
+     */
+    public List<String> getReportLanguages() {
+        return applicationProperties.getReportservice().getLanguages();
+    }
+
+    /**
+     * @return The avialable UI languages
+     */
+    public List<String> getUiLanguages() {
+        return applicationProperties.getUiLanguages();
     }
 
 }

--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -1,10 +1,8 @@
-import { Angulartics2GoogleAnalytics } from "angulartics2";
 import { Component } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 import { UserService } from "./user/user.service";
-import { Router, NavigationEnd } from "@angular/router";
+import { NavigationEnd, Router } from "@angular/router";
 import { Location, PopStateEvent } from "@angular/common";
-import { NotificationService } from "./shared/notification/notification.service";
 import { isNullOrUndefined } from "util";
 import { User } from "./user/model/user.model";
 
@@ -27,14 +25,13 @@ export class AppComponent {
   constructor(public translate: TranslateService,
               private userService: UserService,
               private router: Router,
-              private location: Location,
-              private angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {
+              private location: Location) {
 
-    let languages = [ 'en', 'ja' ];
+    let languages = [ 'en' ];
     let defaultLanguage = languages[ 0 ];
     translate.addLangs(languages);
     translate.setDefaultLang(defaultLanguage);
-    translate.use(languages.indexOf(translate.getBrowserLang()) != -1 ? translate.getBrowserLang() : defaultLanguage);
+    translate.use(defaultLanguage);
   }
 
   ngOnInit() {
@@ -42,6 +39,12 @@ export class AppComponent {
     this.userService.getCurrentUser().subscribe(user => {
       if (!isNullOrUndefined(user)) {
         this._user = user;
+
+        let languages = user.configuration.uiLanguages;
+        this.translate.addLangs(languages);
+        if (languages.indexOf(this.translate.getBrowserLang()) != -1) {
+          this.translate.use(this.translate.getBrowserLang());
+        }
 
         if (window[ 'ga' ] && user.configuration && user.configuration.analyticsTrackingId) {
           window[ 'ga' ]('create', user.configuration.analyticsTrackingId, 'auto');

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -2,51 +2,23 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AssessmentResultsComponent } from "./assessment-results.component";
 import { APP_BASE_HREF } from "@angular/common";
 import { TranslateModule } from "@ngx-translate/core";
-import { FormsModule } from "@angular/forms";
-import { HttpModule } from "@angular/http";
-import { Component, EventEmitter } from "@angular/core";
-import { SharedModule } from "primeng/components/common/shared";
-import { DataTableModule } from "primeng/components/datatable/datatable";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { AssessmentExam } from "../model/assessment-exam.model";
 import { Exam } from "../model/exam.model";
 import { ExamStatisticsCalculator } from "./exam-statistics-calculator";
 import { ExamFilterService } from "../filters/exam-filters/exam-filter.service";
-import { ScaleScoreComponent } from "./scale-score.component";
-import { AverageScaleScoreComponent } from "./average-scale-score.component";
-import { ItemViewerComponent } from "../items/item-viewer/item-viewer.component";
-import { ItemTabComponent } from "../items/item-tab.component";
-import { PopoverModule, TabsModule } from "ngx-bootstrap";
 import { Student } from "../../student/model/student.model";
-import { PopupMenuComponent } from "../menu/popup-menu.component";
 import { ColorService } from "../../shared/color.service";
-import { Angulartics2, Angulartics2Module } from "angulartics2";
-import { ItemExemplarComponent } from "../items/item-exemplar/item-exemplar.component";
-import { ItemScoresComponent } from "../items/item-scores/item-scores.component";
+import { Angulartics2 } from "angulartics2";
 import { TestModule } from "../../../test/test.module";
-import { ItemInfoComponent } from "../items/item-info/item-info.component";
-import { ScaleScoreService } from "../../shared/scale-score.service";
 import { MockDataService } from "../../../test/mock.data.service";
-import { DataService } from "../../shared/data/data.service";
-import { NotificationService } from "../../shared/notification/notification.service";
-import { Notification } from "../../shared/notification/notification.model";
-import { ItemInfoService } from "../items/item-info/item-info.service";
-import { UserService } from "../../user/user.service";
-import { UserMapper } from "../../user/user.mapper";
-import { CachingDataService } from "../../shared/cachingData.service";
-import { ClaimTargetComponent } from "./claim-target.component";
-import { ReportModule } from "../../report/report.module";
 import { CommonModule } from "../../shared/common.module";
-import { ResultsByStudentComponent } from "./view/results-by-student/results-by-student.component";
-import { AssessmentProvider } from "../assessment-provider.interface";
-import { ResultsByItemComponent } from "./view/results-by-item/results-by-item.component";
-import { DistractorAnalysisComponent } from "./view/distractor-analysis/distractor-analysis.component";
 
 describe('AssessmentResultsComponent', () => {
   let component: AssessmentResultsComponent;
   let fixture: ComponentFixture<TestComponentWrapper>;
   let dataService: MockDataService;
-  let service: MockNotificationService;
 
   let mockAngulartics2 = jasmine.createSpyObj<Angulartics2>('angulartics2', [ 'eventTrack' ]);
   mockAngulartics2.eventTrack = jasmine.createSpyObj('angulartics2', [ 'next' ]);
@@ -56,48 +28,23 @@ describe('AssessmentResultsComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule,
-        DataTableModule,
-        FormsModule,
-        HttpModule,
-        PopoverModule.forRoot(),
-        SharedModule,
+        NoopAnimationsModule,
         CommonModule,
-        ReportModule,
-        TabsModule,
         TranslateModule.forRoot(),
-        Angulartics2Module,
         TestModule
       ],
       declarations: [
         AssessmentResultsComponent,
-        DistractorAnalysisComponent,
-        ItemTabComponent,
-        ItemViewerComponent,
-        ItemInfoComponent,
-        ItemExemplarComponent,
-        ItemScoresComponent,
-        PopupMenuComponent,
-        ScaleScoreComponent,
-        AverageScaleScoreComponent,
-        TestComponentWrapper,
-        ClaimTargetComponent,
-        ResultsByStudentComponent,
-        ResultsByItemComponent
+        TestComponentWrapper
       ],
-      providers: [ { provide: APP_BASE_HREF, useValue: '/' },
+      providers: [
+        { provide: APP_BASE_HREF, useValue: '/' },
         { provide: Angulartics2, useValue: mockAngulartics2 },
         ExamStatisticsCalculator,
         ExamFilterService,
-        ColorService,
-        ScaleScoreService,
-        { provide: DataService, useValue: dataService },
-        { provide: NotificationService, useValue: service },
-        ItemInfoService,
-        UserService,
-        UserMapper,
-        { provide: CachingDataService, useValue: dataService }
-      ]
+        ColorService
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponentWrapper);
@@ -175,7 +122,4 @@ class TestComponentWrapper {
   assessment = new AssessmentExam();
 }
 
-class MockNotificationService {
-  onNotification: EventEmitter<Notification> = new EventEmitter();
-}
 

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
@@ -1,24 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ResultsByStudentComponent } from './results-by-student.component';
-import { DataTableModule, SharedModule } from "primeng/primeng";
 import { CommonModule } from "../../../../shared/common.module";
-import { ScaleScoreComponent } from "../../scale-score.component";
-import { PopupMenuComponent } from "../../../menu/popup-menu.component";
-import { PopoverModule } from "ngx-bootstrap";
-import { FormsModule } from "@angular/forms";
 import { MenuActionBuilder } from "../../../menu/menu-action.builder";
 import { TestModule } from "../../../../../test/test.module";
-import { ReportModule } from "../../../../report/report.module";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { HttpModule } from "@angular/http";
 import { TranslateModule } from "@ngx-translate/core";
 import { Angulartics2 } from "angulartics2";
-import { ScaleScoreService } from "../../../../shared/scale-score.service";
-import { DataService } from "../../../../shared/data/data.service";
-import { NotificationService } from "../../../../shared/notification/notification.service";
-import { CachingDataService } from "../../../../shared/cachingData.service";
-import { Component, EventEmitter } from "@angular/core";
+import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { MockDataService } from "../../../../../test/mock.data.service";
 import { Assessment } from "../../../model/assessment.model";
 
@@ -27,7 +15,6 @@ describe('ResultsByStudentComponent', () => {
   let fixture: ComponentFixture<TestComponentWrapper>;
 
   let dataService: MockDataService;
-  let service: MockNotificationService;
   let mockAngulartics2 = jasmine.createSpyObj<Angulartics2>('angulartics2', [ 'eventTrack' ]);
   mockAngulartics2.eventTrack = jasmine.createSpyObj('angulartics2', [ 'next' ]);
 
@@ -36,31 +23,19 @@ describe('ResultsByStudentComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule,
-        DataTableModule,
-        FormsModule,
-        HttpModule,
-        SharedModule,
-        PopoverModule.forRoot(),
         CommonModule,
-        ReportModule,
         TranslateModule.forRoot(),
         TestModule
       ],
       declarations: [
-        PopupMenuComponent,
-        ScaleScoreComponent,
-        TestComponentWrapper,
-        ResultsByStudentComponent
+        ResultsByStudentComponent,
+        TestComponentWrapper
       ],
       providers: [
         { provide: Angulartics2, useValue: mockAngulartics2 },
-        MenuActionBuilder,
-        ScaleScoreService,
-        { provide: DataService, useValue: dataService },
-        { provide: NotificationService, useValue: service },
-        { provide: CachingDataService, useValue: dataService }
-      ]
+        MenuActionBuilder
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
       .compileComponents();
   }));
@@ -82,8 +57,4 @@ describe('ResultsByStudentComponent', () => {
 })
 class TestComponentWrapper {
   assessment = new Assessment();
-}
-
-class MockNotificationService {
-  onNotification: EventEmitter<Notification> = new EventEmitter();
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
@@ -92,7 +92,8 @@ export class ResultsByStudentComponent implements OnInit {
     return !this.isIab;
   }
 
-  constructor(private actionBuilder: MenuActionBuilder,  private translate: TranslateService) {
+  constructor(private actionBuilder: MenuActionBuilder,
+              private translate: TranslateService) {
   }
 
   ngOnInit() {

--- a/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/group-report-download.component.ts
@@ -5,6 +5,7 @@ import { NotificationService } from "../shared/notification/notification.service
 import { Report } from "./report.model";
 import { Group } from "../user/model/group.model";
 import { Observable } from "rxjs";
+import { UserService } from "../user/user.service";
 
 /**
  * Component used for single-student exam report download
@@ -19,8 +20,9 @@ export class GroupReportDownloadComponent extends ReportDownloadComponent {
   group: Group;
 
   constructor(notificationService: NotificationService,
+              userService: UserService,
               private service: ReportService) {
-    super(notificationService);
+    super(notificationService, userService);
   }
 
   createReport(): Observable<Report> {

--- a/webapp/src/main/webapp/src/app/report/report-download.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.html
@@ -41,6 +41,13 @@
               </select>
             </div>
 
+            <div class="form-group" *ngIf="reportLanguages.length > 1">
+              <label for="language-select">{{'labels.reports.form.language' | translate}}</label>
+              <select id="language-select" class="form-control input-sm" name="language" [(ngModel)]="options.language">
+                <option *ngFor="let language of reportLanguages" [ngValue]="language">{{'labels.locale.' + language | translate}}</option>
+              </select>
+            </div>
+
           </div>
           <div class="col-md-6">
 

--- a/webapp/src/main/webapp/src/app/report/report-download.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.html
@@ -44,7 +44,7 @@
             <div class="form-group" *ngIf="reportLanguages.length > 1">
               <label for="language-select">{{'labels.reports.form.language' | translate}}</label>
               <select id="language-select" class="form-control input-sm" name="language" [(ngModel)]="options.language">
-                <option *ngFor="let language of reportLanguages" [ngValue]="language">{{'labels.locale.' + language | translate}}</option>
+                <option *ngFor="let language of reportLanguages" [ngValue]="language">{{'labels.locale.' + language + '.default' | translate}}</option>
               </select>
             </div>
 

--- a/webapp/src/main/webapp/src/app/report/report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.ts
@@ -7,6 +7,8 @@ import { ReportOrder } from "./report-order.enum";
 import { ModalDirective } from "ngx-bootstrap";
 import { Observable } from "rxjs";
 import { Report } from "./report.model";
+import { UserService } from "../user/user.service";
+import { isNullOrUndefined } from "util";
 
 /**
  * Abstract class used to carry the common logic between all exam report download components
@@ -54,11 +56,12 @@ export abstract class ReportDownloadComponent implements OnInit {
   AssessmentType: any = AssessmentType;
   assessmentTypes: AssessmentType[] = [ null, AssessmentType.IAB, AssessmentType.ICA ];
   subjectTypes: AssessmentSubjectType[] = [ null, AssessmentSubjectType.MATH, AssessmentSubjectType.ELA ];
-  languages: string[] = [ 'eng', 'spa', 'vie' ];
   orders: ReportOrder[] = [ ReportOrder.STUDENT_NAME, ReportOrder.STUDENT_SSID ];
   options: ReportOptions;
+  reportLanguages: string[] = ['en'];
 
-  constructor(protected notificationService: NotificationService) {
+  constructor(protected notificationService: NotificationService,
+              protected userService: UserService) {
   }
 
   ngOnInit(): void {
@@ -66,11 +69,17 @@ export abstract class ReportDownloadComponent implements OnInit {
     defaultOptions.assessmentType = this.assessmentType != null ? this.assessmentType : this.assessmentTypes[ 0 ];
     defaultOptions.subject = this.subject != null ? this.getSubjectFromString(this.subject) : this.subjectTypes[ 0 ];
     defaultOptions.schoolYear = this.schoolYear != null ? this.schoolYear : this.schoolYears[ 0 ];
-    defaultOptions.language = this.languages[ 0 ];
+    defaultOptions.language = this.reportLanguages[0];
     defaultOptions.accommodationsVisible = false;
     defaultOptions.order = this.orders[ 0 ];
     defaultOptions.grayscale = false;
     this.options = defaultOptions;
+
+    this.userService.getCurrentUser().subscribe(user => {
+      if (!isNullOrUndefined(user)) {
+        this.reportLanguages = this.reportLanguages.concat(user.configuration.reportLanguages);
+      }
+    });
   }
 
   submit(): void {

--- a/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/school-grade-report-download.component.ts
@@ -7,6 +7,7 @@ import { School } from "../user/model/school.model";
 import { Grade } from "../school-grade/grade.model";
 import { TranslateService } from "@ngx-translate/core";
 import { Observable } from "rxjs";
+import { UserService } from "../user/user.service";
 
 /**
  * Component used for single-student exam report download
@@ -24,9 +25,10 @@ export class SchoolGradeDownloadComponent extends ReportDownloadComponent {
   grade: Grade;
 
   constructor(notificationService: NotificationService,
+              userService: UserService,
               private service: ReportService,
               private translate: TranslateService) {
-    super(notificationService);
+    super(notificationService, userService);
   }
 
   createReport(): Observable<Report> {

--- a/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
+++ b/webapp/src/main/webapp/src/app/report/student-report-download.component.ts
@@ -6,6 +6,7 @@ import { Student } from "../student/model/student.model";
 import { Report } from "./report.model";
 import { Observable } from "rxjs";
 import { TranslateService } from "@ngx-translate/core";
+import { UserService } from "../user/user.service";
 
 /**
  * Component used for single-student exam report download
@@ -20,9 +21,10 @@ export class StudentReportDownloadComponent extends ReportDownloadComponent {
   student: Student;
 
   constructor(notificationService: NotificationService,
+              userService: UserService,
               private service: ReportService,
               private translate: TranslateService) {
-    super(notificationService);
+    super(notificationService, userService);
     this.displayOrder = false;
   }
 

--- a/webapp/src/main/webapp/src/app/user/model/configuration.model.ts
+++ b/webapp/src/main/webapp/src/app/user/model/configuration.model.ts
@@ -5,4 +5,6 @@ export class Configuration {
   userGuideUrl: string;
   minItemDataYear: number;
   adminWebappUrl: string;
+  reportLanguages: string[];
+  uiLanguages: string[];
 }

--- a/webapp/src/main/webapp/src/app/user/user.mapper.ts
+++ b/webapp/src/main/webapp/src/app/user/user.mapper.ts
@@ -82,6 +82,8 @@ export class UserMapper {
     uiModel.userGuideUrl = apiModel.userGuideUrl;
     uiModel.minItemDataYear = apiModel.minItemDataYear;
     uiModel.adminWebappUrl = apiModel.adminWebappUrl;
+    uiModel.reportLanguages = apiModel.reportLanguages;
+    uiModel.uiLanguages = apiModel.uiLanguages;
     return uiModel;
   }
 

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -45,9 +45,18 @@
       }
     },
     "locale": {
-      "en": "English",
-      "es": "Spanish",
-      "vi": "Vietnamese"
+      "en": {
+        "native": "English",
+        "default": "English"
+      },
+      "es": {
+        "native": "Español",
+        "default": "Spanish"
+      },
+      "vi": {
+        "native": "Tiếng Việt",
+        "default": "Vietnamese"
+      }
     },
     "assessmentTypes": {
       "1": {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -44,19 +44,10 @@
         "interpretive-guide-subtitle": "Interim Assessments"
       }
     },
-    "languages": {
-      "eng": {
-        "native": "English",
-        "default" : "English"
-      },
-      "spa": {
-        "native": "Español",
-        "default": "Spanish"
-      },
-      "vie": {
-        "native": "Tiếng Việt",
-        "default": "Vietnamese"
-      }
+    "locale": {
+      "en": "English",
+      "es": "Spanish",
+      "vi": "Vietnamese"
     },
     "assessmentTypes": {
       "1": {
@@ -468,6 +459,7 @@
         },
         "report-name": "Report Name",
         "assessment-type": "Assessment Type",
+        "language": "Report Language",
         "subject": "Subject",
         "school-year": "School Year",
         "accommodations": {

--- a/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClientTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/reporting/report/client/DefaultReportWebServiceClientTest.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.report.client;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opentestsystem.rdw.reporting.configuration.ApplicationProperties;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -17,14 +18,18 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 public class DefaultReportWebServiceClientTest {
 
     private static final String baseURL = "http://url";
+    private ApplicationProperties applicationProperties;
     private DefaultReportWebServiceClient client;
     private MockRestServiceServer server;
 
     @Before
     public void before() {
+        applicationProperties = new ApplicationProperties();
+        applicationProperties.getReportservice().setUrl(baseURL);
+
         final RestTemplate template = new RestTemplate();
         this.server = MockRestServiceServer.bindTo(template).build();
-        this.client = new DefaultReportWebServiceClient(baseURL, template);
+        this.client = new DefaultReportWebServiceClient(applicationProperties, template);
     }
 
     @Test(expected = RuntimeException.class)


### PR DESCRIPTION
This PR adds a language selector to the PDF report generator modal dialog IFF more than english is available as a language.

I've also added a configurable message-source for providing additional languages/english overrides to the Reporting Common translation message source.  This was tested using a local file-system path but should allow access to remote config-server properties files as well.

Sample changes to the reporting webapp configuration:
```
  reportservice:
    url: http://localhost:8085
    languages:
      - es
      - vi
```

Sample changes to the report-processor configuration:
```
tenant:
  translation-location: file:///my/awesome/language/location/
```

Note that I've changed the reporting webapp configuration properties from @Value annotations to a ConfigurationProperties implementation.  @Value does *not* deal well with parsing collections out of configuration properties.