### PR TITLE
Feature/dwr 1055 Dynamic SQL POC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url 'https://mvnrepository.com/artifact/com.healthmarketscience.sqlbuilder/sqlbuilder' }
     }
 
     dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url 'https://mvnrepository.com/artifact/com.healthmarketscience.sqlbuilder/sqlbuilder' }
     }
 
     dependencyManagement {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-properties'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    compile group: 'com.healthmarketscience.sqlbuilder', name: 'sqlbuilder', version: '2.1.7'
+    compile 'com.healthmarketscience.sqlbuilder:sqlbuilder:2.1.7'
 
     optional 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-properties'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    compile group: 'com.healthmarketscience.sqlbuilder', name: 'sqlbuilder', version: '2.1.7'
+
     optional 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile('org.springframework.boot:spring-boot-starter-test') {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
@@ -1,0 +1,94 @@
+package org.opentestsystem.rdw.reporting.common.sqlbuilder;
+
+import com.healthmarketscience.sqlbuilder.CustomCondition;
+import com.healthmarketscience.sqlbuilder.CustomSql;
+import com.healthmarketscience.sqlbuilder.SelectQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * This class is responsible for constructing sql queries from {@link SqlTemplate} templates
+ */
+@Component
+public class QueryProvider {
+
+    private final SqlBuilderConfig sqlBuilderConfig;
+    private final String SelectClause = "select";
+    private final String JoinClause = "join";
+    private final String WhereClause = "conditions";
+    private final String GroupByClause = "grouping";
+    final String[] clauseNames = {SelectClause, JoinClause, WhereClause, GroupByClause};
+
+    /**
+     * Constructor
+     *
+     * @param sqlBuilderConfig the {@link SqlBuilderConfig}
+     */
+    @Autowired
+    public QueryProvider(final SqlBuilderConfig sqlBuilderConfig) {
+        this.sqlBuilderConfig = sqlBuilderConfig;
+    }
+
+    /**
+     * Returns a {@link SelectQuery} constructed by combing the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
+     *
+     * @param templateName the {@link SqlTemplate}'s name
+     * @param addons       the {@link SqlTemplate#addons}'s names
+     * @return constructed {@link SelectQuery}
+     */
+    public SelectQuery newQuery(final String templateName, final Iterable<String> addons) {
+        checkArgument(sqlBuilderConfig.getTemplates() != null && sqlBuilderConfig.getTemplates().containsKey(templateName), "unknown sql builder template name " + templateName);
+
+
+        final SqlTemplate template = sqlBuilderConfig.getTemplates().get(templateName);
+        checkArgument(template.getClauses() != null && template.getClauses().containsKey("from"), "missing from clause for template" + templateName);
+
+        final SelectQuery query = new SelectQuery().addCustomFromTable(template.clauses.get("from"));
+        addClauses(template, query);
+
+        for (final String addon : addons) {
+            checkArgument(template.getAddons() != null && template.getAddons().containsKey(addon), "missing sqlbuilder addon template" + templateName);
+            addClauses(template.getAddons().get(addon), query);
+        }
+
+        return query;
+    }
+
+    /**
+     * Returns a SQL string constructed by combing the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
+     *
+     * @param templateName the {@link SqlTemplate}'s name
+     * @param addons       the {@link SqlTemplate#addons}'s names
+     * @return constructed SQL string
+     */
+    public String newQueryAsString(final String templateName, final Iterable<String> addons) {
+        return newQuery(templateName, addons).toString();
+    }
+
+    private void addClauses(final SqlTemplate template, final SelectQuery query) {
+        for (final String clause : clauseNames) {
+            if (template.getClauses().containsKey(clause)) {
+                addClause(query, clause, template.getClauses().get(clause));
+            }
+        }
+    }
+
+    private void addClause(final SelectQuery query, final String clauseName, final String clause) {
+        switch (clauseName) {
+            case SelectClause:
+                query.addCustomColumns(new CustomSql(" " + clause));
+                break;
+            case JoinClause:
+                query.addCustomJoin(" " + clause);
+                break;
+            case WhereClause:
+                query.addCondition(new CustomCondition(" " + clause));
+                break;
+            case GroupByClause:
+                query.addCustomGroupings(" " + clause);
+                break;
+        }
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * This class is responsible for constructing sql queries from {@link SqlTemplate} templates
+ * This class is responsible for constructing sql queries from {@link SqlTemplate} defined by {@link SqlBuilderConfig}
  */
 @Component
 public class QueryProvider {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
@@ -7,6 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.opentestsystem.rdw.reporting.common.sqlbuilder.SqlClause.FROM;
+import static org.opentestsystem.rdw.reporting.common.sqlbuilder.SqlClause.GROUP_BY;
+import static org.opentestsystem.rdw.reporting.common.sqlbuilder.SqlClause.JOIN;
+import static org.opentestsystem.rdw.reporting.common.sqlbuilder.SqlClause.SELECT;
+import static org.opentestsystem.rdw.reporting.common.sqlbuilder.SqlClause.WHERE;
 
 /**
  * This class is responsible for constructing sql queries from {@link SqlTemplate} defined by {@link SqlBuilderConfig}
@@ -15,11 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class QueryProvider {
 
     private final SqlBuilderConfig sqlBuilderConfig;
-    private final String SelectClause = "select";
-    private final String JoinClause = "join";
-    private final String WhereClause = "conditions";
-    private final String GroupByClause = "grouping";
-    final String[] clauseNames = {SelectClause, JoinClause, WhereClause, GroupByClause};
 
     /**
      * Constructor
@@ -32,7 +32,7 @@ public class QueryProvider {
     }
 
     /**
-     * Returns a {@link SelectQuery} constructed by combing the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
+     * Returns a {@link SelectQuery} constructed by scanning the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
      *
      * @param templateName the {@link SqlTemplate}'s name
      * @param addons       the {@link SqlTemplate#addons}'s names
@@ -41,11 +41,10 @@ public class QueryProvider {
     public SelectQuery newQuery(final String templateName, final Iterable<String> addons) {
         checkArgument(sqlBuilderConfig.getTemplates() != null && sqlBuilderConfig.getTemplates().containsKey(templateName), "unknown sql builder template name " + templateName);
 
-
         final SqlTemplate template = sqlBuilderConfig.getTemplates().get(templateName);
-        checkArgument(template.getClauses() != null && template.getClauses().containsKey("from"), "missing from clause for template" + templateName);
+        checkArgument(template.getClauses() != null && template.getClauses().containsKey(FROM), "missing from clause for template" + templateName);
 
-        final SelectQuery query = new SelectQuery().addCustomFromTable(template.clauses.get("from"));
+        final SelectQuery query = new SelectQuery().addCustomFromTable(template.clauses.get(FROM));
         addClauses(template, query);
 
         for (final String addon : addons) {
@@ -57,7 +56,7 @@ public class QueryProvider {
     }
 
     /**
-     * Returns a SQL string constructed by combing the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
+     * Returns a SQL string constructed by scanning the {@link SqlTemplate} and applying its{@link SqlTemplate#addons}
      *
      * @param templateName the {@link SqlTemplate}'s name
      * @param addons       the {@link SqlTemplate#addons}'s names
@@ -68,27 +67,33 @@ public class QueryProvider {
     }
 
     private void addClauses(final SqlTemplate template, final SelectQuery query) {
-        for (final String clause : clauseNames) {
+        // FROM clause is applicable to the main template only and is handled separately
+        final SqlClause[] clauses = {SELECT, JOIN, WHERE, GROUP_BY};
+
+        for (final SqlClause clause : clauses) {
             if (template.getClauses().containsKey(clause)) {
                 addClause(query, clause, template.getClauses().get(clause));
             }
         }
     }
 
-    private void addClause(final SelectQuery query, final String clauseName, final String clause) {
-        switch (clauseName) {
-            case SelectClause:
-                query.addCustomColumns(new CustomSql(" " + clause));
+    private void addClause(final SelectQuery query, final SqlClause clause, final String clauseSql) {
+        final String customSql = " " + clauseSql;
+        switch (clause) {
+            case SELECT:
+                query.addCustomColumns(new CustomSql(customSql));
                 break;
-            case JoinClause:
-                query.addCustomJoin(" " + clause);
+            case JOIN:
+                query.addCustomJoin(customSql);
                 break;
-            case WhereClause:
-                query.addCondition(new CustomCondition(" " + clause));
+            case WHERE:
+                query.addCondition(new CustomCondition(customSql));
                 break;
-            case GroupByClause:
-                query.addCustomGroupings(" " + clause);
+            case GROUP_BY:
+                query.addCustomGroupings(customSql);
                 break;
+            default:
+                throw new IllegalArgumentException("unsupported request for the given clause " + clause);
         }
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlBuilderConfig.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlBuilderConfig.java
@@ -1,0 +1,25 @@
+package org.opentestsystem.rdw.reporting.common.sqlbuilder;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import javax.validation.Valid;
+import java.util.Map;
+
+/**
+ * Configuration for {@link SqlTemplate}s identified by names
+ */
+@Component
+@ConfigurationProperties(prefix = "sqlbuilder")
+public class SqlBuilderConfig {
+    @Valid
+    public Map<String, SqlTemplate> templates;
+
+    public Map<String, SqlTemplate> getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(final Map<String, SqlTemplate> templates) {
+        this.templates = templates;
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlClause.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlClause.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.reporting.common.sqlbuilder;
+
+/**
+ * An enum of sql clauses
+ */
+public enum SqlClause {
+    SELECT("select"),
+    JOIN("join"),
+    WHERE("where"),
+    GROUP_BY("groupBy"),
+    FROM("from");
+
+    private final String clause;
+
+    SqlClause(final String clause) {
+        this.clause = clause;
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlTemplate.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlTemplate.java
@@ -11,17 +11,17 @@ import java.util.Map;
 public class SqlTemplate {
     @Valid
     @NotNull
-    public Map<String, String> clauses;
+    public Map<SqlClause, String> clauses;
 
     @Valid
     public Map<String, SqlTemplate> addons;
 
     @NotNull
-    public Map<String, String> getClauses() {
+    public Map<SqlClause, String> getClauses() {
         return clauses;
     }
 
-    public void setClauses(final Map<String, String> clauses) {
+    public void setClauses(final Map<SqlClause, String> clauses) {
         this.clauses = clauses;
     }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlTemplate.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/SqlTemplate.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.reporting.common.sqlbuilder;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+/**
+ * Configuration for a SQL template that contains SQL clauses and optional addons.
+ * This is used by {@link QueryProvider} to construct sql queries
+ */
+public class SqlTemplate {
+    @Valid
+    @NotNull
+    public Map<String, String> clauses;
+
+    @Valid
+    public Map<String, SqlTemplate> addons;
+
+    @NotNull
+    public Map<String, String> getClauses() {
+        return clauses;
+    }
+
+    public void setClauses(final Map<String, String> clauses) {
+        this.clauses = clauses;
+    }
+
+    public Map<String, SqlTemplate> getAddons() {
+        return addons;
+    }
+
+    public void setAddons(final Map<String, SqlTemplate> addons) {
+        this.addons = addons;
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProviderTestIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProviderTestIT.java
@@ -1,0 +1,122 @@
+package org.opentestsystem.rdw.reporting.common.sqlbuilder;
+
+
+import com.google.common.collect.ImmutableList;
+import com.healthmarketscience.sqlbuilder.BinaryCondition;
+import com.healthmarketscience.sqlbuilder.ComboCondition;
+import com.healthmarketscience.sqlbuilder.CustomCondition;
+import com.healthmarketscience.sqlbuilder.CustomSql;
+import com.healthmarketscience.sqlbuilder.custom.NamedParamObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {QueryProvider.class, SqlBuilderConfig.class, SqlTemplate.class, YamlPropertiesConfigurator.class})
+@Import(ConfigurationPropertiesAutoConfiguration.class)
+@ActiveProfiles("test")
+public class QueryProviderTestIT {
+    @Autowired
+    private QueryProvider provider;
+
+    @Test
+    public void testQueryAsString() {
+
+        String query = provider.newQueryAsString("achievementLevels", newArrayList());
+        assertThat(query).isEqualTo("SELECT  count(*) AS count, " +
+                "avg(scale_score) AS score, " +
+                "sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1, " +
+                "sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2, " +
+                "sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3, " +
+                "sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4, " +
+                "fe.asmt_grade_id, " +
+                "fe.school_year, " +
+                "a.subject_id " +
+                "FROM fact_student_ica_exam fe JOIN ica_asmt a ON a.id = fe.asmt_id " +
+                "WHERE ( fe.school_year IN (:school_years) AND fe.asmt_grade_id IN (:asmt_grade_ids) AND a.grade_id IN (:asmt_grade_ids)) " +
+                "GROUP BY  fe.school_year, fe.asmt_grade_id, a.subject_id");
+
+        query = provider.newQueryAsString("achievementLevels", ImmutableList.of("state"));
+        assertThat(query).isEqualTo("SELECT  count(*) AS count, " +
+                "avg(scale_score) AS score, " +
+                "sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1, " +
+                "sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2, " +
+                "sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3, " +
+                "sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4, " +
+                "fe.asmt_grade_id, " +
+                "fe.school_year, " +
+                "a.subject_id, " +
+                "'state' AS type " +
+                "FROM fact_student_ica_exam fe JOIN ica_asmt a ON a.id = fe.asmt_id " +
+                "WHERE ( fe.school_year IN (:school_years) AND fe.asmt_grade_id IN (:asmt_grade_ids) AND a.grade_id IN (:asmt_grade_ids)) " +
+                "GROUP BY  fe.school_year, fe.asmt_grade_id, a.subject_id");
+
+        query = provider.newQueryAsString("achievementLevels", ImmutableList.of("allDistricts"));
+        assertThat(query).isEqualTo("SELECT  count(*) AS count, " +
+                "avg(scale_score) AS score, " +
+                "sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1, " +
+                "sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2, " +
+                "sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3, " +
+                "sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4, " +
+                "fe.asmt_grade_id, " +
+                "fe.school_year, " +
+                "a.subject_id, " +
+                "sch.district_id, " +
+                "'district' AS type " +
+                "FROM fact_student_ica_exam fe JOIN ica_asmt a ON a.id = fe.asmt_id JOIN school sch ON sch.id = fe.school_id " +
+                "WHERE ( fe.school_year IN (:school_years) AND fe.asmt_grade_id IN (:asmt_grade_ids) AND a.grade_id IN (:asmt_grade_ids)) " +
+                "GROUP BY  fe.school_year, fe.asmt_grade_id, a.subject_id, sch.district_id");
+
+        query = provider.newQueryAsString("achievementLevels", ImmutableList.of("allDistricts", "districts"));
+        assertThat(query).isEqualTo("SELECT  count(*) AS count, " +
+                "avg(scale_score) AS score, " +
+                "sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1, " +
+                "sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2, " +
+                "sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3, " +
+                "sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4, " +
+                "fe.asmt_grade_id, " +
+                "fe.school_year, " +
+                "a.subject_id, " +
+                "sch.district_id, " +
+                "'district' AS type " +
+                "FROM fact_student_ica_exam fe JOIN ica_asmt a ON a.id = fe.asmt_id JOIN school sch ON sch.id = fe.school_id " +
+                "WHERE (( fe.school_year IN (:school_years) AND fe.asmt_grade_id IN (:asmt_grade_ids) AND a.grade_id IN (:asmt_grade_ids)) AND ( district_id in (:district_ids))) " +
+                "GROUP BY  fe.school_year, fe.asmt_grade_id, a.subject_id, sch.district_id");
+    }
+
+    @Test
+    public void testQuery() {
+        final String query = provider
+                .newQuery("achievementLevels", newArrayList())
+                .addCustomColumns(new CustomSql("fooCol"), new CustomSql("BazzCol"))
+                .addCondition(ComboCondition.and(
+                        new BinaryCondition(BinaryCondition.Op.LESS_THAN,
+                                new CustomSql("fooCol"),
+                                new NamedParamObject("fooCol")),
+                        new CustomCondition("bazzCol IS FUNKY")))
+                .toString();
+
+        assertThat(query).isEqualTo("SELECT  count(*) AS count, " +
+                "avg(scale_score) AS score, " +
+                "sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1, " +
+                "sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2, " +
+                "sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3, " +
+                "sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4, " +
+                "fe.asmt_grade_id, " +
+                "fe.school_year, " +
+                "a.subject_id," +
+                "fooCol,BazzCol " +
+                "FROM fact_student_ica_exam fe JOIN ica_asmt a ON a.id = fe.asmt_id " +
+                "WHERE (( fe.school_year IN (:school_years) AND fe.asmt_grade_id IN (:asmt_grade_ids) AND a.grade_id IN (:asmt_grade_ids)) AND ((fooCol < :fooCol) AND (bazzCol IS FUNKY))) " +
+                "GROUP BY  fe.school_year, fe.asmt_grade_id, a.subject_id");
+    }
+}

--- a/common/src/test/resources/sample.sql.yml
+++ b/common/src/test/resources/sample.sql.yml
@@ -20,12 +20,12 @@ sqlbuilder:
           join: >-
               JOIN ica_asmt a ON a.id = fe.asmt_id
 
-          conditions: >-
+          where: >-
               fe.school_year IN (:school_years) AND
               fe.asmt_grade_id IN (:asmt_grade_ids) AND
               a.grade_id IN (:asmt_grade_ids)
 
-          grouping: >-
+          groupBy: >-
               fe.school_year,
               fe.asmt_grade_id,
               a.subject_id
@@ -47,12 +47,12 @@ sqlbuilder:
                 join: >-
                     JOIN school sch ON sch.id = fe.school_id
 
-                grouping: >-
+                groupBy: >-
                     sch.district_id
 
       # ------------ achievement level by selected district(s)  -----------------------------------------------------------
             districts:
               clauses:
-                conditions: >-
+                where: >-
                    district_id in (:district_ids)
 

--- a/common/src/test/resources/sample.sql.yml
+++ b/common/src/test/resources/sample.sql.yml
@@ -1,0 +1,58 @@
+sqlbuilder:
+  templates:
+      # ------------ achievement level report t  -----------------------------------------------------------------------------
+      achievementLevels:
+        clauses:
+          select:  >-
+               count(*) AS count,
+               avg(scale_score) AS score,
+               sum(CASE WHEN performance_level = 1 THEN 1 ELSE 0 END) AS level1,
+               sum(CASE WHEN performance_level = 2 THEN 1 ELSE 0 END) AS level2,
+               sum(CASE WHEN performance_level = 3 THEN 1 ELSE 0 END) AS level3,
+               sum(CASE WHEN performance_level = 4 THEN 1 ELSE 0 END) AS level4,
+               fe.asmt_grade_id,
+               fe.school_year,
+               a.subject_id
+
+          from: >-
+              fact_student_ica_exam fe
+
+          join: >-
+              JOIN ica_asmt a ON a.id = fe.asmt_id
+
+          conditions: >-
+              fe.school_year IN (:school_years) AND
+              fe.asmt_grade_id IN (:asmt_grade_ids) AND
+              a.grade_id IN (:asmt_grade_ids)
+
+          grouping: >-
+              fe.school_year,
+              fe.asmt_grade_id,
+              a.subject_id
+
+      # ------------ achievement level by state ---------------------------------------------------------------------------
+        addons:
+            state:
+              clauses:
+                select:  >-
+                   'state' AS type
+
+      # ------------ achievement level - all districts  -------------------------------------------------------------------
+            allDistricts:
+              clauses:
+                select:  >-
+                      sch.district_id,
+                      'district' AS type
+
+                join: >-
+                    JOIN school sch ON sch.id = fe.school_id
+
+                grouping: >-
+                    sch.district_id
+
+      # ------------ achievement level by selected district(s)  -----------------------------------------------------------
+            districts:
+              clauses:
+                conditions: >-
+                   district_id in (:district_ids)
+


### PR DESCRIPTION
I do not like this solution, but I cannot think of a better one. Open for suggestions.

I suggest to start the review from `sample.sql.yml`:
https://github.com/SmarterApp/RDW_Reporting/pull/624/files#diff-cf69b859c000ed30a85c87e3f1108bc4

I am using this third party solution: http://openhms.sourceforge.net/sqlbuilder/example.html

It could be used in two ways: one is to define a schema object with all the table specs, and another is to use it as a fancy String builder (aka "custom SQL"). I am using the later in this review.

I have been asked by some people and question it myself if using this library justifiable for what we are doing. Here is where I see a 'value added':

1. it supports constructing SQL by building clauses in any order, and it then assembles them into one SQL string.
2. it takes care of commas and parentheses.
3. **IFF** we decide to use RSQL, it could be helpful.

NOTE: while this could be used for the current reporting queries, this was not the intend. The main goal it to support dynamic queries for the custom aggregate reports. If we decide to keep it and use for the current reporting SQLs, we could/should enhance/simplify it.
