### PR TITLE
corrected pdf reports having 0 width scale score. Minimum value is no…

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
@@ -98,7 +98,7 @@ public class ReportViewSupport {
         final int length = maximumScore - minimumScore;
 
         // the whole percent of the scale score position along the length of the graph
-        final int position = getPercentRounded(scaleScore - minimumScore, length);
+        final int position = getPercentRoundedWithinBounds(scaleScore - minimumScore, length);
 
         final List<ScaleScoreView.Level> levels = newArrayList();
         for (int i = 1; i < cutPoints.size(); i++) {
@@ -107,7 +107,7 @@ public class ReportViewSupport {
             final int sumOfWidth = levels.stream().mapToInt(ScaleScoreView.Level::getWidth).sum();
 
             final int width = i < cutPoints.size() - 1
-                    ? getPercentRounded(current - previous, length)
+                    ? getPercentRoundedWithinBounds(current - previous, length)
                     // The last bar should be the remaining percent width of the graph
                     // This will avoid rounding errors and the graph width not adding to 100 percent
                     : 100 - sumOfWidth;
@@ -127,7 +127,7 @@ public class ReportViewSupport {
      * @param length   the distance
      * @return the percent distance covered by the given position along the given length
      */
-    private float getPercent(final float position, final float length) {
+    private float getPercentWithinBounds(final float position, final float length) {
         if (position < 0) {
             return 0;
         }
@@ -146,8 +146,8 @@ public class ReportViewSupport {
      * @param length   the distance
      * @return the percent distance covered by the given position along the given length in whole percent (1 - 100)
      */
-    private int getPercentRounded(final float position, final float length) {
-        return clamp(Math.round(getPercent(position, length)), 1, 100);
+    private int getPercentRoundedWithinBounds(final float position, final float length) {
+        return clamp(Math.round(getPercentWithinBounds(position, length)), 1, 100);
     }
 
     /**

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
@@ -120,7 +120,7 @@ public class ReportViewSupport {
 
     /**
      * Gets the percent distance covered by the given position along the given length (0f - 100f)
-     * If the given value is less than the length <code>0</code> will be returned
+     * If the given value is less than <code>0</code> then <code>0</code> will be returned
      * If the given value is greater than the length <code>100</code> will be returned
      *
      * @param position the position along the length
@@ -138,16 +138,16 @@ public class ReportViewSupport {
     }
 
     /**
-     * Gets the percent distance covered by the given position along the given length in whole percent (0 - 100)
-     * If the given value is less than the length <code>0</code> will be returned
+     * Gets the percent distance covered by the given position along the given length in whole percent (1 - 100)
+     * If the given value is less than <code>1</code> then <code>1</code> will be returned
      * If the given value is greater than the length <code>100</code> will be returned
      *
      * @param position the position along the length
      * @param length   the distance
-     * @return the percent distance covered by the given position along the given length in whole percent (0 - 100)
+     * @return the percent distance covered by the given position along the given length in whole percent (1 - 100)
      */
     private int getPercentRounded(final float position, final float length) {
-        return Math.round(getPercent(position, length));
+        return clamp(Math.round(getPercent(position, length)), 1, 100);
     }
 
     /**

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupportTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupportTest.java
@@ -50,8 +50,8 @@ public class ReportViewSupportTest {
     }
 
     @Test
-    public void getScaleScoreViewShouldEnforcePositionMinimumOfZero() throws Exception {
-        assertThat(support.getScaleScoreView(exam(-100), simpleIAB).getPosition()).isEqualTo(0);
+    public void getScaleScoreViewShouldEnforcePositionMinimumOfOne() throws Exception {
+        assertThat(support.getScaleScoreView(exam(-100), simpleIAB).getPosition()).isEqualTo(1);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ReportViewSupportTest {
 
     @Test
     public void getScaleScoreViewShouldSetPositionCorrectlyWhenMinimum() throws Exception {
-        assertThat(support.getScaleScoreView(exam(simpleIAB.getCutPoints().get(0)), simpleIAB).getPosition()).isEqualTo(0);
+        assertThat(support.getScaleScoreView(exam(simpleIAB.getCutPoints().get(0)), simpleIAB).getPosition()).isEqualTo(1);
     }
 
     @Test

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -80,6 +80,7 @@
 .scale-title {
   color: @gray-mid;
 }
+
 .tag.gray-mid.reverse.tag.gray-mid, .tag.gray-mid.active.tag.gray-mid {
   background-color: @gray-mid;
 }
@@ -89,9 +90,6 @@
 }
 
 .table .scale-score .error-band {
-  color: @gray-mid;
-}
-.btn.btn-borderless.btn-default {
   color: @gray-mid;
 }
 
@@ -108,7 +106,7 @@ h1 + p.pull-left, .h1 + p.pull-left, h2 + p.pull-left, .h2 + p.pull-left, h3 + p
 }
 
 .btn.btn-borderless.btn-default, .scale-score-graph .bar-container .bar .bar-label, .table .scale-score .error-band {
-  color: @gray-mid;
+  color: darken(@gray-mid, 10%);
 }
 // ------------------------------
 // RDW Custom Styles to Match Comps


### PR DESCRIPTION
…w 1.

Addresses 
<img width="815" alt="reportscaleissue" src="https://user-images.githubusercontent.com/33040425/32914644-2148a616-cacb-11e7-85ef-5656a2314583.png">

Issue was caused by a scale score with a 0 width. Since this is used for display purposes only I believe we can have 1 as our minimum instead of 0
