### PR TITLE
A baby step in simplifying SQL.

### DIFF
--- a/admin-webapp/src/main/resources/application.sql.yml
+++ b/admin-webapp/src/main/resources/application.sql.yml
@@ -9,7 +9,7 @@ sql:
       from student_group sg
         join school sc on sc.id = sg.school_id
       where sg.deleted = 0
-        and (1=:statewide or sc.district_group_id in (:district_group_ids) or sc.district_id in (:district_ids) or sc.school_group_id in (:school_group_ids) or sg.school_id in (:school_ids))
+        and ${sql.snippet.basicPermission}
 
     findAllByQuery: >-
       select sg.id,
@@ -26,21 +26,21 @@ sql:
         and sg.deleted = 0
         and (sg.subject_id is null or sg.subject_id in (:subject_ids))
         and sg.school_year = :school_year
-        and (1=:statewide or sc.district_group_id in (:district_group_ids) or sc.district_id in (:district_ids) or sc.school_group_id in (:school_group_ids) or sg.school_id in (:school_ids))
+        and ${sql.snippet.basicPermission}
 
     delete: >-
       update student_group sg
-        join school s on sg.school_id = s.id
+        join school sc on sg.school_id = sc.id
       set sg.deleted = 1,
         sg.update_import_id = :import_id
       where sg.id = :id
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or sg.school_id in (:school_ids))
+        and ${sql.snippet.basicPermission}
 
   school:
     findAll: >-
       select name, id, natural_id
-      from school
-      where (1=:statewide or district_group_id in (:district_group_ids) or district_id in (:district_ids) or school_group_id in (:school_group_ids) or id in (:school_ids))
+      from school sc
+      where ${sql.snippet.basicPermission}
 
   schoolYear:
     findAll: >-

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -123,3 +123,7 @@ sql:
           OR
           (s.id IS NOT NULL AND (1=:statewide OR sch.district_group_id IN (:district_group_ids) OR sch.district_id IN (:district_ids) OR sch.school_group_id IN (:school_group_ids) OR sch.id IN (:school_ids)))
         LIMIT 1
+
+  snippet:
+    basicPermission: >-
+        (1=:statewide or sc.district_group_id in (:district_group_ids) or sc.district_id in (:district_ids) or sc.school_group_id in (:school_group_ids) or sc.id in (:school_ids))

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -48,8 +48,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.unknownScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.unknownScopePermission}
       order by e.completed_at desc
 
     findAllIabsByStudentIdsAndQueryParamsIndividualPermissions: >-
@@ -100,8 +100,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       order by e.completed_at desc
 
     findAllIabsByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -156,8 +156,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       order by e.completed_at desc
 
     findAllIcasByStudentIdsAndQueryParamsUnknownPermissions: >-
@@ -228,8 +228,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.unknownScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.unknownScopePermission}
 
       order by e.completed_at asc
 
@@ -301,8 +301,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       order by e.completed_at asc
 
     findAllIcasByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -377,8 +377,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       order by e.completed_at asc
 
   export:
@@ -623,7 +623,7 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
         and
         ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
           # Individual permissions test
@@ -676,8 +676,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       group by st.id
 
     findByExamQueryParamsGroupPermissions: >-
@@ -701,11 +701,11 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and ${sql.reportingProcessor.snippet.schoolScopePermission}
-        and ${sql.reportingProcessor.snippet.individualScopePermission}
+        and ${sql.reportProcessor.snippet.schoolScopePermission}
+        and ${sql.reportProcessor.snippet.individualScopePermission}
       group by st.id
 
-  reportingProcessor:
+  reportProcessor:
     snippet:
       unknownScopePermission: >-
           ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -48,53 +48,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-      and
-      ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
-        # Individual permissions test
-        (
-          (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
-          )
-        )
-        or
-        # Group permissions test
-        (
-          exists(
-              select 1
-              from student_group_membership sgm
-                join student_group sg on sgm.student_group_id = sg.id
-              where sgm.student_group_id in (:group_ids)
-                    and sgm.student_id in (:student_ids)
-                    and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
-          )
-          and
-          (
-            (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
-            )
-          )
-        )
-      )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.unknownScopePermission}
       order by e.completed_at desc
 
     findAllIabsByStudentIdsAndQueryParamsIndividualPermissions: >-
@@ -145,30 +100,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and
-          (
-            :school_id is null
-            or
-            (
-              s.id=:school_id
-              or
-              (
-                (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-                and
-                isch.id = :school_id
-              )
-            )
-          )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and
-            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
       order by e.completed_at desc
 
     findAllIabsByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -223,30 +156,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=2
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and
-            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
       order by e.completed_at desc
 
     findAllIcasByStudentIdsAndQueryParamsUnknownPermissions: >-
@@ -317,53 +228,9 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-        and
-        ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
-          # Individual permissions test
-          (
-            (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
-            )
-          )
-          or
-          # Group permissions test
-          (
-            exists(
-                select 1
-                from student_group_membership sgm
-                  join student_group sg on sgm.student_group_id = sg.id
-                where sgm.student_group_id in (:group_ids)
-                      and sgm.student_id in (:student_ids)
-                      and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
-            )
-            and
-            (
-              (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
-              or
-              (
-                (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-                and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
-              )
-            )
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.unknownScopePermission}
+
       order by e.completed_at asc
 
     findAllIcasByStudentIdsAndQueryParamsIndividualPermissions: >-
@@ -434,29 +301,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
       order by e.completed_at asc
 
     findAllIcasByStudentIdsAndQueryParamsGroupPermissions: >-
@@ -531,29 +377,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and a.type_id=1
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
       order by e.completed_at asc
 
   export:
@@ -798,20 +623,7 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
         and
         ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
           # Individual permissions test
@@ -864,30 +676,8 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and
-        (
-          :school_id is null
-          or
-          (
-            s.id=:school_id
-            or
-            (
-              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-              and
-              isch.id = :school_id
-            )
-          )
-        )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and
-            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
       group by st.id
 
     findByExamQueryParamsGroupPermissions: >-
@@ -911,7 +701,58 @@ sql:
         and (:subject_id is null or a.subject_id=:subject_id)
         and (:grade_id is null or a.grade_id=:grade_id)
         and (:assessment_type is null or a.type_id=:assessment_type)
-        and
+        and ${sql.reportingProcessor.snippet.schoolScopePermission}
+        and ${sql.reportingProcessor.snippet.individualScopePermission}
+      group by st.id
+
+  reportingProcessor:
+    snippet:
+      unknownScopePermission: >-
+          ( # This query can run from the context of both GROUP_PII_READ and INDIVIDUAL_PII_READ, so need to evaluate both.
+            # Individual permissions test
+            (
+              (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+              or
+              (
+                (1 = :allow_transfer_access and 0 = :disable_transfer_access)
+                and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+              )
+            )
+            or
+            # Group permissions test
+            (
+              exists(
+                  select 1
+                  from student_group_membership sgm
+                    join student_group sg on sgm.student_group_id = sg.id
+                  where sgm.student_group_id in (:group_ids)
+                        and sgm.student_id in (:student_ids)
+                        and (:subject_id is null or sg.subject_id is null or sg.subject_id = :subject_id)
+              )
+              and
+              (
+                (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+                or
+                  (
+                      (1 = :allow_transfer_access and 0 = :disable_transfer_access)
+                      and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+                    )
+                  )
+              )
+            )
+
+      individualScopePermission: >-
+          (
+            (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+            or
+            (
+              (1 = :allow_transfer_access and 0 = :disable_transfer_access)
+              and
+              (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+            )
+          )
+
+      schoolScopePermission:  >-
           (
             :school_id is null
             or
@@ -925,14 +766,3 @@ sql:
               )
             )
           )
-        and
-        (
-          (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          or
-          (
-            (1 = :allow_transfer_access and 0 = :disable_transfer_access)
-            and
-            (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
-      group by st.id

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -61,39 +61,7 @@ sql:
         join school s on e.school_id=s.id
         join school isch on st.inferred_school_id = isch.id
       where e.student_id=:student_id
-        and
-        (
-          # Individual permissions test
-          (
-            (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
-            or
-            (
-              1 = :allow_transfer_access
-              and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
-            )
-          )
-          or
-          # Group permissions test
-          (
-            exists(
-                select 1
-                from student_group_membership sgm
-                  join student_group sg on sgm.student_group_id = sg.id
-                where sgm.student_group_id in (:group_ids)
-                      and sgm.student_id = st.id
-                      and (sg.subject_id is null or sg.subject_id = a.subject_id)
-            )
-            and
-            (
-              (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
-              or
-              (
-                1 = :allow_transfer_access
-                and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
-              )
-            )
-          )
-        )
+        and ${sql.reporting.snippet.unknownScopePermission}
 
     # NOTE that existsForStudentId does not sample the students' inferred schools
     # because a student's inferred school is determined by their latest exam.
@@ -143,39 +111,7 @@ sql:
           join school s on e.school_id=s.id
           join school isch on st.inferred_school_id = isch.id
         where e.id=:exam_id
-          and
-          (
-            # Individual permissions test
-            (
-              (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
-              or
-              (
-                1 = :allow_transfer_access
-                and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
-              )
-            )
-            or
-            # Group permissions test
-            (
-              exists(
-                  select 1
-                  from student_group_membership sgm
-                    join student_group sg on sgm.student_group_id = sg.id
-                  where sgm.student_group_id in (:group_ids)
-                        and sgm.student_id = st.id
-                        and (sg.subject_id is null or sg.subject_id = a.subject_id)
-              )
-              and
-              (
-                (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
-                or
-                (
-                  1 = :allow_transfer_access
-                  and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
-                )
-              )
-            )
-          )
+          and ${sql.reporting.snippet.unknownScopePermission}
 
   group:
     findAllForUsername: >-
@@ -220,14 +156,7 @@ sql:
             and a.id = e.asmt_id
             and sgm.student_group_id=:group_id
             and (0=:group_subject_id or a.subject_id=:group_subject_id)
-            and (
-              (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-              or
-              (
-                1 = :allow_transfer_access
-                and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-              )
-            )
+            and ${sql.reporting.snippet.individualScopePermission}
 
 
     exam:
@@ -253,11 +182,11 @@ sql:
           from exam e
             join student_group_membership sgm on e.student_id=sgm.student_id
             join asmt a on e.asmt_id=a.id
-            join school s on e.school_id=s.id
+            join school sc on e.school_id=sc.id
           where e.school_year=:school_year
             and sgm.student_group_id=:group_id
             and (0=:group_subject_id or a.subject_id=:group_subject_id)
-            and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+            and ${sql.snippet.basicPermission}
           order by e.completed_at desc
           limit 1
 
@@ -315,14 +244,7 @@ sql:
           and e.school_year=:school_year
           and sgm.student_group_id=:group_id
           and (0=:group_subject_id or a.subject_id=:group_subject_id)
-          and (
-            (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-            or
-            (
-              1 = :allow_transfer_access
-              and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-            )
-          )
+          and ${sql.reporting.snippet.individualScopePermission}
 
       item:
         findAllExamItemScoresForAssessment:
@@ -343,14 +265,7 @@ sql:
             and e.school_year=:school_year
             and sgm.student_group_id=:group_id
             and (0=:group_subject_id or a.subject_id=:group_subject_id)
-            and (
-              (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-              or
-              (
-                1 = :allow_transfer_access
-                and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-              )
-            )
+            and ${sql.reporting.snippet.individualScopePermission}
 
   schoolgrade:
     assessment:
@@ -379,18 +294,7 @@ sql:
               join school isch on st.inferred_school_id = isch.id
             where e.school_year=:school_year
             and a.id = e.asmt_id
-            and (
-              (
-                e.school_id=:school_id
-                and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-              )
-              or
-              (
-                1 = :allow_transfer_access
-                and isch.id = :school_id
-                and (1=:statewide or isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-              )
-            )
+            and ${sql.reporting.snippet.schoolScopePermission}
         )
         and a.grade_id=:grade_id
 
@@ -416,11 +320,11 @@ sql:
           a.cut_point_3
         from exam e
           join asmt a on e.asmt_id=a.id
-          join school s on e.school_id=s.id
+          join school sc on e.school_id=sc.id
         where e.school_year=:school_year
         and e.school_id=:school_id
         and a.grade_id=:grade_id
-        and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or s.id in (:school_ids))
+        and ${sql.snippet.basicPermission}
         order by e.completed_at desc
         limit 1
 
@@ -476,19 +380,7 @@ sql:
         where e.asmt_id=:assessment_id
         and a.grade_id=:grade_id
         and e.school_year=:school_year
-        and (
-          (
-            e.school_id=:school_id
-            and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-          )
-          or
-          (
-            1 = :allow_transfer_access
-            and isch.id = :school_id
-            and (1=:statewide or isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-          )
-        )
-
+        and ${sql.reporting.snippet.schoolScopePermission}
       item:
         findAllExamItemScoresForAssessment:
           select
@@ -506,18 +398,7 @@ sql:
           where e.asmt_id=:assessment_id
           and e.school_year=:school_year
           and a.grade_id=:grade_id
-          and (
-            (
-              e.school_id=:school_id
-              and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
-            )
-            or
-            (
-              1 = :allow_transfer_access
-              and isch.id = :school_id
-              and (1=:statewide or isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
-            )
-          )
+          and ${sql.reporting.snippet.schoolScopePermission}
 
   assessment:
     grade:
@@ -527,9 +408,9 @@ sql:
             select a.grade_id
             from exam e
               join asmt a on e.asmt_id=a.id
-              join school s on e.school_id=s.id
+              join school sc on e.school_id=sc.id
             where e.school_id=:school_id
-            and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+            and ${sql.snippet.basicPermission}
             and g.id=a.grade_id
         )
 
@@ -654,3 +535,64 @@ sql:
           OR (ir.org_level = 'District' AND district.id IS NOT NULL)
           OR (ir.org_level = 'SchoolGroup' AND school_group.id IS NOT NULL)
         )
+
+
+  reporting:
+    snippet:
+      unknownScopePermission: >-
+          (
+             # Individual permissions test
+            (
+              (1 = :individual_statewide or s.district_group_id in (:individual_district_group_ids) or s.district_id in (:individual_district_ids) or s.school_group_id in (:individual_school_group_ids) or e.school_id in (:individual_school_ids))
+              or
+              (
+                1 = :allow_transfer_access
+                and (isch.district_group_id in (:individual_district_group_ids) or isch.district_id in (:individual_district_ids) or isch.school_group_id in (:individual_school_group_ids) or isch.id in (:individual_school_ids))
+              )
+            )
+            or
+            # Group permissions test
+            (
+              exists(
+                  select 1
+                  from student_group_membership sgm
+                    join student_group sg on sgm.student_group_id = sg.id
+                  where sgm.student_group_id in (:group_ids)
+                        and sgm.student_id = st.id
+                        and (sg.subject_id is null or sg.subject_id = a.subject_id)
+              )
+              and
+              (
+                (1 = :group_statewide or s.district_group_id in (:group_district_group_ids) or s.district_id in (:group_district_ids) or s.school_group_id in (:group_school_group_ids) or e.school_id in (:group_school_ids))
+                or
+                (
+                  1 = :allow_transfer_access
+                  and (isch.district_group_id in (:group_district_group_ids) or isch.district_id in (:group_district_ids) or isch.school_group_id in (:group_school_group_ids) or isch.id in (:group_school_ids))
+                )
+              )
+            )
+          )
+
+      individualScopePermission: >-
+          (
+            (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+            or
+            (
+              1 = :allow_transfer_access
+              and (isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+            )
+          )
+
+      schoolScopePermission:  >-
+          (
+            (
+              e.school_id=:school_id
+              and (1=:statewide or s.district_group_id in (:district_group_ids) or s.district_id in (:district_ids) or s.school_group_id in (:school_group_ids) or e.school_id in (:school_ids))
+            )
+            or
+            (
+              1 = :allow_transfer_access
+              and isch.id = :school_id
+              and (1=:statewide or isch.district_group_id in (:district_group_ids) or isch.district_id in (:district_ids) or isch.school_group_id in (:school_group_ids) or isch.id in (:school_ids))
+            )
+          )


### PR DESCRIPTION
I am trying to make the SQL more manageable.
This is the first baby step: I moved all the shared permissions queries into shared properties.

With this change it is easier to see when we have a non-standard SQL for permissions. Once it is merged, I will ask @wtritch and @esotrope to review the non-standard ones to see if they have to be this way.
