### PR TITLE
Added label-max-width to datatable-row-expander to trim long labels w…

### DIFF
--- a/admin-webapp/src/main/webapp/src/styles.less
+++ b/admin-webapp/src/main/webapp/src/styles.less
@@ -195,3 +195,9 @@ footer {
 .font-weight-light {
   font-weight: lighter;
 }
+
+.label-max-width {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 330px;
+}

--- a/common-ngx/src/datatable/datatable-row-expander.component.ts
+++ b/common-ngx/src/datatable/datatable-row-expander.component.ts
@@ -8,7 +8,7 @@ import { Utils } from "../support";
 @Component({
   selector: 'datatable-row-expander',
   template: `
-    <button class="btn btn-info btn-xs btn-block text-left" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !expanded, 'fa-chevron-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
+    <button class="btn btn-info btn-xs btn-block text-left label-max-width" (click)="toggle()"><i class="fa" [ngClass]="{'fa-chevron-right': !expanded, 'fa-chevron-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
   `
 })
 export class DataTableRowExpander {


### PR DESCRIPTION
…ith ellipses (including long file names).

Note:  This also fixes in other places that use the same common component, i.e. the student name in Items By Results.

