### PR TITLE
apply correct clamps on all scale scores

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupport.java
@@ -97,20 +97,21 @@ public class ReportViewSupport {
 
         final int length = maximumScore - minimumScore;
 
-        // the whole percent of the scale score position along the length of the graph
-        final int position = getPercentRoundedWithinBounds(scaleScore - minimumScore, length);
+        // the whole percent of the scale score position along the length of the graph. This is independent of separators
+        final int position = getPercentRoundedWithinBounds(scaleScore - minimumScore, length, 0);
 
         final List<ScaleScoreView.Level> levels = newArrayList();
+        final int numberOfSeparators = cutPoints.size() - 2;
         for (int i = 1; i < cutPoints.size(); i++) {
             final int previous = cutPoints.get(i - 1) - minimumScore;
             final int current = cutPoints.get(i) - minimumScore;
             final int sumOfWidth = levels.stream().mapToInt(ScaleScoreView.Level::getWidth).sum();
 
             final int width = i < cutPoints.size() - 1
-                    ? getPercentRoundedWithinBounds(current - previous, length)
+                    ? getPercentRoundedWithinBounds(current - previous, length, numberOfSeparators)
                     // The last bar should be the remaining percent width of the graph
                     // This will avoid rounding errors and the graph width not adding to 100 percent
-                    : 100 - sumOfWidth;
+                    : clamp(100 - sumOfWidth, 1, 100);
 
             levels.add(new ScaleScoreView.Level(sumOfWidth, width));
 
@@ -138,16 +139,17 @@ public class ReportViewSupport {
     }
 
     /**
-     * Gets the percent distance covered by the given position along the given length in whole percent (1 - 100)
+     * Gets the percent distance covered by the given position along the given length in whole percent (1 - (100 minus numberOfSeparators))
      * If the given value is less than <code>1</code> then <code>1</code> will be returned
-     * If the given value is greater than the length <code>100</code> will be returned
+     * If the given value is greater than the length then <code>100 - numberOfSeparators</code> will be returned
      *
-     * @param position the position along the length
-     * @param length   the distance
+     * @param position           the position along the length
+     * @param length             the distance
+     * @param numberOfSeparators the number of separators in the graph
      * @return the percent distance covered by the given position along the given length in whole percent (1 - 100)
      */
-    private int getPercentRoundedWithinBounds(final float position, final float length) {
-        return clamp(Math.round(getPercentWithinBounds(position, length)), 1, 100);
+    private int getPercentRoundedWithinBounds(final float position, final float length, final int numberOfSeparators) {
+        return clamp(Math.round(getPercentWithinBounds(position, length)), 1, 100 - numberOfSeparators);
     }
 
     /**

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupportTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ReportViewSupportTest.java
@@ -25,6 +25,12 @@ public class ReportViewSupportTest {
             .cutPoints(newArrayList(2000, 0, 2450, 0, 2900))
             .build();
 
+    private final Assessment simpleIAB2 = Assessment.builder()
+            .type(AssessmentType.IAB)
+            .cutPoints(newArrayList(100, 0, 400, 0, 700))
+            .build();
+
+
     private ReportViewSupport support;
     private MessageSource messageSource;
 
@@ -104,6 +110,17 @@ public class ReportViewSupportTest {
                         level(0, 33),
                         level(33, 33),
                         level(66, 34)
+                );
+    }
+
+    @Test
+    public void getScaleScoreViewShouldReturnCorrectLevelsForHighStdErrIAB() throws Exception {
+        assertThat(support.getScaleScoreView(exam(100, 200), simpleIAB2).getLevels())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                        level(0, 1),
+                        level(1, 98),
+                        level(99, 1)
                 );
     }
 


### PR DESCRIPTION
large stderr caused issues with displaying the number graphs. The issue was that a large enough stderr would eventually create a sumOfWidth = 100, which would result in the last calculated width being 0. Now, we ensure the max value for scale scores is at most 100 - number of separators (2). 