### PR TITLE
validate year when loading student groups

### DIFF
--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/SchoolYearRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/SchoolYearRepository.java
@@ -1,0 +1,11 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import java.util.List;
+
+public interface SchoolYearRepository {
+
+    /**
+     * @return list of valid school years
+     */
+    List<Integer> findAll();
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepository.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Repository
+class JdbcSchoolYearRepository implements SchoolYearRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.schoolYear.findAll}")
+    private String findAllQuery;
+
+    @Autowired
+    JdbcSchoolYearRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<Integer> findAll() {
+        return template.queryForList(findAllQuery, new HashMap<>(), Integer.class);
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.csv.CSVRecord;
 import org.opentestsystem.rdw.admin.model.Organization;
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
 import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.admin.model.CsvSubject;
 import org.opentestsystem.rdw.admin.model.CsvValidationResult;
@@ -53,10 +54,13 @@ public class DefaultCsvValidationService implements CsvValidationService {
     private static final String MoreSuccessesFormat = "With %1$d additional schools";
     private static final int MaxMessages = 100;
     private final SchoolRepository schoolRepository;
+    private final SchoolYearRepository schoolYearRepository;
 
     @Autowired
-    public DefaultCsvValidationService(final SchoolRepository schoolRepository) {
+    public DefaultCsvValidationService(final SchoolRepository schoolRepository,
+                                       final SchoolYearRepository schoolYearRepository) {
         this.schoolRepository = schoolRepository;
+        this.schoolYearRepository = schoolYearRepository;
     }
 
     @Override
@@ -78,6 +82,7 @@ public class DefaultCsvValidationService implements CsvValidationService {
         final List<CsvValidationResult> successes = new ArrayList<>();
 
         final List<Organization> availableSchools = schoolRepository.findAll(permissionScope);
+        final List<Integer> schoolYears = schoolYearRepository.findAll();
 
         final Set<String> completedSchools = new HashSet<>();
         final Set<String> completedSchoolGroupYears = new HashSet<>();
@@ -98,8 +103,15 @@ public class DefaultCsvValidationService implements CsvValidationService {
             final CsvSubject subject = CsvSubject.valueOfCaseInsensitive(record.get(HeaderSubject));
             recordNumber = record.getRecordNumber();
 
-            validateKeyValues(failures, school, group, schoolYear, recordNumber);
-            if (!failures.isEmpty()) continue;
+            //Require all key fields to be set
+            if (!validateKeyValues(failures, school, group, schoolYear, recordNumber)) {
+                continue;
+            }
+
+            //Validate the School Year
+            if (!schoolYears.contains(schoolYear)) {
+                addUniqueFailure(failures, recordNumber, "Invalid school year: " + schoolYear);
+            }
 
             //Validate the School
             if (currentSchool == null || !currentSchool.equals(school)) {
@@ -109,10 +121,15 @@ public class DefaultCsvValidationService implements CsvValidationService {
                 }
                 completedSchoolGroupYears.clear();
                 currentSchoolGroupYear = null;
-                currentSchool = school;
+                currentSchool = null;
                 groupCountPerSchool = 0;
 
-                validateSchool(failures, availableSchools, completedSchools, school, recordNumber);
+                if (validateSchool(failures, availableSchools, completedSchools, school, recordNumber)) {
+                    currentSchool = school;
+                } else {
+                    // no point in continuing processing since we don't have a current school
+                    continue;
+                }
             }
 
             //Validate the School, Group, and Year
@@ -136,9 +153,9 @@ public class DefaultCsvValidationService implements CsvValidationService {
             if (currentSchoolGroupYearSubject == null) {
                 currentSchoolGroupYearSubject = subject;
             } else if (subject != null && !subject.equals(currentSchoolGroupYearSubject)) {
-                failures.add(failure(recordNumber,
+                addUniqueFailure(failures, recordNumber,
                         "Record is attempting to re-define group subject from ["
-                                + currentSchoolGroupYearSubject.name() + "] to [" + subject.name() + "]"));
+                                + currentSchoolGroupYearSubject.name() + "] to [" + subject.name() + "]");
 
                 currentSchoolGroupYearSubject = subject;
             }
@@ -157,27 +174,6 @@ public class DefaultCsvValidationService implements CsvValidationService {
         }
 
         return ImmutableList.copyOf(failures);
-    }
-
-    private void validateStudentCount(final List<CsvValidationResult> failures,
-                                      final String school,
-                                      final String group,
-                                      final int studentCount,
-                                      final long recordNumber) {
-        if (studentCount > MaxStudentsPerGroup) {
-            failures.add(failure(recordNumber,
-                    "School [" + school + "] Group [" + group + "] contains "
-                            + studentCount + " students.  Maximum students allowed per group is " + MaxStudentsPerGroup));
-        }
-    }
-
-    private void validateSchoolGroupYear(final List<CsvValidationResult> failures,
-                                         final Set<String> completedSchoolGroupYears,
-                                         final String schoolGroupYear,
-                                         final long recordNumber) {
-        if (completedSchoolGroupYears.contains(schoolGroupYear)) {
-            failures.add(failure(recordNumber, "Record is out-of-order: sort CSV by school, group, year"));
-        }
     }
 
     @Override
@@ -214,41 +210,82 @@ public class DefaultCsvValidationService implements CsvValidationService {
         }
     }
 
-    private void validateKeyValues(final List<CsvValidationResult> failures,
-                                   final String school,
-                                   final String group,
-                                   final Integer schoolYear,
-                                   final long recordNumber) {
+    private static boolean validateKeyValues(final List<CsvValidationResult> failures,
+                                             final String school,
+                                             final String group,
+                                             final Integer schoolYear,
+                                             final long recordNumber) {
+        boolean failure = false;
+
         if (isBlank(school)) {
             failures.add(failure(recordNumber, "Record does not contain a school"));
+            failure = true;
         }
         if (isBlank(group)) {
             failures.add(failure(recordNumber, "Record does not contain a group name"));
+            failure = true;
         }
         if (schoolYear == null) {
             failures.add(failure(recordNumber, "Record does not contain a school year"));
+            failure = true;
         }
+
+        return !failure;
     }
 
-    private void validateSchool(final List<CsvValidationResult> failures,
-                                final List<Organization> availableSchools,
-                                final Set<String> completedSchools,
-                                final String school,
-                                final long recordNumber) {
+    private static boolean validateSchool(final List<CsvValidationResult> failures,
+                                          final List<Organization> availableSchools,
+                                          final Set<String> completedSchools,
+                                          final String school,
+                                          final long recordNumber) {
+        boolean failure = false;
+
         if (availableSchools.stream().noneMatch(x -> Objects.equals(x.getNaturalId(), school))) {
-            failures.add(failure(recordNumber, "School [" + school + "] can not be found"));
+            addUniqueFailure(failures, recordNumber, "School [" + school + "] can not be found");
+            failure = true;
         }
         if (completedSchools.contains(school)) {
-            failures.add(failure(recordNumber, "School [" + school + "] is out-of-order: sort CSV by school, group, year"));
+            addUniqueFailure(failures, recordNumber, "School [" + school + "] is out-of-order: sort CSV by school, group, year");
+            failure = true;
+        }
+
+        return !failure;
+    }
+
+    private static void validateStudentCount(final List<CsvValidationResult> failures,
+                                             final String school,
+                                             final String group,
+                                             final int studentCount,
+                                             final long recordNumber) {
+        if (studentCount > MaxStudentsPerGroup) {
+            addUniqueFailure(failures, recordNumber,
+                    "School [" + school + "] Group [" + group + "] contains "
+                            + studentCount + " students.  Maximum students allowed per group is " + MaxStudentsPerGroup);
         }
     }
 
-    private CsvValidationResult success(final long recordNumber, final int groupCount, final Organization school) {
+    private static void validateSchoolGroupYear(final List<CsvValidationResult> failures,
+                                                final Set<String> completedSchoolGroupYears,
+                                                final String schoolGroupYear,
+                                                final long recordNumber) {
+        if (completedSchoolGroupYears.contains(schoolGroupYear)) {
+            addUniqueFailure(failures, recordNumber, "Record is out-of-order: sort CSV by school, group, year");
+        }
+    }
+
+    private static void addUniqueFailure(final List<CsvValidationResult> failures, final long recordNumber, final String message) {
+        for (final CsvValidationResult failure : failures) {
+            if (failure.getMessage().equals(message)) return;
+        }
+        failures.add(failure(recordNumber, message));
+    }
+
+    private static CsvValidationResult success(final long recordNumber, final int groupCount, final Organization school) {
         return CsvValidationResult.success(recordNumber, String.format(ValidationSuccessFormat,
                 groupCount, groupCount == 1 ? "" : "s", school.getName(), school.getNaturalId()));
     }
 
-    private Organization getSchool(final List<Organization> availableSchools, final String naturalId) {
+    private static Organization getSchool(final List<Organization> availableSchools, final String naturalId) {
         return availableSchools.stream().filter(x -> Objects.equals(x.getNaturalId(), naturalId)).findFirst().get();
     }
 

--- a/admin-webapp/src/main/resources/application.sql.yml
+++ b/admin-webapp/src/main/resources/application.sql.yml
@@ -40,6 +40,10 @@ sql:
       from school
       where (1=:statewide or district_group_id in (:district_group_ids) or district_id in (:district_ids) or school_group_id in (:school_group_ids) or id in (:school_ids))
 
+  schoolYear:
+    findAll: >-
+      SELECT year FROM school_year ORDER BY year
+
   status:
     readTest: >-
       SELECT ist.name FROM import_status ist

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepositoryIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepositoryIT.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {JdbcSchoolYearRepository.class})
+@ActiveProfiles("test")
+public class JdbcSchoolYearRepositoryIT {
+
+    @Autowired
+    JdbcSchoolYearRepository repository;
+
+    @Test
+    public void itShouldFindByAllSchoolYears() {
+        assertThat(repository.findAll()).contains(2016, 2017, 2018);
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.admin.model.Organization;
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
 import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.admin.model.CsvSubject;
 import org.opentestsystem.rdw.admin.model.CsvValidationResult;
@@ -44,6 +45,8 @@ public class DefaultCsvValidationServiceTest {
 
     @Mock
     private SchoolRepository schoolRepository;
+    @Mock
+    private SchoolYearRepository schoolYearRepository;
 
     private DefaultCsvValidationService service;
 
@@ -54,7 +57,9 @@ public class DefaultCsvValidationServiceTest {
         schools.add(new Organization(2, "School B", SchoolB));
         when(schoolRepository.findAll(PermissionScope.STATEWIDE)).thenReturn(schools);
 
-        service = new DefaultCsvValidationService(schoolRepository);
+        when(schoolYearRepository.findAll()).thenReturn(newArrayList(2016, 2017, 2018));
+
+        service = new DefaultCsvValidationService(schoolRepository, schoolYearRepository);
     }
 
     @Test
@@ -82,6 +87,25 @@ public class DefaultCsvValidationServiceTest {
 
         assertThat(failure.getRow()).isEqualTo(0);
         assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));
+    }
+
+    @Test
+    public void itShouldNotValidateUnknownSchoolYear() throws IOException {
+        final RecordBuilder builder = recordBuilder()
+                .row(SchoolA, "Good Year", 2016, null, null)
+                .row(SchoolA, "Bad Year 1718-A", 1718, null, null)
+                .row(SchoolA, "Bad Year 1718-B", 1718, null, null)
+                .row(SchoolA, "Bad Year 1964", 1964, null, null);
+
+        try (final CSVParser parser = builder.build()) {
+            final List<CsvValidationResult> failures = service.validateRecords(parser.iterator(), PermissionScope.STATEWIDE);
+
+            assertThat(failures).hasSize(2);
+            assertThat(failures.get(0).getRow()).isEqualTo(2);
+            assertThat(failures.get(0).getMessage()).contains("Invalid school year: 1718");
+            assertThat(failures.get(1).getRow()).isEqualTo(4);
+            assertThat(failures.get(1).getMessage()).contains("Invalid school year: 1964");
+        }
     }
 
     @Test
@@ -237,10 +261,10 @@ public class DefaultCsvValidationServiceTest {
         }
 
         RecordBuilder row(final String school,
-                                 final String group,
-                                 final int schoolYear,
-                                 final CsvSubject subject,
-                                 final String studentSSID) {
+                          final String group,
+                          final int schoolYear,
+                          final CsvSubject subject,
+                          final String studentSSID) {
             final Map<String, String> record = new HashMap<>();
             record.put(HeaderSchool, school);
             record.put(HeaderGroup, group);


### PR DESCRIPTION
As part of this, i changed the validation to continue past any row with an error. Previously it would break out as soon as it hit a row with an error. And, as part of that, i made it so it wouldn't log duplicate messages (i.e. if the same unknown school is seen in 20 rows, there will be only one error message regarding that school being unknown).