### PR TITLE
Fix reporting front-end cookie service.

### DIFF
--- a/common-ngx/src/preference/rdw-preference.module.ts
+++ b/common-ngx/src/preference/rdw-preference.module.ts
@@ -8,9 +8,13 @@ import { CookieService } from "angular2-cookie/services/cookies.service";
     RdwCoreModule
   ],
   providers: [
-    CookieService,
-    UserPreferenceService
+    UserPreferenceService,
+    { provide: CookieService, useFactory: cookieServiceFactory }
   ]
 })
 export class RdwPreferenceModule {
+}
+
+export function cookieServiceFactory() {
+  return new CookieService();
 }


### PR DESCRIPTION
This looks to be reported in the cookie service project as https://github.com/salemdar/angular2-cookie/issues/37

Since we don't need default CookieOptions, I decided to go with the factory provider solution.

Note that this was reproducible with meaningful error messages by changing `npm start` to run `ng serve --proxy-config proxy.conf.json --aot` with the added `--aot`