### PR TITLE
Introduce an admin instructional-resource api and organization search…

### DIFF
--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
@@ -6,6 +6,8 @@ import org.opentestsystem.rdw.admin.configuration.TranslationWebConfiguration;
 import org.opentestsystem.rdw.admin.web.NotFoundIndexTemplate;
 import org.opentestsystem.rdw.common.status.StatusConfiguration;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
+import org.opentestsystem.rdw.reporting.common.repository.OrganizationRepository;
+import org.opentestsystem.rdw.reporting.common.repository.impl.ReportingJdbcOrganizationRepository;
 import org.opentestsystem.rdw.reporting.common.web.WebExecptionHandlerConfiguration;
 import org.opentestsystem.rdw.reporting.common.web.security.SecurityConfiguration;
 import org.opentestsystem.rdw.reporting.common.web.security.auth.GroupGrantRepository;
@@ -52,6 +54,12 @@ public class ApplicationConfiguration {
     @Primary
     public GroupGrantRepository groupGrantRepository(@Qualifier("warehouseJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
         return new JdbcGroupGrantRepository(jdbcTemplate);
+    }
+
+    @Bean
+    public OrganizationRepository reportingOrganizationRepository(@Qualifier("reportingJdbcTemplate") final NamedParameterJdbcTemplate template,
+                                                                  final SecurityParameterProvider securityParameterProvider) {
+        return new ReportingJdbcOrganizationRepository(template, securityParameterProvider);
     }
 }
 

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/configuration/ApplicationProperties.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/configuration/ApplicationProperties.java
@@ -14,6 +14,7 @@ public class ApplicationProperties {
     private AnalyticsProperties analytics = new AnalyticsProperties();
     private String homeUrl;
     private List<String> uiLanguages = new ArrayList<>();
+    private StateProperties state = new StateProperties();
 
     /**
      * @return Google Analytics properties
@@ -40,6 +41,13 @@ public class ApplicationProperties {
         return uiLanguages;
     }
 
+    /**
+     * @return Tenant state properties
+     */
+    public StateProperties getState() {
+        return state;
+    }
+
     public static class AnalyticsProperties {
         private String trackingId;
 
@@ -52,6 +60,33 @@ public class ApplicationProperties {
 
         public void setTrackingId(final String trackingId) {
             this.trackingId = trackingId;
+        }
+    }
+
+    public static class StateProperties {
+        private String code;
+        private String name;
+
+        /**
+         * @return The state code
+         */
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(final String code) {
+            this.code = code;
+        }
+
+        /**
+         * @return The state name
+         */
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
         }
     }
 }

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/model/InstructionalResource.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/model/InstructionalResource.java
@@ -1,0 +1,140 @@
+package org.opentestsystem.rdw.admin.model;
+
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+
+/**
+ * This model represents an InstructionalResource for a given assessment,
+ * organization, and performance level.
+ */
+public class InstructionalResource {
+
+    private int assessmentId;
+    private int performanceLevel;
+    private OrganizationType organizationType;
+    private Integer organizationId;
+    private String resource;
+    private String assessmentName;
+    private String organizationName;
+
+    /**
+     * @return The assessment id
+     */
+    public int getAssessmentId() {
+        return assessmentId;
+    }
+
+    /**
+     * @return The performance level
+     */
+    public int getPerformanceLevel() {
+        return performanceLevel;
+    }
+
+    /**
+     * @return The organization type
+     */
+    public OrganizationType getOrganizationType() {
+        return organizationType;
+    }
+
+    /**
+     * @return The organization id, may be null for state-wide
+     */
+    public Integer getOrganizationId() {
+        return organizationId;
+    }
+
+    /**
+     * @return The resource url
+     */
+    public String getResource() {
+        return resource;
+    }
+
+    /**
+     * @return The assessment name
+     */
+    public String getAssessmentName() {
+        return assessmentName;
+    }
+
+    /**
+     * @return The organization name, may be null for state-wide
+     */
+    public String getOrganizationName() {
+        return organizationName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int assessmentId;
+        private int performanceLevel;
+        private OrganizationType organizationType;
+        private Integer organizationId;
+        private String resource;
+        private String assessmentName;
+        private String organizationName;
+
+        public InstructionalResource build() {
+            final InstructionalResource instructionalResource = new InstructionalResource();
+            instructionalResource.assessmentId = assessmentId;
+            instructionalResource.performanceLevel = performanceLevel;
+            instructionalResource.organizationType = organizationType;
+            instructionalResource.organizationId = organizationId;
+            instructionalResource.resource = resource;
+            instructionalResource.assessmentName = assessmentName;
+            instructionalResource.organizationName = organizationName;
+            return instructionalResource;
+        }
+
+        public Builder copy(final InstructionalResource instructionalResource) {
+            this.assessmentId = instructionalResource.assessmentId;
+            this.performanceLevel = instructionalResource.performanceLevel;
+            this.organizationType = instructionalResource.organizationType;
+            this.organizationId = instructionalResource.organizationId;
+            this.resource = instructionalResource.resource;
+            this.assessmentName = instructionalResource.assessmentName;
+            this.organizationName = instructionalResource.organizationName;
+            return this;
+        }
+
+        public Builder assessmentId(final int assessmentId) {
+            this.assessmentId = assessmentId;
+            return this;
+        }
+
+        public Builder performanceLevel(final int performanceLevel) {
+            this.performanceLevel = performanceLevel;
+            return this;
+        }
+
+        public Builder organizationType(final OrganizationType organizationType) {
+            this.organizationType = organizationType;
+            return this;
+        }
+
+        public Builder organizationId(final Integer organizationId) {
+            this.organizationId = organizationId;
+            return this;
+        }
+
+        public Builder resource(final String resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        public Builder assessmentName(final String assessmentName) {
+            this.assessmentName = assessmentName;
+            return this;
+        }
+
+        public Builder organizationName(final String organizationName) {
+            this.organizationName = organizationName;
+            return this;
+        }
+    }
+
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/model/InstructionalResource.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/model/InstructionalResource.java
@@ -8,20 +8,13 @@ import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
  */
 public class InstructionalResource {
 
-    private int assessmentId;
     private int performanceLevel;
     private OrganizationType organizationType;
     private Integer organizationId;
     private String resource;
     private String assessmentName;
+    private String assessmentLabel;
     private String organizationName;
-
-    /**
-     * @return The assessment id
-     */
-    public int getAssessmentId() {
-        return assessmentId;
-    }
 
     /**
      * @return The performance level
@@ -59,6 +52,13 @@ public class InstructionalResource {
     }
 
     /**
+     * @return The assessment label
+     */
+    public String getAssessmentLabel() {
+        return assessmentLabel;
+    }
+
+    /**
      * @return The organization name, may be null for state-wide
      */
     public String getOrganizationName() {
@@ -70,39 +70,34 @@ public class InstructionalResource {
     }
 
     public static class Builder {
-        private int assessmentId;
         private int performanceLevel;
         private OrganizationType organizationType;
         private Integer organizationId;
         private String resource;
         private String assessmentName;
+        private String assessmentLabel;
         private String organizationName;
 
         public InstructionalResource build() {
             final InstructionalResource instructionalResource = new InstructionalResource();
-            instructionalResource.assessmentId = assessmentId;
             instructionalResource.performanceLevel = performanceLevel;
             instructionalResource.organizationType = organizationType;
             instructionalResource.organizationId = organizationId;
             instructionalResource.resource = resource;
             instructionalResource.assessmentName = assessmentName;
+            instructionalResource.assessmentLabel = assessmentLabel;
             instructionalResource.organizationName = organizationName;
             return instructionalResource;
         }
 
         public Builder copy(final InstructionalResource instructionalResource) {
-            this.assessmentId = instructionalResource.assessmentId;
             this.performanceLevel = instructionalResource.performanceLevel;
             this.organizationType = instructionalResource.organizationType;
             this.organizationId = instructionalResource.organizationId;
             this.resource = instructionalResource.resource;
             this.assessmentName = instructionalResource.assessmentName;
+            this.assessmentLabel = instructionalResource.assessmentLabel;
             this.organizationName = instructionalResource.organizationName;
-            return this;
-        }
-
-        public Builder assessmentId(final int assessmentId) {
-            this.assessmentId = assessmentId;
             return this;
         }
 
@@ -128,6 +123,11 @@ public class InstructionalResource {
 
         public Builder assessmentName(final String assessmentName) {
             this.assessmentName = assessmentName;
+            return this;
+        }
+
+        public Builder assessmentLabel(final String assessmentLabel) {
+            this.assessmentLabel = assessmentLabel;
             return this;
         }
 

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/InstructionalResourceRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/InstructionalResourceRepository.java
@@ -1,0 +1,51 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.security.PermissionScope;
+
+import java.util.Collection;
+
+/**
+ * Implementations of this repository are responsible for persisting
+ * {@link InstructionalResource} instances.
+ */
+public interface InstructionalResourceRepository {
+
+    /**
+     * Find all Instructional Resources that the user has access to modify.
+     *
+     * @param permissionScope The user's permission scope
+     * @return All Instructional Resources for the user
+     */
+    Collection<InstructionalResource> findAll(PermissionScope permissionScope);
+
+    /**
+     * Find an existing Instructional Resource, if it exists.
+     *
+     * @param permissionScope       The user's permission scope
+     * @param instructionalResource An instructional resource containing primary key fields
+     */
+    InstructionalResource findOne(PermissionScope permissionScope,
+                                  InstructionalResource instructionalResource);
+
+    /**
+     * Create a new Instructional Resource.
+     *
+     * @param instructionalResource The new instructional resource
+     */
+    void create(InstructionalResource instructionalResource);
+
+    /**
+     * Update an existing Instructional Resource.
+     *
+     * @param instructionalResource The updated instructional resource
+     */
+    void update(InstructionalResource instructionalResource);
+
+    /**
+     * Delete an existing Instructional Resource, if it exists.
+     *
+     * @param instructionalResource An instructional resource containing primary key fields
+     */
+    void delete(InstructionalResource instructionalResource);
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepository.java
@@ -1,0 +1,133 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.repository.InstructionalResourceRepository;
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
+
+/**
+ * JDBC-backed implementation of an InstructionalResourceRepository.
+ */
+@Repository
+class JdbcInstructionalResourceRepository implements InstructionalResourceRepository {
+
+    @Value("${sql.instructionalResource.findAll}")
+    private String findAllQuery;
+
+    @Value("${sql.instructionalResource.findOne}")
+    private String findOneQuery;
+
+    @Value("${sql.instructionalResource.create}")
+    private String createQuery;
+
+    @Value("${sql.instructionalResource.update}")
+    private String updateQuery;
+
+    @Value("${sql.instructionalResource.delete}")
+    private String deleteQuery;
+
+    private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
+
+    @Autowired
+    JdbcInstructionalResourceRepository(@Qualifier("reportingJdbcTemplate") final NamedParameterJdbcTemplate template,
+                                        final SecurityParameterProvider securityParameterProvider) {
+        this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
+    }
+
+    @Override
+    public Collection<InstructionalResource> findAll(final PermissionScope permissionScope) {
+        return template.query(
+                findAllQuery,
+                securityParameterProvider.getSecurityParameters(permissionScope),
+                (row, rowNum) -> parseInstructionalResource(row));
+    }
+
+    @Override
+    public InstructionalResource findOne(final PermissionScope permissionScope,
+                                         final InstructionalResource instructionalResource) {
+        try {
+            return template.queryForObject(
+                    findOneQuery,
+                    new MapSqlParameterSource()
+                            .addValues(securityParameterProvider.getSecurityParameters(permissionScope))
+                            .addValues(asSource(instructionalResource).getValues()),
+                    (row, rowNum) -> parseInstructionalResource(row));
+        } catch (final EmptyResultDataAccessException exception) {
+            return null;
+        }
+    }
+
+    @Override
+    public void create(final InstructionalResource instructionalResource) {
+        final int createCount = template.update(
+                createQuery,
+                asSource(instructionalResource));
+        if (createCount != 1) {
+            throw new IllegalArgumentException("Unable to create instructional resource");
+        }
+    }
+
+    @Override
+    public void update(final InstructionalResource instructionalResource) {
+        final int updateCount = template.update(
+                updateQuery,
+                asSource(instructionalResource));
+        if (updateCount != 1) {
+            throw new NoSuchElementException("Resource not found: amst_id: " + instructionalResource.getAssessmentId() +
+                    " performance_level: " + instructionalResource.getPerformanceLevel() +
+                    " org_level: " + instructionalResource.getOrganizationType().name() +
+                    " org_id: " + instructionalResource.getOrganizationId());
+        }
+    }
+
+    @Override
+    public void delete(final InstructionalResource instructionalResource) {
+        final int deleteCount = template.update(
+                deleteQuery,
+                asSource(instructionalResource));
+        if (deleteCount > 1) {
+            throw new IllegalArgumentException("Attempting to delete more than one resource: amst_id: " + instructionalResource.getAssessmentId() +
+                    " performance_level: " + instructionalResource.getPerformanceLevel() +
+                    " org_type: " + instructionalResource.getOrganizationType().name() +
+                    " org_id: " + instructionalResource.getOrganizationId());
+        }
+    }
+
+    private static InstructionalResource parseInstructionalResource(final ResultSet row) throws SQLException {
+        return InstructionalResource.builder()
+                .assessmentId(row.getInt("asmt_id"))
+                .performanceLevel(row.getInt("performance_level"))
+                .organizationType(OrganizationType.valueOf(row.getString("org_level")))
+                .organizationId(getNullable(row, row.getInt("org_id")))
+                .resource(row.getString("resource"))
+                .assessmentName(row.getString("asmt_name"))
+                .organizationName(row.getString("org_name"))
+                .build();
+    }
+
+    private MapSqlParameterSource asSource(final InstructionalResource instructionalResource) {
+        return new MapSqlParameterSource()
+                .addValue("asmt_id", instructionalResource.getAssessmentId())
+                .addValue("org_level", instructionalResource.getOrganizationType().name())
+                .addValue("performance_level", instructionalResource.getPerformanceLevel())
+                .addValue("org_id", instructionalResource.getOrganizationId())
+                .addValue("resource", instructionalResource.getResource());
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepository.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepository.java
@@ -90,7 +90,7 @@ class JdbcInstructionalResourceRepository implements InstructionalResourceReposi
                 updateQuery,
                 asSource(instructionalResource));
         if (updateCount != 1) {
-            throw new NoSuchElementException("Resource not found: amst_id: " + instructionalResource.getAssessmentId() +
+            throw new NoSuchElementException("Resource not found: amst_name: " + instructionalResource.getAssessmentName() +
                     " performance_level: " + instructionalResource.getPerformanceLevel() +
                     " org_level: " + instructionalResource.getOrganizationType().name() +
                     " org_id: " + instructionalResource.getOrganizationId());
@@ -103,7 +103,7 @@ class JdbcInstructionalResourceRepository implements InstructionalResourceReposi
                 deleteQuery,
                 asSource(instructionalResource));
         if (deleteCount > 1) {
-            throw new IllegalArgumentException("Attempting to delete more than one resource: amst_id: " + instructionalResource.getAssessmentId() +
+            throw new IllegalArgumentException("Attempting to delete more than one resource: amst_name: " + instructionalResource.getAssessmentName() +
                     " performance_level: " + instructionalResource.getPerformanceLevel() +
                     " org_type: " + instructionalResource.getOrganizationType().name() +
                     " org_id: " + instructionalResource.getOrganizationId());
@@ -112,19 +112,19 @@ class JdbcInstructionalResourceRepository implements InstructionalResourceReposi
 
     private static InstructionalResource parseInstructionalResource(final ResultSet row) throws SQLException {
         return InstructionalResource.builder()
-                .assessmentId(row.getInt("asmt_id"))
                 .performanceLevel(row.getInt("performance_level"))
                 .organizationType(OrganizationType.valueOf(row.getString("org_level")))
                 .organizationId(getNullable(row, row.getInt("org_id")))
                 .resource(row.getString("resource"))
                 .assessmentName(row.getString("asmt_name"))
+                .assessmentLabel(row.getString("asmt_label"))
                 .organizationName(row.getString("org_name"))
                 .build();
     }
 
     private MapSqlParameterSource asSource(final InstructionalResource instructionalResource) {
         return new MapSqlParameterSource()
-                .addValue("asmt_id", instructionalResource.getAssessmentId())
+                .addValue("asmt_name", instructionalResource.getAssessmentName())
                 .addValue("org_level", instructionalResource.getOrganizationType().name())
                 .addValue("performance_level", instructionalResource.getPerformanceLevel())
                 .addValue("org_id", instructionalResource.getOrganizationId())

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/InstructionalResourceService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/InstructionalResourceService.java
@@ -1,0 +1,51 @@
+package org.opentestsystem.rdw.admin.service;
+
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.util.List;
+
+/**
+ * Implementations of this service are responsible for working with InstructionalResource instances.
+ */
+@PreAuthorize("hasAuthority('PERM_INSTRUCTIONAL_RESOURCE_WRITE')")
+public interface InstructionalResourceService {
+
+    /**
+     * Find all instructional resources that the given user has permissions
+     * to modify. Results are ordered by assessment name, organization level,
+     * organization, performance level.
+     *
+     * @param user A user
+     * @return All instructional resources
+     */
+    List<InstructionalResource> findAll(User user);
+
+    /**
+     * Create a new instructional resource.
+     *
+     * @param user                  A user
+     * @param instructionalResource A new instructional resource
+     * @return The created instructional resource
+     */
+    InstructionalResource create(User user, InstructionalResource instructionalResource);
+
+    /**
+     * Update an existing instructional resource.
+     *
+     * @param user                  A user
+     * @param instructionalResource An updated instructional resource
+     * @return The updated instructional resource
+     */
+    InstructionalResource update(User user, InstructionalResource instructionalResource);
+
+    /**
+     * Delete an existing instructional resource.
+     * NOTE: Deleting a non-existent instructional resource behaves as a no-op.
+     *
+     * @param user                  A user
+     * @param instructionalResource An instructional resource
+     */
+    void delete(User user, InstructionalResource instructionalResource);
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/OrganizationService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/OrganizationService.java
@@ -1,0 +1,22 @@
+package org.opentestsystem.rdw.admin.service;
+
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.security.PermissionScope;
+
+import java.util.List;
+
+/**
+ * Implementations of this interface are responsible for retrieving Organizations.
+ */
+public interface OrganizationService {
+
+    /**
+     * Find all matching organizations granted by the given permission scope.
+     * Results are ordered by organization type, organization name.
+     *
+     * @param permissionScope A permission scope
+     * @return All matching organizations
+     */
+    List<Organization> findByQuery(final PermissionScope permissionScope, final OrganizationQuery query);
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceService.java
@@ -1,0 +1,113 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import com.google.common.collect.Ordering;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.repository.InstructionalResourceRepository;
+import org.opentestsystem.rdw.admin.service.InstructionalResourceService;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.repository.OrganizationRepository;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.opentestsystem.rdw.admin.security.AdminPermission.InstructionalResourceWrite;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.State;
+
+/**
+ * Default repository-backed implementation of an InstructionalResourceService.
+ */
+@Service
+class DefaultInstructionalResourceService implements InstructionalResourceService {
+    private static final Ordering<InstructionalResource> ResourceOrdering = Ordering.natural()
+            .onResultOf(InstructionalResource::getAssessmentName)
+            .compound(Ordering.natural()
+                    .onResultOf(InstructionalResource::getOrganizationType))
+            .compound(Ordering.natural()
+                    .nullsFirst()
+                    .onResultOf(InstructionalResource::getOrganizationName))
+            .compound(Ordering.natural()
+                    .onResultOf(InstructionalResource::getPerformanceLevel));
+
+
+    private final InstructionalResourceRepository repository;
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public DefaultInstructionalResourceService(final InstructionalResourceRepository repository,
+                                               final OrganizationRepository organizationRepository) {
+        this.repository = repository;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public List<InstructionalResource> findAll(final User user) {
+        return ResourceOrdering.sortedCopy(repository.findAll(toScope(user)));
+    }
+
+    @Override
+    @Transactional(transactionManager = "reportingTxManager")
+    public InstructionalResource create(final User user, final InstructionalResource instructionalResource) {
+        final PermissionScope scope = toScope(user);
+
+        //Ensure user has access to the specified organization
+        if (invalidOrganization(scope, instructionalResource)) {
+            throw new NoSuchElementException("Organization: " + instructionalResource.getOrganizationType().name() +
+                    " id: " + instructionalResource.getOrganizationId() + " not found");
+        }
+
+        repository.create(instructionalResource);
+        return repository.findOne(scope, instructionalResource);
+    }
+
+    @Override
+    @Transactional(transactionManager = "reportingTxManager")
+    public InstructionalResource update(final User user, final InstructionalResource instructionalResource) {
+        final PermissionScope scope = toScope(user);
+
+        final InstructionalResource existing = repository.findOne(scope, instructionalResource);
+        if (existing == null) {
+            throw new NoSuchElementException("Instructional Resource for Organization: " + instructionalResource.getOrganizationType().name() +
+                    " id: " + instructionalResource.getOrganizationId() +
+                    " performance level: " + instructionalResource.getPerformanceLevel() +
+                    " not found");
+        }
+        final InstructionalResource updated = InstructionalResource.builder()
+                .copy(existing)
+                .resource(instructionalResource.getResource())
+                .build();
+
+        repository.update(updated);
+        return updated;
+    }
+
+    @Override
+    @Transactional(transactionManager = "reportingTxManager")
+    public void delete(final User user, final InstructionalResource instructionalResource) {
+        final PermissionScope scope = toScope(user);
+
+        //Ensure user has access to the specified organization
+        if (invalidOrganization(scope, instructionalResource)) {
+            throw new NoSuchElementException("Organization: " + instructionalResource.getOrganizationType().name() +
+                    " id: " + instructionalResource.getOrganizationId() + " not found");
+        }
+
+        repository.delete(instructionalResource);
+    }
+
+    private PermissionScope toScope(final User user) {
+        return user.getPermissionScopeByPermissionId(InstructionalResourceWrite);
+    }
+
+    private boolean invalidOrganization(final PermissionScope permissionScope, final InstructionalResource instructionalResource) {
+        if (instructionalResource.getOrganizationType() == State) {
+            return !permissionScope.isStatewide();
+        }
+        final Organization organization = organizationRepository.findOneByTypeAndId(permissionScope, instructionalResource.getOrganizationType(), instructionalResource.getOrganizationId());
+        return organization == null;
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceService.java
@@ -54,11 +54,7 @@ class DefaultInstructionalResourceService implements InstructionalResourceServic
     public InstructionalResource create(final User user, final InstructionalResource instructionalResource) {
         final PermissionScope scope = toScope(user);
 
-        //Ensure user has access to the specified organization
-        if (invalidOrganization(scope, instructionalResource)) {
-            throw new NoSuchElementException("Organization: " + instructionalResource.getOrganizationType().name() +
-                    " id: " + instructionalResource.getOrganizationId() + " not found");
-        }
+        checkAccess(scope, instructionalResource);
 
         repository.create(instructionalResource);
         return repository.findOne(scope, instructionalResource);
@@ -90,11 +86,7 @@ class DefaultInstructionalResourceService implements InstructionalResourceServic
     public void delete(final User user, final InstructionalResource instructionalResource) {
         final PermissionScope scope = toScope(user);
 
-        //Ensure user has access to the specified organization
-        if (invalidOrganization(scope, instructionalResource)) {
-            throw new NoSuchElementException("Organization: " + instructionalResource.getOrganizationType().name() +
-                    " id: " + instructionalResource.getOrganizationId() + " not found");
-        }
+        checkAccess(scope, instructionalResource);
 
         repository.delete(instructionalResource);
     }
@@ -109,5 +101,12 @@ class DefaultInstructionalResourceService implements InstructionalResourceServic
         }
         final Organization organization = organizationRepository.findOneByTypeAndId(permissionScope, instructionalResource.getOrganizationType(), instructionalResource.getOrganizationId());
         return organization == null;
+    }
+
+    private void checkAccess(final PermissionScope permissionScope, final InstructionalResource instructionalResource) {
+        if (invalidOrganization(permissionScope, instructionalResource)) {
+            throw new NoSuchElementException("Organization: " + instructionalResource.getOrganizationType().name() +
+                    " id: " + instructionalResource.getOrganizationId() + " not found");
+        }
     }
 }

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
@@ -46,7 +46,7 @@ class DefaultOrganizationService implements OrganizationService {
 
         final OrganizationQuery limitedQuery = OrganizationQuery.builder()
                 .copy(query)
-                .limit(Math.min(MaxLimit, query.getLimit()))
+                .limit(Math.max(0, Math.min(MaxLimit, query.getLimit())))
                 .build();
         final List<Organization> organizations = newArrayList(repository.findAll(permissionScope, limitedQuery));
         if (query.getTypes().contains(OrganizationType.State) &&

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
@@ -1,0 +1,62 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import com.google.common.collect.Ordering;
+import org.opentestsystem.rdw.admin.configuration.ApplicationProperties;
+import org.opentestsystem.rdw.admin.service.OrganizationService;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.opentestsystem.rdw.reporting.common.model.State;
+import org.opentestsystem.rdw.reporting.common.repository.OrganizationRepository;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * Default implementation of an OrganizationService.
+ */
+@Service
+class DefaultOrganizationService implements OrganizationService {
+    private static final int MaxLimit = 1000;
+    private static final Ordering<Organization> organizationOrdering = Ordering.natural()
+            .onResultOf(Organization::getOrganizationType)
+            .compound(Ordering.natural()
+                    .onResultOf(Organization::getName));
+
+    private final OrganizationRepository repository;
+    private final ApplicationProperties applicationProperties;
+
+    @Autowired
+    public DefaultOrganizationService(final OrganizationRepository repository,
+                                      final ApplicationProperties applicationProperties) {
+        this.repository = repository;
+        this.applicationProperties = applicationProperties;
+    }
+
+    @Override
+    public List<Organization> findByQuery(final PermissionScope permissionScope, final OrganizationQuery query) {
+        if (permissionScope.equals(PermissionScope.EMPTY)) {
+            return of();
+        }
+
+        final OrganizationQuery limitedQuery = OrganizationQuery.builder()
+                .copy(query)
+                .limit(Math.min(MaxLimit, query.getLimit()))
+                .build();
+        final List<Organization> organizations = newArrayList(repository.findAll(permissionScope, limitedQuery));
+        if (query.getTypes().contains(OrganizationType.State) &&
+                (query.getName() == null || applicationProperties.getState().getName().toUpperCase().contains(query.getName().toUpperCase()))) {
+            organizations.add(State.builder()
+                    .naturalId(applicationProperties.getState().getCode())
+                    .name(applicationProperties.getState().getName())
+                    .build());
+        }
+
+        return organizationOrdering.sortedCopy(repository.findAll(permissionScope, limitedQuery));
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolver.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolver.java
@@ -25,7 +25,7 @@ public class InstructionalResourceArgumentResolver implements HandlerMethodArgum
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
         return InstructionalResource.builder()
-                .assessmentId(parseInt(webRequest.getParameter("assessmentId")))
+                .assessmentName(webRequest.getParameter("assessmentName"))
                 .organizationType(OrganizationType.caseInsensitiveValue(webRequest.getParameter("organizationType")))
                 .organizationId(Ints.tryParse(trimToEmpty(webRequest.getParameter("organizationId"))))
                 .performanceLevel(parseInt(webRequest.getParameter("performanceLevel")))

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolver.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolver.java
@@ -1,0 +1,34 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.google.common.primitives.Ints;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+
+/**
+ * Argument resolver for {@link InstructionalResource} instances.
+ */
+public class InstructionalResourceArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(InstructionalResource.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
+        return InstructionalResource.builder()
+                .assessmentId(parseInt(webRequest.getParameter("assessmentId")))
+                .organizationType(OrganizationType.caseInsensitiveValue(webRequest.getParameter("organizationType")))
+                .organizationId(Ints.tryParse(trimToEmpty(webRequest.getParameter("organizationId"))))
+                .performanceLevel(parseInt(webRequest.getParameter("performanceLevel")))
+                .build();
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceController.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,7 @@ import static org.springframework.http.HttpStatus.CREATED;
  * This controller is responsible for interacting with instructional resources
  */
 @RestController
+@RequestMapping("/api")
 public class InstructionalResourceController {
 
     private final InstructionalResourceService service;
@@ -31,26 +33,26 @@ public class InstructionalResourceController {
         this.service = service;
     }
 
-    @GetMapping("/api/instructional-resources")
+    @GetMapping("/instructional-resources")
     public List<InstructionalResource> getResources(@AuthenticationPrincipal final User user) {
         return service.findAll(user);
     }
 
-    @PostMapping("/api/instructional-resources")
+    @PostMapping("/instructional-resources")
     @ResponseStatus(CREATED)
     public InstructionalResource createResource(@AuthenticationPrincipal final User user,
                                                 @RequestBody final InstructionalResource instructionalResource) {
         return service.create(user, instructionalResource);
     }
 
-    @PutMapping("/api/instructional-resources")
+    @PutMapping("/instructional-resources")
     @ResponseStatus(HttpStatus.OK)
     public InstructionalResource updateResource(@AuthenticationPrincipal final User user,
                                                 @RequestBody final InstructionalResource instructionalResource) {
         return service.update(user, instructionalResource);
     }
 
-    @DeleteMapping("/api/instructional-resources")
+    @DeleteMapping("/instructional-resources")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteResource(@AuthenticationPrincipal final User user,
                                final InstructionalResource instructionalResource) {

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceController.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/InstructionalResourceController.java
@@ -1,0 +1,59 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.service.InstructionalResourceService;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+/**
+ * This controller is responsible for interacting with instructional resources
+ */
+@RestController
+public class InstructionalResourceController {
+
+    private final InstructionalResourceService service;
+
+    @Autowired
+    public InstructionalResourceController(final InstructionalResourceService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/api/instructional-resources")
+    public List<InstructionalResource> getResources(@AuthenticationPrincipal final User user) {
+        return service.findAll(user);
+    }
+
+    @PostMapping("/api/instructional-resources")
+    @ResponseStatus(CREATED)
+    public InstructionalResource createResource(@AuthenticationPrincipal final User user,
+                                                @RequestBody final InstructionalResource instructionalResource) {
+        return service.create(user, instructionalResource);
+    }
+
+    @PutMapping("/api/instructional-resources")
+    @ResponseStatus(HttpStatus.OK)
+    public InstructionalResource updateResource(@AuthenticationPrincipal final User user,
+                                                @RequestBody final InstructionalResource instructionalResource) {
+        return service.update(user, instructionalResource);
+    }
+
+    @DeleteMapping("/api/instructional-resources")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteResource(@AuthenticationPrincipal final User user,
+                               final InstructionalResource instructionalResource) {
+        service.delete(user, instructionalResource);
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationController.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationController.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.opentestsystem.rdw.admin.service.OrganizationService;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.upperCase;
+
+/**
+ * This controller is responsible for providing authenticated organizations to the user.
+ */
+@RestController
+public class OrganizationController {
+
+    private final OrganizationService service;
+
+    @Autowired
+    public OrganizationController(final OrganizationService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/api/organizations")
+    public List<Organization> getOrganizations(@AuthenticationPrincipal final User user,
+                                               @RequestParam("permission") final String permission,
+                                               final OrganizationQuery query) {
+        final PermissionScope scope = user.getPermissionScopeByPermissionId(upperCase(permission));
+        return service.findByQuery(scope, query);
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationController.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationController.java
@@ -8,6 +8,7 @@ import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,7 @@ import static org.apache.commons.lang.StringUtils.upperCase;
  * This controller is responsible for providing authenticated organizations to the user.
  */
 @RestController
+@RequestMapping("/api")
 public class OrganizationController {
 
     private final OrganizationService service;
@@ -28,7 +30,7 @@ public class OrganizationController {
         this.service = service;
     }
 
-    @GetMapping("/api/organizations")
+    @GetMapping("/organizations")
     public List<Organization> getOrganizations(@AuthenticationPrincipal final User user,
                                                @RequestParam("permission") final String permission,
                                                final OrganizationQuery query) {

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationQueryArgumentResolver.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/OrganizationQueryArgumentResolver.java
@@ -1,0 +1,52 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.google.common.primitives.Ints;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+
+/**
+ * Argument resolver for {@link OrganizationQuery} instances.
+ */
+public class OrganizationQueryArgumentResolver implements HandlerMethodArgumentResolver {
+    static final int DefaultLimit = 20;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(OrganizationQuery.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+                                  final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest,
+                                  final WebDataBinderFactory binderFactory) throws Exception {
+        final Integer limit = Ints.tryParse(trimToEmpty(webRequest.getParameter("limit")));
+        final String[] types = webRequest.getParameterValues("types");
+        return OrganizationQuery.builder()
+                .limit(limit == null ? DefaultLimit : limit)
+                .name(webRequest.getParameter("name"))
+                .types(types == null ? emptySet() : Stream.of(types)
+                        .map(type -> {
+                            try {
+                                return OrganizationType.caseInsensitiveValue(type);
+                            } catch (final IllegalArgumentException exception) {
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(toSet()))
+                .build();
+    }
+}

--- a/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/WebMvcContext.java
+++ b/admin-webapp/src/main/java/org/opentestsystem/rdw/admin/web/WebMvcContext.java
@@ -12,5 +12,7 @@ public class WebMvcContext extends WebMvcConfigurerAdapter {
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(new GroupQueryArgumentResolver());
+        argumentResolvers.add(new OrganizationQueryArgumentResolver());
+        argumentResolvers.add(new InstructionalResourceArgumentResolver());
     }
 }

--- a/admin-webapp/src/main/resources/application.sql.yml
+++ b/admin-webapp/src/main/resources/application.sql.yml
@@ -77,7 +77,7 @@ sql:
   instructionalResource:
     findAll: >-
       SELECT DISTINCT
-        a.id as asmt_id,
+        a.label as asmt_label,
         ir.asmt_name,
         ir.performance_level,
         ir.org_level,
@@ -131,7 +131,7 @@ sql:
 
     findOne: >-
       SELECT DISTINCT
-        a.id as asmt_id,
+        a.label as asmt_label,
         ir.asmt_name,
         ir.performance_level,
         ir.org_level,
@@ -155,7 +155,7 @@ sql:
         OR sch.school_group_id = ir.org_id
       WHERE ir.org_level != 'System'
         AND ir.org_level = :org_level
-        AND a.id = :asmt_id
+        AND ir.asmt_name = :asmt_name
         AND ir.performance_level = :performance_level
         AND ir.org_id <=> :org_id
         AND
@@ -189,20 +189,18 @@ sql:
 
     update: >-
       UPDATE instructional_resource ir
-        JOIN asmt a
-          ON a.name = ir.asmt_name
       SET
         ir.resource = :resource
       WHERE ir.org_level != 'System'
         AND ir.org_level = :org_level
-        AND a.id = :asmt_id
+        AND ir.asmt_name = :asmt_name
         AND ir.performance_level = :performance_level
         AND ir.org_id <=> :org_id
 
     create: >-
       INSERT INTO instructional_resource (asmt_name, resource, org_level, performance_level, org_id)
         SELECT
-          a.name,
+          :asmt_name,
           :resource,
           :org_level,
           :performance_level,
@@ -213,15 +211,13 @@ sql:
               AND ir.performance_level = :performance_level
               AND ir.org_level = :org_level
               AND ir.org_id <=> :org_id
-        WHERE a.id = :asmt_id
+        WHERE a.name = :asmt_name
           AND ir.asmt_name IS NULL
 
     delete: >-
-      DELETE ir FROM instructional_resource ir
-        JOIN asmt a
-          ON a.name = ir.asmt_name
-      WHERE ir.org_level != 'System'
-        AND ir.org_level = :org_level
-        AND a.id = :asmt_id
-        AND ir.performance_level = :performance_level
-        AND ir.org_id <=> :org_id
+      DELETE FROM instructional_resource
+      WHERE org_level != 'System'
+        AND org_level = :org_level
+        AND asmt_name = :asmt_name
+        AND performance_level = :performance_level
+        AND org_id <=> :org_id

--- a/admin-webapp/src/main/resources/application.sql.yml
+++ b/admin-webapp/src/main/resources/application.sql.yml
@@ -73,3 +73,155 @@ sql:
       UPDATE import
       SET status = 1
       WHERE id = :import_id
+
+  instructionalResource:
+    findAll: >-
+      SELECT DISTINCT
+        a.id as asmt_id,
+        ir.asmt_name,
+        ir.performance_level,
+        ir.org_level,
+        ir.resource,
+        ir.org_id,
+        coalesce(district_group.name, district.name, school_group.name) as org_name
+      FROM instructional_resource ir
+        JOIN asmt a
+          ON a.name = ir.asmt_name
+        LEFT JOIN district_group
+          ON ir.org_level = 'DistrictGroup'
+          AND district_group.id = ir.org_id
+        LEFT JOIN district
+          ON ir.org_level = 'District'
+          AND district.id = ir.org_id
+        LEFT JOIN school_group
+          ON ir.org_level = 'SchoolGroup'
+          AND school_group.id = ir.org_id
+      LEFT JOIN school sch
+        ON sch.district_id = ir.org_id
+        OR sch.school_group_id = ir.org_id
+      WHERE ir.org_level != 'System'
+        AND
+        (
+          1=:statewide
+          OR
+          (
+            (ir.org_level = 'DistrictGroup' AND district_group.id in (:district_group_ids))
+            OR
+            (
+              ir.org_level = 'District'
+              AND
+              (
+                district.id in (:district_ids)
+                OR
+                (district.id = sch.district_id AND sch.district_group_id in (:district_group_ids))
+              )
+            )
+            OR
+            (
+              ir.org_level = 'SchoolGroup'
+              AND
+              (
+                school_group.id in (:school_group_ids)
+                OR
+                (school_group.id = sch.school_group_id AND (sch.district_id in (:district_ids) OR sch.district_group_id in (:district_group_ids)))
+              )
+            )
+          )
+        )
+
+    findOne: >-
+      SELECT DISTINCT
+        a.id as asmt_id,
+        ir.asmt_name,
+        ir.performance_level,
+        ir.org_level,
+        ir.resource,
+        ir.org_id,
+        coalesce(district_group.name, district.name, school_group.name) as org_name
+      FROM instructional_resource ir
+        JOIN asmt a
+          ON a.name = ir.asmt_name
+        LEFT JOIN district_group
+          ON ir.org_level = 'DistrictGroup'
+          AND district_group.id = ir.org_id
+        LEFT JOIN district
+          ON ir.org_level = 'District'
+          AND district.id = ir.org_id
+        LEFT JOIN school_group
+          ON ir.org_level = 'SchoolGroup'
+          AND school_group.id = ir.org_id
+      LEFT JOIN school sch
+        ON sch.district_id = ir.org_id
+        OR sch.school_group_id = ir.org_id
+      WHERE ir.org_level != 'System'
+        AND ir.org_level = :org_level
+        AND a.id = :asmt_id
+        AND ir.performance_level = :performance_level
+        AND ir.org_id <=> :org_id
+        AND
+        (
+          1=:statewide
+          OR
+          (
+            (ir.org_level = 'DistrictGroup' AND district_group.id in (:district_group_ids))
+            OR
+            (
+              ir.org_level = 'District'
+              AND
+              (
+                district.id in (:district_ids)
+                OR
+                (district.id = sch.district_id AND sch.district_group_id in (:district_group_ids))
+              )
+            )
+            OR
+            (
+              ir.org_level = 'SchoolGroup'
+              AND
+              (
+                school_group.id in (:school_group_ids)
+                OR
+                (school_group.id = sch.school_group_id AND (sch.district_id in (:district_ids) OR sch.district_group_id in (:district_group_ids)))
+              )
+            )
+          )
+        )
+
+    update: >-
+      UPDATE instructional_resource ir
+        JOIN asmt a
+          ON a.name = ir.asmt_name
+      SET
+        ir.resource = :resource
+      WHERE ir.org_level != 'System'
+        AND ir.org_level = :org_level
+        AND a.id = :asmt_id
+        AND ir.performance_level = :performance_level
+        AND ir.org_id <=> :org_id
+
+    create: >-
+      INSERT INTO instructional_resource (asmt_name, resource, org_level, performance_level, org_id)
+        SELECT
+          a.name,
+          :resource,
+          :org_level,
+          :performance_level,
+          :org_id
+        FROM asmt a
+          LEFT JOIN instructional_resource ir
+            ON ir.asmt_name = a.name
+              AND ir.performance_level = :performance_level
+              AND ir.org_level = :org_level
+              AND ir.org_id <=> :org_id
+        WHERE a.id = :asmt_id
+          AND ir.asmt_name IS NULL
+
+    delete: >-
+      DELETE ir FROM instructional_resource ir
+        JOIN asmt a
+          ON a.name = ir.asmt_name
+      WHERE ir.org_level != 'System'
+        AND ir.org_level = :org_level
+        AND a.id = :asmt_id
+        AND ir.performance_level = :performance_level
+        AND ir.org_id <=> :org_id

--- a/admin-webapp/src/main/resources/application.yml
+++ b/admin-webapp/src/main/resources/application.yml
@@ -123,6 +123,7 @@ permissionservice:
 app:
   state:
     code: CA
+    name: California
 
   home-url: /
 

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/AdminUserPermissionsTestBuilder.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/AdminUserPermissionsTestBuilder.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.admin;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.reporting.common.report.UserPermissions;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
+
+import static org.opentestsystem.rdw.admin.security.AdminPermission.InstructionalResourceWrite;
+
+public class AdminUserPermissionsTestBuilder {
+
+    public static UserPermissions instructionalResources(final PermissionScope scope) {
+        return UserPermissions.builder()
+                .permissionsById(ImmutableMap.of(
+                        InstructionalResourceWrite, new Permission(InstructionalResourceWrite, scope)))
+                .build();
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepositoryIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepositoryIT.java
@@ -1,0 +1,251 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.District;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.DistrictGroup;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.SchoolGroup;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.State;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districtGroups;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districts;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schoolGroups;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = JdbcInstructionalResourceRepository.class)
+@Sql(
+        config = @SqlConfig(dataSource = "reportingDatasource", transactionManager = "reportingTxManager"),
+        scripts = {"classpath:instructional-resource-data.sql"}
+)
+@Transactional(transactionManager = "reportingTxManager")
+public class JdbcInstructionalResourceRepositoryIT {
+
+    @Autowired
+    private JdbcInstructionalResourceRepository repository;
+
+    @Autowired
+    @Qualifier("reportingJdbcTemplate")
+    private NamedParameterJdbcTemplate template;
+
+    @Test
+    public void itShouldRetrieveAllNonSystemInstructionalResourcesForAStatewideUser() {
+        assertThat(toResourceUrls(repository.findAll(statewide()))).containsOnly(
+                resourceUrl("ica1", State, 0, null),
+                resourceUrl("ica1", State, 1, null),
+                resourceUrl("iab1", DistrictGroup, 0, -10),
+                resourceUrl("iab1", DistrictGroup, 1, -10),
+                resourceUrl("iab1", DistrictGroup, 0, -20),
+                resourceUrl("sum1", District, 0, -10),
+                resourceUrl("sum1", District, 0, -20),
+                resourceUrl("sum1", District, 0, -30),
+                resourceUrl("sum2", SchoolGroup, 0, -10));
+    }
+
+    @Test
+    public void itShouldRetrieveAllApplicableInstructionalResourcesForADistrictGroupUser() {
+        assertThat(toResourceUrls(repository.findAll(districtGroups(-10L)))).containsOnly(
+                resourceUrl("iab1", DistrictGroup, 0, -10),
+                resourceUrl("iab1", DistrictGroup, 1, -10),
+                resourceUrl("sum1", District, 0, -10),
+                resourceUrl("sum2", SchoolGroup, 0, -10));
+
+        assertThat(toResourceUrls(repository.findAll(districtGroups(-20L)))).containsOnly(
+                resourceUrl("iab1", DistrictGroup, 0, -20),
+                resourceUrl("sum1", District, 0, -20));
+    }
+
+    @Test
+    public void itShouldRetrieveAllApplicableInstructionalResourcesForADistrictUser() {
+        assertThat(toResourceUrls(repository.findAll(districts(-10L)))).containsOnly(
+                resourceUrl("sum1", District, 0, -10),
+                resourceUrl("sum2", SchoolGroup, 0, -10));
+
+        assertThat(toResourceUrls(repository.findAll(districts(-20L)))).containsOnly(
+                resourceUrl("sum1", District, 0, -20));
+    }
+
+    @Test
+    public void itShouldRetrieveAllApplicableInstructionalResourcesForASchoolGroupUser() {
+        assertThat(toResourceUrls(repository.findAll(schoolGroups(-10L)))).containsOnly(
+                resourceUrl("sum2", SchoolGroup, 0, -10));
+
+        assertThat(toResourceUrls(repository.findAll(schoolGroups(-20L)))).isEmpty();
+    }
+
+    @Test
+    public void itShouldFindOneInstructionalResource() {
+        final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(0)
+                .organizationType(State)
+                .build();
+        assertThat(repository.findOne(statewide(), stateResourceSpecifier))
+                .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
+                        .assessmentId(-1)
+                        .assessmentName("ica1")
+                        .performanceLevel(0)
+                        .organizationType(State)
+                        .resource("http://State/ica1/0")
+                        .build());
+
+        final InstructionalResource schoolGroupResourceSpecifier = InstructionalResource.builder()
+                .assessmentId(-4)
+                .performanceLevel(0)
+                .organizationType(SchoolGroup)
+                .organizationId(-10)
+                .build();
+        assertThat(repository.findOne(districtGroups(-10L), schoolGroupResourceSpecifier))
+                .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
+                        .assessmentId(-4)
+                        .assessmentName("sum2")
+                        .performanceLevel(0)
+                        .organizationType(SchoolGroup)
+                        .organizationId(-10)
+                        .organizationName("schoolgroup1")
+                        .resource("http://SchoolGroup-10/sum2/0")
+                        .build());
+    }
+
+    @Test
+    public void itShouldNotFindOneInstructionalResourceIfUserDoesNotHavePermissions() {
+        final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(0)
+                .organizationType(State)
+                .build();
+        assertThat(repository.findOne(districtGroups(-10L), stateResourceSpecifier))
+                .isNull();
+
+        final InstructionalResource schoolGroupResourceSpecifier = InstructionalResource.builder()
+                .assessmentId(-4)
+                .performanceLevel(0)
+                .organizationType(SchoolGroup)
+                .organizationId(-10)
+                .build();
+        assertThat(repository.findOne(districtGroups(-20L), schoolGroupResourceSpecifier))
+                .isNull();
+    }
+
+    @Test
+    public void itShouldUpdateAnInstructionalResource() {
+        final InstructionalResource updated = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(0)
+                .organizationType(State)
+                .resource("http://my-new-resource/")
+                .build();
+        repository.update(updated);
+
+        assertThat(repository.findOne(statewide(), updated))
+                .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
+                        .assessmentId(-1)
+                        .assessmentName("ica1")
+                        .performanceLevel(0)
+                        .organizationType(State)
+                        .resource("http://my-new-resource/")
+                        .build());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotUpdateANonExistentInstructionalResource() {
+        final InstructionalResource updated = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(3)
+                .organizationType(State)
+                .resource("http://my-new-resource/")
+                .build();
+        repository.update(updated);
+    }
+
+    @Test
+    public void itShouldCreateANewInstructionalResource() {
+        final InstructionalResource newResource = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(3)
+                .organizationType(District)
+                .organizationId(-10)
+                .resource("http://my-new-resource")
+                .build();
+        repository.create(newResource);
+
+        final InstructionalResource expectedResource = InstructionalResource.builder()
+                .copy(newResource)
+                .organizationName("district1")
+                .assessmentName("ica1")
+                .build();
+        assertThat(repository.findOne(districts(-10L), newResource))
+                .isEqualToComparingFieldByFieldRecursively(expectedResource);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldNotCreateADuplicateInstructionalResource() {
+        final InstructionalResource existing = InstructionalResource.builder()
+                .assessmentId(-1)
+                .assessmentName("ica1")
+                .performanceLevel(0)
+                .organizationType(State)
+                .resource("http://my-new-resource/")
+                .build();
+        repository.create(existing);
+    }
+
+    @Test
+    public void itShouldDeleteAnInstructionalResource() {
+        final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
+                .assessmentId(-1)
+                .performanceLevel(0)
+                .organizationType(State)
+                .build();
+
+        assertThat(repository.findOne(statewide(), stateResourceSpecifier)).isNotNull();
+        repository.delete(stateResourceSpecifier);
+        assertThat(repository.findOne(statewide(), stateResourceSpecifier)).isNull();
+
+        //Since we're joining on the asmt table during the deletion, ensure the assessment is still present
+        assertThat(template.queryForObject("SELECT id FROM asmt WHERE id = -1", new MapSqlParameterSource(), Integer.class))
+                .isEqualTo(-1);
+    }
+
+    @Test
+    public void itShouldNotComplainWhenDeletingANonExistentInstructionalResource() {
+        final InstructionalResource districtSpecifier = InstructionalResource.builder()
+                .assessmentId(-2)
+                .performanceLevel(0)
+                .organizationType(District)
+                .build();
+        repository.delete(districtSpecifier);
+    }
+
+    private Stream<String> toResourceUrls(final Collection<InstructionalResource> instructionalResources) {
+        return instructionalResources.stream()
+                .map(InstructionalResource::getResource);
+    }
+
+    private String resourceUrl(final String asmtName,
+                                  final OrganizationType organizationLevel,
+                                  final int performanceLevel,
+                                  final Integer organizationId) {
+        final String orgId = organizationId == null ? EMPTY : organizationId.toString();
+        return "http://" + organizationLevel + orgId + "/" + asmtName + "/" + performanceLevel;
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepositoryIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcInstructionalResourceRepositoryIT.java
@@ -95,29 +95,29 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldFindOneInstructionalResource() {
         final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(0)
                 .organizationType(State)
                 .build();
         assertThat(repository.findOne(statewide(), stateResourceSpecifier))
                 .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
-                        .assessmentId(-1)
                         .assessmentName("ica1")
+                        .assessmentLabel("ica1")
                         .performanceLevel(0)
                         .organizationType(State)
                         .resource("http://State/ica1/0")
                         .build());
 
         final InstructionalResource schoolGroupResourceSpecifier = InstructionalResource.builder()
-                .assessmentId(-4)
+                .assessmentName("sum2")
                 .performanceLevel(0)
                 .organizationType(SchoolGroup)
                 .organizationId(-10)
                 .build();
         assertThat(repository.findOne(districtGroups(-10L), schoolGroupResourceSpecifier))
                 .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
-                        .assessmentId(-4)
                         .assessmentName("sum2")
+                        .assessmentLabel("sum2")
                         .performanceLevel(0)
                         .organizationType(SchoolGroup)
                         .organizationId(-10)
@@ -129,7 +129,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldNotFindOneInstructionalResourceIfUserDoesNotHavePermissions() {
         final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(0)
                 .organizationType(State)
                 .build();
@@ -137,7 +137,7 @@ public class JdbcInstructionalResourceRepositoryIT {
                 .isNull();
 
         final InstructionalResource schoolGroupResourceSpecifier = InstructionalResource.builder()
-                .assessmentId(-4)
+                .assessmentName("sum2")
                 .performanceLevel(0)
                 .organizationType(SchoolGroup)
                 .organizationId(-10)
@@ -149,7 +149,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldUpdateAnInstructionalResource() {
         final InstructionalResource updated = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(0)
                 .organizationType(State)
                 .resource("http://my-new-resource/")
@@ -158,8 +158,8 @@ public class JdbcInstructionalResourceRepositoryIT {
 
         assertThat(repository.findOne(statewide(), updated))
                 .isEqualToComparingFieldByFieldRecursively(InstructionalResource.builder()
-                        .assessmentId(-1)
                         .assessmentName("ica1")
+                        .assessmentLabel("ica1")
                         .performanceLevel(0)
                         .organizationType(State)
                         .resource("http://my-new-resource/")
@@ -169,7 +169,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test(expected = NoSuchElementException.class)
     public void itShouldNotUpdateANonExistentInstructionalResource() {
         final InstructionalResource updated = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(3)
                 .organizationType(State)
                 .resource("http://my-new-resource/")
@@ -180,7 +180,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldCreateANewInstructionalResource() {
         final InstructionalResource newResource = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(3)
                 .organizationType(District)
                 .organizationId(-10)
@@ -191,7 +191,7 @@ public class JdbcInstructionalResourceRepositoryIT {
         final InstructionalResource expectedResource = InstructionalResource.builder()
                 .copy(newResource)
                 .organizationName("district1")
-                .assessmentName("ica1")
+                .assessmentLabel("ica1")
                 .build();
         assertThat(repository.findOne(districts(-10L), newResource))
                 .isEqualToComparingFieldByFieldRecursively(expectedResource);
@@ -200,7 +200,6 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test(expected = IllegalArgumentException.class)
     public void itShouldNotCreateADuplicateInstructionalResource() {
         final InstructionalResource existing = InstructionalResource.builder()
-                .assessmentId(-1)
                 .assessmentName("ica1")
                 .performanceLevel(0)
                 .organizationType(State)
@@ -212,7 +211,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldDeleteAnInstructionalResource() {
         final InstructionalResource stateResourceSpecifier = InstructionalResource.builder()
-                .assessmentId(-1)
+                .assessmentName("ica1")
                 .performanceLevel(0)
                 .organizationType(State)
                 .build();
@@ -229,7 +228,7 @@ public class JdbcInstructionalResourceRepositoryIT {
     @Test
     public void itShouldNotComplainWhenDeletingANonExistentInstructionalResource() {
         final InstructionalResource districtSpecifier = InstructionalResource.builder()
-                .assessmentId(-2)
+                .assessmentName("iab1")
                 .performanceLevel(0)
                 .organizationType(District)
                 .build();

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceServiceTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceServiceTest.java
@@ -58,7 +58,7 @@ public class DefaultInstructionalResourceServiceTest {
     @Before
     public void setup() {
         districtResource = InstructionalResource.builder()
-                .assessmentId(1)
+                .assessmentName("Assesssment A")
                 .performanceLevel(0)
                 .organizationType(District)
                 .organizationId(2)
@@ -66,7 +66,7 @@ public class DefaultInstructionalResourceServiceTest {
                 .build();
 
         stateResource = InstructionalResource.builder()
-                .assessmentId(1)
+                .assessmentName("Assessment A")
                 .performanceLevel(0)
                 .organizationType(State)
                 .resource("http://some-state-resource/")

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceServiceTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultInstructionalResourceServiceTest.java
@@ -1,0 +1,214 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.repository.InstructionalResourceRepository;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.opentestsystem.rdw.reporting.common.repository.OrganizationRepository;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.security.PermissionScope;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.admin.AdminUserPermissionsTestBuilder.instructionalResources;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.District;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.DistrictGroup;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.School;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.SchoolGroup;
+import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.State;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.districts;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultInstructionalResourceServiceTest {
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private InstructionalResourceRepository repository;
+
+    @Captor
+    private ArgumentCaptor<InstructionalResource> resourceCaptor;
+
+    private InstructionalResource districtResource;
+    private InstructionalResource stateResource;
+    private User user;
+    private DefaultInstructionalResourceService service;
+
+
+    @Before
+    public void setup() {
+        districtResource = InstructionalResource.builder()
+                .assessmentId(1)
+                .performanceLevel(0)
+                .organizationType(District)
+                .organizationId(2)
+                .resource("http://some-resource/")
+                .build();
+
+        stateResource = InstructionalResource.builder()
+                .assessmentId(1)
+                .performanceLevel(0)
+                .organizationType(State)
+                .resource("http://some-state-resource/")
+                .build();
+
+        user = User.builder()
+                .id("aUser")
+                .username("user")
+                .password("pass")
+                .permissionsById(instructionalResources(statewide()).getPermissionsById())
+                .build();
+
+        when(organizationRepository.findOneByTypeAndId(any(PermissionScope.class), any(OrganizationType.class), anyInt()))
+                .thenReturn(mock(Organization.class));
+
+        service = new DefaultInstructionalResourceService(repository, organizationRepository);
+    }
+
+    @Test
+    public void itShouldCreateAResource() {
+        when(repository.findOne(eq(statewide()), eq(districtResource)))
+                .thenReturn(districtResource);
+
+        final InstructionalResource response = service.create(user, districtResource);
+        assertThat(response).isEqualTo(districtResource);
+
+        verify(repository).create(eq(districtResource));
+        verify(organizationRepository).findOneByTypeAndId(eq(statewide()), eq(District), eq(districtResource.getOrganizationId()));
+    }
+
+    @Test
+    public void itShouldCreateAStateResource() {
+        when(repository.findOne(eq(statewide()), eq(stateResource)))
+                .thenReturn(stateResource);
+
+        final InstructionalResource response = service.create(user, stateResource);
+        assertThat(response).isEqualTo(stateResource);
+
+        verify(repository).create(eq(stateResource));
+        verifyZeroInteractions(organizationRepository);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotCreateAResourceIfOrganizationIsNotFound() {
+        when(organizationRepository.findOneByTypeAndId(any(PermissionScope.class), any(OrganizationType.class), anyInt()))
+                .thenReturn(null);
+
+        service.create(user, districtResource);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotCreateAStateResourceIfUserDoesNotHaveStatePermissions() {
+        user = User.builder()
+                .id("aUser")
+                .username("user")
+                .password("pass")
+                .permissionsById(instructionalResources(districts(1L)).getPermissionsById())
+                .build();
+
+        service.create(user, stateResource);
+    }
+
+    @Test
+    public void itShouldUpdateAResource() {
+        final InstructionalResource updated = InstructionalResource.builder()
+                .copy(districtResource)
+                .resource("http://updated-resource/")
+                .build();
+
+        when(repository.findOne(eq(statewide()), eq(updated)))
+                .thenReturn(districtResource);
+
+        assertThat(service.update(user, updated))
+                .isEqualToComparingFieldByFieldRecursively(updated);
+
+        verify(repository).update(resourceCaptor.capture());
+        assertThat(resourceCaptor.getValue())
+                .isEqualToComparingFieldByFieldRecursively(updated);
+    }
+
+    @Test
+    public void itShouldDeleteAResource() {
+        service.delete(user, districtResource);
+        verify(organizationRepository).findOneByTypeAndId(eq(statewide()), eq(District), eq(districtResource.getOrganizationId()));
+        verify(repository).delete(districtResource);
+    }
+
+    @Test
+    public void itShouldDeleteAStateResource() {
+        service.delete(user, stateResource);
+        verify(repository).delete(stateResource);
+        verifyZeroInteractions(organizationRepository);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotDeleteAResourceIfOrganizationIsNotFound() {
+        when(organizationRepository.findOneByTypeAndId(any(PermissionScope.class), any(OrganizationType.class), anyInt()))
+                .thenReturn(null);
+
+        service.delete(user, districtResource);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotDeleteAStateResourceIfUserDoesNotHaveStatePermissions() {
+        user = User.builder()
+                .id("aUser")
+                .username("user")
+                .password("pass")
+                .permissionsById(instructionalResources(districts(1L)).getPermissionsById())
+                .build();
+
+        service.delete(user, stateResource);
+    }
+
+    @Test
+    public void itShouldOrderFoundResources() {
+        final List<InstructionalResource> orderedResources = newArrayList();
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(State).performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(State).performanceLevel(1).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(State).performanceLevel(2).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(State).performanceLevel(3).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(DistrictGroup).organizationName("District Group A").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(DistrictGroup).organizationName("District Group B").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(District).organizationName("District A").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(District).organizationName("District B").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(SchoolGroup).organizationName("School Group A").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(SchoolGroup).organizationName("School Group B").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(School).organizationName("School A").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment A").organizationType(School).organizationName("School B").performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment B").organizationType(State).performanceLevel(0).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment B").organizationType(State).performanceLevel(1).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment B").organizationType(State).performanceLevel(2).build());
+        orderedResources.add(InstructionalResource.builder().assessmentName("Assessment B").organizationType(State).performanceLevel(3).build());
+
+        final List<InstructionalResource> randomizedResources = newArrayList(orderedResources);
+        Collections.shuffle(randomizedResources);
+
+        when(repository.findAll(eq(statewide()))).thenReturn(randomizedResources);
+
+        assertThat(service.findAll(user))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyElementsOf(orderedResources);
+    }
+
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolverTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolverTest.java
@@ -1,0 +1,87 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstructionalResourceArgumentResolverTest {
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @Mock
+    private WebDataBinderFactory binderFactory;
+
+    private Map<String, String> parameters;
+
+    private InstructionalResourceArgumentResolver resolver;
+
+    @Before
+    public void setup() {
+        when(methodParameter.getParameterType())
+                .thenAnswer(invocation -> InstructionalResource.class);
+
+        parameters = new HashMap<>();
+        when(webRequest.getParameter(anyString()))
+                .thenAnswer(invocation -> parameters
+                        .get(invocation.getArgumentAt(0, String.class)));
+
+        resolver = new InstructionalResourceArgumentResolver();
+    }
+
+    @Test
+    public void itShouldResolveInstructionalResourceParameters() {
+        assertThat(resolver.supportsParameter(methodParameter)).isTrue();
+
+        when(methodParameter.getParameterType())
+                .thenAnswer(invocation -> Object.class);
+        assertThat(resolver.supportsParameter(methodParameter)).isFalse();
+    }
+
+    @Test
+    public void itShouldParseAnInstructionalResource() throws Exception {
+        parameters.put("assessmentId", "123");
+        parameters.put("organizationType", "district");
+        parameters.put("organizationId", "234");
+        parameters.put("performanceLevel", "1");
+        final InstructionalResource resource = (InstructionalResource) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        assertThat(resource.getAssessmentId()).isEqualTo(123);
+        assertThat(resource.getOrganizationType()).isEqualTo(OrganizationType.District);
+        assertThat(resource.getOrganizationId()).isEqualTo(234);
+        assertThat(resource.getPerformanceLevel()).isEqualTo(1);
+    }
+
+    @Test
+    public void itShouldParseAnInstructionalResourceWithoutAnOrganizationId() throws Exception {
+        parameters.put("assessmentId", "123");
+        parameters.put("organizationType", "state");
+        parameters.put("performanceLevel", "1");
+        final InstructionalResource resource = (InstructionalResource) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        assertThat(resource.getAssessmentId()).isEqualTo(123);
+        assertThat(resource.getOrganizationType()).isEqualTo(OrganizationType.State);
+        assertThat(resource.getOrganizationId()).isNull();
+        assertThat(resource.getPerformanceLevel()).isEqualTo(1);
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolverTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceArgumentResolverTest.java
@@ -62,12 +62,12 @@ public class InstructionalResourceArgumentResolverTest {
 
     @Test
     public void itShouldParseAnInstructionalResource() throws Exception {
-        parameters.put("assessmentId", "123");
+        parameters.put("assessmentName", "Assessment A");
         parameters.put("organizationType", "district");
         parameters.put("organizationId", "234");
         parameters.put("performanceLevel", "1");
         final InstructionalResource resource = (InstructionalResource) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
-        assertThat(resource.getAssessmentId()).isEqualTo(123);
+        assertThat(resource.getAssessmentName()).isEqualTo("Assessment A");
         assertThat(resource.getOrganizationType()).isEqualTo(OrganizationType.District);
         assertThat(resource.getOrganizationId()).isEqualTo(234);
         assertThat(resource.getPerformanceLevel()).isEqualTo(1);
@@ -75,11 +75,11 @@ public class InstructionalResourceArgumentResolverTest {
 
     @Test
     public void itShouldParseAnInstructionalResourceWithoutAnOrganizationId() throws Exception {
-        parameters.put("assessmentId", "123");
+        parameters.put("assessmentName", "Assessment A");
         parameters.put("organizationType", "state");
         parameters.put("performanceLevel", "1");
         final InstructionalResource resource = (InstructionalResource) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
-        assertThat(resource.getAssessmentId()).isEqualTo(123);
+        assertThat(resource.getAssessmentName()).isEqualTo("Assessment A");
         assertThat(resource.getOrganizationType()).isEqualTo(OrganizationType.State);
         assertThat(resource.getOrganizationId()).isNull();
         assertThat(resource.getPerformanceLevel()).isEqualTo(1);

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceControllerIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceControllerIT.java
@@ -62,8 +62,8 @@ public class InstructionalResourceControllerIT {
     public void itShouldRetrieveInstructionalResources() throws Exception {
         when(service.findAll(any(User.class))).thenReturn(ImmutableList.of(
                 InstructionalResource.builder()
-                        .assessmentId(123)
                         .assessmentName("Assessment A")
+                        .assessmentLabel("Assessment Label A")
                         .organizationId(234)
                         .organizationName("Organization A")
                         .organizationType(OrganizationType.District)
@@ -71,8 +71,8 @@ public class InstructionalResourceControllerIT {
                         .resource("http://somewhere-a/")
                         .build(),
                 InstructionalResource.builder()
-                        .assessmentId(456)
                         .assessmentName("Assessment B")
+                        .assessmentLabel("Assessment Label B")
                         .organizationId(567)
                         .organizationName("Organization B")
                         .organizationType(OrganizationType.SchoolGroup)
@@ -85,14 +85,14 @@ public class InstructionalResourceControllerIT {
                 .with(user(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*", hasSize(2)))
-                .andExpect(jsonPath("$[0].assessmentId").value(123))
                 .andExpect(jsonPath("$[0].assessmentName").value("Assessment A"))
+                .andExpect(jsonPath("$[0].assessmentLabel").value("Assessment Label A"))
                 .andExpect(jsonPath("$[0].organizationId").value(234))
                 .andExpect(jsonPath("$[0].organizationName").value("Organization A"))
                 .andExpect(jsonPath("$[0].organizationType").value("District"))
                 .andExpect(jsonPath("$[0].performanceLevel").value(0))
                 .andExpect(jsonPath("$[0].resource").value("http://somewhere-a/"))
-                .andExpect(jsonPath("$[1].assessmentId").value(456));
+                .andExpect(jsonPath("$[1].assessmentName").value("Assessment B"));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class InstructionalResourceControllerIT {
                 .thenAnswer(invocation -> invocation.getArgumentAt(1, InstructionalResource.class));
 
         final InstructionalResource newResource = InstructionalResource.builder()
-                .assessmentId(123)
+                .assessmentName("Assessment A")
                 .organizationId(234)
                 .organizationType(OrganizationType.District)
                 .performanceLevel(0)
@@ -123,7 +123,7 @@ public class InstructionalResourceControllerIT {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(newResource)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.assessmentId").value(123))
+                .andExpect(jsonPath("$.assessmentName").value("Assessment A"))
                 .andExpect(jsonPath("$.organizationId").value(234))
                 .andExpect(jsonPath("$.organizationType").value("District"))
                 .andExpect(jsonPath("$.performanceLevel").value(0))
@@ -136,7 +136,7 @@ public class InstructionalResourceControllerIT {
                 .thenAnswer(invocation -> invocation.getArgumentAt(1, InstructionalResource.class));
 
         final InstructionalResource updatedResource = InstructionalResource.builder()
-                .assessmentId(123)
+                .assessmentName("Assessment A")
                 .organizationId(234)
                 .organizationType(OrganizationType.District)
                 .performanceLevel(0)
@@ -148,7 +148,7 @@ public class InstructionalResourceControllerIT {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(updatedResource)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.assessmentId").value(123))
+                .andExpect(jsonPath("$.assessmentName").value("Assessment A"))
                 .andExpect(jsonPath("$.organizationId").value(234))
                 .andExpect(jsonPath("$.organizationType").value("District"))
                 .andExpect(jsonPath("$.performanceLevel").value(0))
@@ -157,13 +157,13 @@ public class InstructionalResourceControllerIT {
 
     @Test
     public void itShouldDeleteAnInstructionalResource() throws Exception {
-        mvc.perform(delete("/api/instructional-resources?assessmentId=123&organizationId=234&organizationType=District&performanceLevel=1")
+        mvc.perform(delete("/api/instructional-resources?assessmentName=AssessmentA&organizationId=234&organizationType=District&performanceLevel=1")
                 .with(user(user)))
                 .andExpect(status().isNoContent());
 
         verify(service).delete(any(User.class), resourceCaptor.capture());
         final InstructionalResource deleted = resourceCaptor.getValue();
-        assertThat(deleted.getAssessmentId()).isEqualTo(123);
+        assertThat(deleted.getAssessmentName()).isEqualTo("AssessmentA");
         assertThat(deleted.getOrganizationId()).isEqualTo(234);
         assertThat(deleted.getOrganizationType()).isEqualTo(OrganizationType.District);
         assertThat(deleted.getPerformanceLevel()).isEqualTo(1);
@@ -171,13 +171,13 @@ public class InstructionalResourceControllerIT {
 
     @Test
     public void itShouldDeleteAnInstructionalResourceWithoutAnOrganizationId() throws Exception {
-        mvc.perform(delete("/api/instructional-resources?assessmentId=123&organizationType=State&performanceLevel=1")
+        mvc.perform(delete("/api/instructional-resources?assessmentName=AssessmentA&organizationType=State&performanceLevel=1")
                 .with(user(user)))
                 .andExpect(status().isNoContent());
 
         verify(service).delete(any(User.class), resourceCaptor.capture());
         final InstructionalResource deleted = resourceCaptor.getValue();
-        assertThat(deleted.getAssessmentId()).isEqualTo(123);
+        assertThat(deleted.getAssessmentName()).isEqualTo("AssessmentA");
         assertThat(deleted.getOrganizationType()).isEqualTo(OrganizationType.State);
         assertThat(deleted.getPerformanceLevel()).isEqualTo(1);
         assertThat(deleted.getOrganizationId()).isNull();

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceControllerIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/InstructionalResourceControllerIT.java
@@ -1,0 +1,185 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.opentestsystem.rdw.admin.model.InstructionalResource;
+import org.opentestsystem.rdw.admin.service.InstructionalResourceService;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.admin.AdminUserPermissionsTestBuilder.instructionalResources;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(InstructionalResourceController.class)
+public class InstructionalResourceControllerIT {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private InstructionalResourceService service;
+
+    @Captor
+    private ArgumentCaptor<InstructionalResource> resourceCaptor;
+
+    private final User user = User.builder()
+            .id("user")
+            .username("username")
+            .password("password")
+            .authorities(ImmutableSet.of(new SimpleGrantedAuthority("ROLE_USER")))
+            .permissionsById(instructionalResources(statewide()).getPermissionsById())
+            .build();
+
+    @Test
+    public void itShouldRetrieveInstructionalResources() throws Exception {
+        when(service.findAll(any(User.class))).thenReturn(ImmutableList.of(
+                InstructionalResource.builder()
+                        .assessmentId(123)
+                        .assessmentName("Assessment A")
+                        .organizationId(234)
+                        .organizationName("Organization A")
+                        .organizationType(OrganizationType.District)
+                        .performanceLevel(0)
+                        .resource("http://somewhere-a/")
+                        .build(),
+                InstructionalResource.builder()
+                        .assessmentId(456)
+                        .assessmentName("Assessment B")
+                        .organizationId(567)
+                        .organizationName("Organization B")
+                        .organizationType(OrganizationType.SchoolGroup)
+                        .performanceLevel(1)
+                        .resource("http://somewhere-b/")
+                        .build()
+        ));
+
+        mvc.perform(get("/api/instructional-resources")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(2)))
+                .andExpect(jsonPath("$[0].assessmentId").value(123))
+                .andExpect(jsonPath("$[0].assessmentName").value("Assessment A"))
+                .andExpect(jsonPath("$[0].organizationId").value(234))
+                .andExpect(jsonPath("$[0].organizationName").value("Organization A"))
+                .andExpect(jsonPath("$[0].organizationType").value("District"))
+                .andExpect(jsonPath("$[0].performanceLevel").value(0))
+                .andExpect(jsonPath("$[0].resource").value("http://somewhere-a/"))
+                .andExpect(jsonPath("$[1].assessmentId").value(456));
+    }
+
+    @Test
+    public void itShouldReturnAnEmptyArrayForNoResults() throws Exception {
+        when(service.findAll(any(User.class))).thenReturn(ImmutableList.of());
+
+        mvc.perform(get("/api/instructional-resources")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(0)));
+    }
+
+    @Test
+    public void itShouldCreateAnInstructionalResource() throws Exception {
+        when(service.create(any(User.class), any(InstructionalResource.class)))
+                .thenAnswer(invocation -> invocation.getArgumentAt(1, InstructionalResource.class));
+
+        final InstructionalResource newResource = InstructionalResource.builder()
+                .assessmentId(123)
+                .organizationId(234)
+                .organizationType(OrganizationType.District)
+                .performanceLevel(0)
+                .resource("http://somewhere-a/")
+                .build();
+
+        mvc.perform(post("/api/instructional-resources")
+                .with(user(user))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(newResource)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.assessmentId").value(123))
+                .andExpect(jsonPath("$.organizationId").value(234))
+                .andExpect(jsonPath("$.organizationType").value("District"))
+                .andExpect(jsonPath("$.performanceLevel").value(0))
+                .andExpect(jsonPath("$.resource").value("http://somewhere-a/"));
+    }
+
+    @Test
+    public void itShouldUpdateAnInstructionalResource() throws Exception {
+        when(service.update(any(User.class), any(InstructionalResource.class)))
+                .thenAnswer(invocation -> invocation.getArgumentAt(1, InstructionalResource.class));
+
+        final InstructionalResource updatedResource = InstructionalResource.builder()
+                .assessmentId(123)
+                .organizationId(234)
+                .organizationType(OrganizationType.District)
+                .performanceLevel(0)
+                .resource("http://somewhere-a/")
+                .build();
+
+        mvc.perform(put("/api/instructional-resources")
+                .with(user(user))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updatedResource)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.assessmentId").value(123))
+                .andExpect(jsonPath("$.organizationId").value(234))
+                .andExpect(jsonPath("$.organizationType").value("District"))
+                .andExpect(jsonPath("$.performanceLevel").value(0))
+                .andExpect(jsonPath("$.resource").value("http://somewhere-a/"));
+    }
+
+    @Test
+    public void itShouldDeleteAnInstructionalResource() throws Exception {
+        mvc.perform(delete("/api/instructional-resources?assessmentId=123&organizationId=234&organizationType=District&performanceLevel=1")
+                .with(user(user)))
+                .andExpect(status().isNoContent());
+
+        verify(service).delete(any(User.class), resourceCaptor.capture());
+        final InstructionalResource deleted = resourceCaptor.getValue();
+        assertThat(deleted.getAssessmentId()).isEqualTo(123);
+        assertThat(deleted.getOrganizationId()).isEqualTo(234);
+        assertThat(deleted.getOrganizationType()).isEqualTo(OrganizationType.District);
+        assertThat(deleted.getPerformanceLevel()).isEqualTo(1);
+    }
+
+    @Test
+    public void itShouldDeleteAnInstructionalResourceWithoutAnOrganizationId() throws Exception {
+        mvc.perform(delete("/api/instructional-resources?assessmentId=123&organizationType=State&performanceLevel=1")
+                .with(user(user)))
+                .andExpect(status().isNoContent());
+
+        verify(service).delete(any(User.class), resourceCaptor.capture());
+        final InstructionalResource deleted = resourceCaptor.getValue();
+        assertThat(deleted.getAssessmentId()).isEqualTo(123);
+        assertThat(deleted.getOrganizationType()).isEqualTo(OrganizationType.State);
+        assertThat(deleted.getPerformanceLevel()).isEqualTo(1);
+        assertThat(deleted.getOrganizationId()).isNull();
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/OrganizationControllerIT.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/OrganizationControllerIT.java
@@ -1,0 +1,85 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.service.OrganizationService;
+import org.opentestsystem.rdw.reporting.common.model.District;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.opentestsystem.rdw.reporting.common.model.State;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.EnumSet;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.admin.AdminUserPermissionsTestBuilder.instructionalResources;
+import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(OrganizationController.class)
+public class OrganizationControllerIT {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private OrganizationService service;
+
+    private final User user = User.builder()
+            .id("user")
+            .username("username")
+            .password("password")
+            .authorities(ImmutableSet.of(new SimpleGrantedAuthority("ROLE_USER")))
+            .permissionsById(instructionalResources(statewide()).getPermissionsById())
+            .build();
+
+    @Test
+    public void itShouldGetOrganizations() throws Exception {
+        when(service.findByQuery(eq(PermissionScope.STATEWIDE), refEq(
+                OrganizationQuery.builder()
+                        .types(EnumSet.of(OrganizationType.State, OrganizationType.District))
+                        .limit(20)
+                        .name("name")
+                        .build()))
+        ).thenReturn(ImmutableList.of(
+                State.builder()
+                        .name("California")
+                        .naturalId("CA")
+                        .build(),
+                District.builder()
+                        .name("My District")
+                        .naturalId("my_district")
+                        .id(123)
+                        .districtGroupId(234L)
+                        .build()
+        ));
+
+        mvc.perform(get("/api/organizations?permission=instructional_resource_write&limit=20&name=name&types=State&types=District")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(2)))
+                .andExpect(jsonPath("$[0].name", equalTo("California")))
+                .andExpect(jsonPath("$[0].naturalId", equalTo("CA")))
+                .andExpect(jsonPath("$[1].name", equalTo("My District")))
+                .andExpect(jsonPath("$[1].naturalId", equalTo("my_district")))
+                .andExpect(jsonPath("$[1].id", equalTo(123)))
+                .andExpect(jsonPath("$[1].districtGroupId", equalTo(234)));
+    }
+}

--- a/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/OrganizationQueryArgumentResolverTest.java
+++ b/admin-webapp/src/test/java/org/opentestsystem/rdw/admin/web/OrganizationQueryArgumentResolverTest.java
@@ -1,0 +1,90 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
+import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Collection;
+
+import static com.google.common.collect.ImmutableList.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OrganizationQueryArgumentResolverTest {
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @Mock
+    private WebDataBinderFactory binderFactory;
+
+    private Multimap<String, String> parameters;
+
+    private OrganizationQueryArgumentResolver resolver;
+
+    @Before
+    public void setup() {
+        when(methodParameter.getParameterType())
+                .thenAnswer(invocation -> OrganizationQuery.class);
+
+        parameters = HashMultimap.create();
+        when(webRequest.getParameter(anyString()))
+                .thenAnswer(invocation -> parameters
+                        .get(invocation.getArgumentAt(0, String.class)).stream()
+                        .findFirst()
+                        .orElse(null));
+        when(webRequest.getParameterValues(anyString()))
+                .thenAnswer(invocation -> {
+                    final Collection<String> values = parameters.get(invocation.getArgumentAt(0, String.class));
+                    return values.toArray(new String[values.size()]);
+                });
+
+        resolver = new OrganizationQueryArgumentResolver();
+    }
+
+    @Test
+    public void itShouldResolveOrganizationQueryParameters() {
+        assertThat(resolver.supportsParameter(methodParameter)).isTrue();
+
+        when(methodParameter.getParameterType())
+                .thenAnswer(invocation -> Object.class);
+        assertThat(resolver.supportsParameter(methodParameter)).isFalse();
+    }
+
+    @Test
+    public void itShouldParseAnEmptyOrganizationQuery() throws Exception {
+        final OrganizationQuery query = (OrganizationQuery) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        assertThat(query.getLimit()).isEqualTo(OrganizationQueryArgumentResolver.DefaultLimit);
+        assertThat(query.getTypes()).isEmpty();
+        assertThat(query.getName()).isNull();
+    }
+
+    @Test
+    public void itShouldParseAnOrganizationQuery() throws Exception {
+        parameters.putAll("types", of("state", "district", "schoolgroup"));
+        parameters.put("limit", "123");
+        parameters.put("name", "some name");
+        final OrganizationQuery query = (OrganizationQuery) resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        assertThat(query.getLimit()).isEqualTo(123);
+        assertThat(query.getTypes()).containsOnly(OrganizationType.State, OrganizationType.District, OrganizationType.SchoolGroup);
+        assertThat(query.getName()).isEqualTo("some name");
+    }
+}

--- a/admin-webapp/src/test/resources/instructional-resource-data.sql
+++ b/admin-webapp/src/test/resources/instructional-resource-data.sql
@@ -1,0 +1,47 @@
+insert into district_group (id, natural_id, name) values
+  (-10, 'districtgroup1', 'districtgroup1'),
+  (-20, 'districtgroup2', 'districtgroup2');
+
+insert into district (id, natural_id, name) values
+  (-10, 'district1', 'district1'),
+  (-20, 'district2', 'district2'),
+  (-30, 'district3', 'district3');
+
+insert into school_group (id, natural_id, name) values
+  (-10, 'schoolgroup1', 'schoolgroup1');
+
+insert into school (id, district_group_id, district_id, school_group_id, natural_id, name, update_import_id, updated, migrate_id, external_id) VALUES
+  (-101, -10, -10, -10, 'schoolNat1', 'school1', -1, '1997-07-18 20:14:34.000000', -1, 'externalId1'),
+  (-102, -10, -10, null, 'schoolNat2', 'school2', -1, '1997-07-18 20:14:34.000000', -1, 'externalId2'),
+  (-201, -20, -20, null, 'schoolNat3', 'school3', -1, '1997-07-18 20:14:34.000000', -1, 'externalId3'),
+  (-301, null, -30, null, 'schoolNat4', 'school4', -1, '1997-07-18 20:14:34.000000', -1, 'externalId4');
+
+insert into school_year (year) values
+  (1996),
+  (1997),
+  (1998);
+
+insert into grade (id, code, name) values
+  (-1, 'g1', 'grade1'),
+  (-2, 'g2', 'grade2'),
+  (-3, 'g3', 'grade3');
+
+insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, school_year, name, label, version,
+                  claim1_score_code, claim2_score_code, claim3_score_code, claim4_score_code,
+                  min_score, cut_point_1, cut_point_2, cut_point_3, max_score, update_import_id, updated, migrate_id) values
+  (-1, 1, 'ica1', -1, 'g1', 1, 1997, 'ica1', 'ica1', 'v1', 'ica_claim1', 'ica_claim2', 'ica_claim3', 'ica_claim4', 100, 200, 300, 400, 500, -1, '1997-07-18 20:14:34.000000', -1),
+  (-2, 2, 'iab1', -1, 'g1', 1, 1997, 'iab1', 'iab1', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
+  (-3, 3, 'sum1', -1, 'g1', 1, 1997, 'sum1', 'sum1', 'v1', 'sum_claim1', 'sum_claim2', 'sum_claim3', null, 1000, 2000, 3000, 4000, 5000, -1, '1997-07-18 20:14:34.000000', -1),
+  (-4, 3, 'sum2', -1, 'g1', 2, 1997, 'sum2', 'sum1', 'v1', 'sum_claim1', 'sum_claim2', 'sum_claim3', null, 1000, 2000, 3000, 4000, 5000, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into instructional_resource (asmt_name, resource, org_level, performance_level, org_id) VALUES
+  ('ica1', 'http://System/ica1/0', 'System', 0, null),
+  ('ica1', 'http://State/ica1/0', 'State', 0, null),
+  ('ica1', 'http://State/ica1/1', 'State', 1, null),
+  ('iab1', 'http://DistrictGroup-10/iab1/0', 'DistrictGroup', 0, -10),
+  ('iab1', 'http://DistrictGroup-10/iab1/1', 'DistrictGroup', 1, -10),
+  ('iab1', 'http://DistrictGroup-20/iab1/0', 'DistrictGroup', 0, -20),
+  ('sum1', 'http://District-10/sum1/0', 'District', 0, -10),
+  ('sum1', 'http://District-20/sum1/0', 'District', 0, -20),
+  ('sum1', 'http://District-30/sum1/0', 'District', 0, -30),
+  ('sum2', 'http://SchoolGroup-10/sum2/0', 'SchoolGroup', 0, -10);

--- a/admin-webapp/src/test/resources/instructional-resource-data.sql
+++ b/admin-webapp/src/test/resources/instructional-resource-data.sql
@@ -32,7 +32,7 @@ insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, sch
   (-1, 1, 'ica1', -1, 'g1', 1, 1997, 'ica1', 'ica1', 'v1', 'ica_claim1', 'ica_claim2', 'ica_claim3', 'ica_claim4', 100, 200, 300, 400, 500, -1, '1997-07-18 20:14:34.000000', -1),
   (-2, 2, 'iab1', -1, 'g1', 1, 1997, 'iab1', 'iab1', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
   (-3, 3, 'sum1', -1, 'g1', 1, 1997, 'sum1', 'sum1', 'v1', 'sum_claim1', 'sum_claim2', 'sum_claim3', null, 1000, 2000, 3000, 4000, 5000, -1, '1997-07-18 20:14:34.000000', -1),
-  (-4, 3, 'sum2', -1, 'g1', 2, 1997, 'sum2', 'sum1', 'v1', 'sum_claim1', 'sum_claim2', 'sum_claim3', null, 1000, 2000, 3000, 4000, 5000, -1, '1997-07-18 20:14:34.000000', -1);
+  (-4, 3, 'sum2', -1, 'g1', 2, 1997, 'sum2', 'sum2', 'v1', 'sum_claim1', 'sum_claim2', 'sum_claim3', null, 1000, 2000, 3000, 4000, 5000, -1, '1997-07-18 20:14:34.000000', -1);
 
 insert into instructional_resource (asmt_name, resource, org_level, performance_level, org_id) VALUES
   ('ica1', 'http://System/ica1/0', 'System', 0, null),

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/OrganizationQuery.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/OrganizationQuery.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.common.model;
 
-import java.util.EnumSet;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * This model represents a query for organizations.
@@ -8,7 +9,7 @@ import java.util.EnumSet;
 public class OrganizationQuery {
 
     private int limit = 1000;
-    private EnumSet<OrganizationType> types = EnumSet.noneOf(OrganizationType.class);
+    private Set<OrganizationType> types = Collections.emptySet();
     private String name;
 
     /**
@@ -21,7 +22,7 @@ public class OrganizationQuery {
     /**
      * @return The allowed organization types
      */
-    public EnumSet<OrganizationType> getTypes() {
+    public Set<OrganizationType> getTypes() {
         return types;
     }
 
@@ -37,8 +38,8 @@ public class OrganizationQuery {
     }
 
     public static class Builder {
-        private int limit = 100;
-        private EnumSet<OrganizationType> types = EnumSet.noneOf(OrganizationType.class);
+        private int limit = 1000;
+        private Set<OrganizationType> types = Collections.emptySet();
         private String name;
 
         public OrganizationQuery build() {
@@ -49,12 +50,19 @@ public class OrganizationQuery {
             return query;
         }
 
+        public Builder copy(final OrganizationQuery query) {
+            limit(query.getLimit());
+            types(query.getTypes());
+            name(query.getName());
+            return this;
+        }
+
         public Builder limit(final int limit) {
             this.limit = limit;
             return this;
         }
 
-        public Builder types(final EnumSet<OrganizationType> types) {
+        public Builder types(final Set<OrganizationType> types) {
             this.types = types;
             return this;
         }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/OrganizationType.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/OrganizationType.java
@@ -9,5 +9,14 @@ public enum OrganizationType {
     DistrictGroup,
     District,
     SchoolGroup,
-    School
+    School;
+
+    public static OrganizationType caseInsensitiveValue(final String name) {
+        for (final OrganizationType type : OrganizationType.values()) {
+            if (type.name().equalsIgnoreCase(name)) {
+                return type;
+            }
+        }
+        return null;
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/State.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/State.java
@@ -1,0 +1,23 @@
+package org.opentestsystem.rdw.reporting.common.model;
+
+/**
+ * Represents the tenant State organization.
+ */
+public class State extends Organization {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends BaseBuilder<State, State.Builder> {
+
+        public Builder() {
+            organizationType(OrganizationType.State);
+        }
+
+        @Override
+        protected State createInstance() {
+            return new State();
+        }
+    }
+}


### PR DESCRIPTION
… api

This PR introduces an Admin CRUD API for Instructional Resources as well as an Organization search API.

GET /api/instructional-resources - returns all instructional resources that the user has permissions to edit/delete.
POST /api/instructional-resources - creates a new instructional resource after validating that the user has permissions for the targeted organization
PUT /api/instructional-resources - updates the resource url for the given instructional resource after validating that the user has permissions for the targeted organization
DELETE /api/instructional-resources?assessmentId=1&organizationType=district&performanceLevel=0&organizationId=2 - deletes the targeted (single) instructional resource after validating that the user has permissions to the targeted organization

GET /api/organizations?permission=instructional_resource_write&name=calif&types=district&types=school&limit=20 - searches for organizations of type District and/or School granted to the user with INSTRUCTIONAL_RESOURCE_WRITE permissions with "calif" in their name limited to 20 results.