### PR TITLE
Enable simple translation caching

### DIFF
--- a/admin-webapp/src/main/resources/application.yml
+++ b/admin-webapp/src/main/resources/application.yml
@@ -61,7 +61,7 @@ spring:
 
   cache:
     type: SIMPLE
-    cache-names: permissionsByRole
+    cache-names: permissionsByRole, mergeTranslations
 
     # Force the (rabbit) queues to be created when posting messages so, even if
     # there are no consumers running, the messages will not get lost. Routing is

--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultTranslationMergeService.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultTranslationMergeService.java
@@ -9,6 +9,7 @@ import org.opentestsystem.rdw.reporting.common.service.TranslationMergeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.Iterator;
@@ -36,8 +37,8 @@ public class DefaultTranslationMergeService implements TranslationMergeService {
         this.objectMapper = objectMapper;
     }
 
-    //TODO Consider application-level caching scheme - this should almost never change.
     @Override
+    @Cacheable(value = "mergeTranslations", key = "#locale.toString()")
     public ObjectNode getLocaleMessages(final Locale locale) {
         final ObjectNode messages = objectMapper.createObjectNode();
         for (final TranslationProvider provider : translationProviders) {

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
 
   cache:
     type: SIMPLE
-    cache-names: permissionsByRole, internalTranslationsByCode
+    cache-names: permissionsByRole, internalTranslationsByCode, mergeTranslations
 
   thymeleaf:
     mode: HTML
@@ -110,12 +110,6 @@ app:
   # google analytics configuration
   analytics:
     trackingId: ${rdw.reporting.analytics.trackingId:}
-
-  wkhtmltopdf:
-    url: http://localhost:8082
-    options:
-      page-size: Letter
-      zoom: 0.75
 
   reportservice:
     url: http://localhost:8085


### PR DESCRIPTION
In lieu of a more robust solution, enable simple translation caching for interim work and awsqa testing.