### PR TITLE
Add an aggregate reporting UI development harness to allow simultaneo…

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.html
@@ -1,0 +1,6 @@
+<div class="well">
+  <h3>Sample Aggregate Report Landing Page</h3>
+  <p>
+    <a routerLink="results">Sample Results View</a>
+  </p>
+</div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.ts
@@ -1,0 +1,9 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: 'aggregate-reports',
+  templateUrl: './aggregate-reports.component.html',
+})
+export class AggregateReportsComponent {
+
+}

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
@@ -1,0 +1,26 @@
+import { Angulartics2Module } from "angulartics2";
+import { NgModule } from "@angular/core";
+import { CommonModule } from "../shared/common.module";
+import { DataTableModule } from "primeng/primeng";
+import { AggregateReportsComponent } from "./aggregate-reports.component";
+import { AggregateReportsResultsComponent } from "./results/aggregate-reports-results.component";
+
+@NgModule({
+  declarations: [
+    AggregateReportsComponent,
+    AggregateReportsResultsComponent
+  ],
+  imports: [
+    Angulartics2Module.forChild(),
+    CommonModule,
+    DataTableModule
+  ],
+  exports: [
+    AggregateReportsComponent,
+    AggregateReportsResultsComponent
+  ],
+  providers: [
+  ]
+})
+export class AggregateReportsModule {
+}

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-reports-results.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-reports-results.component.html
@@ -1,0 +1,4 @@
+<div class="well">
+  <h3>Sample Aggregate Report Results</h3>
+
+</div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-reports-results.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-reports-results.component.ts
@@ -1,0 +1,9 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: 'aggregate-reports-results',
+  templateUrl: './aggregate-reports-results.component.html',
+})
+export class AggregateReportsResultsComponent {
+
+}

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { RdwRouteReuseStrategy } from "./shared/rdw-route-reuse.strategy";
 import { ErrorComponent } from './error/error.component';
 import { AccessDeniedComponent } from './error/access-denied/access-denied.component';
 import { OrganizationExportModule } from "./organization-export/organization-export.module";
+import { AggregateReportsModule } from "./aggregate-report/aggregate-reports.module";
 
 @NgModule({
   declarations: [
@@ -27,6 +28,7 @@ import { OrganizationExportModule } from "./organization-export/organization-exp
     AccessDeniedComponent
   ],
   imports: [
+    AggregateReportsModule,
     AlertModule.forRoot(),
     BrowserModule,
     CommonModule,

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -23,6 +23,8 @@ import { OrganizationExportComponent } from "./organization-export/organization-
 import { UserOrganizationsResolve } from "./organization-export/organization/user-organizations.resolve";
 import { RoutingAuthorizationCanActivate } from "@sbac/rdw-reporting-common-ngx/security/routing-authorization.can-activate";
 import { AuthorizationCanActivate } from "@sbac/rdw-reporting-common-ngx/security/authorization.can-activate";
+import { AggregateReportsComponent } from "./aggregate-report/aggregate-reports.component";
+import { AggregateReportsResultsComponent } from "./aggregate-report/results/aggregate-reports-results.component";
 
 
 const studentTestHistoryChildRoute = {
@@ -138,10 +140,30 @@ export const routes: Routes = [
       {
         path: 'reports',
         pathMatch: 'full',
-        data: { breadcrumb: { translate: 'labels.reports.heading' }, permissions: [ 'GROUP_PII_READ' ]},
+        data: {
+          breadcrumb: { translate: 'labels.reports.heading' }, permissions: [ 'GROUP_PII_READ' ]},
         canActivate: [ AuthorizationCanActivate ],
         resolve: { reports: ReportsResolve },
         component: ReportsComponent
+      },
+      {
+        path: 'aggregate-reports',
+        data: { breadcrumb: { translate: 'labels.aggregate-reports.heading'}, permissions: [ /*TODO*/ ]},
+        // canActivate: [ AuthorizationCanActivate ],
+        children: [
+          {
+            path: '',
+            data: { canReuse: true },
+            pathMatch: 'full',
+            component: AggregateReportsComponent
+          },
+          {
+            path: 'results',
+            pathMatch: 'full',
+            data: { breadcrumb: { translate: 'labels.aggregate-reports.results.heading'}},
+            component: AggregateReportsResultsComponent
+          }
+        ]
       },
       {
         path: 'custom-export',

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -51,6 +51,12 @@
   "collapse": "Collapse",
   "select": "Select",
   "labels": {
+    "aggregate-reports": {
+      "heading": "Aggregate Reports",
+      "results": {
+        "heading": "Aggregate Report Results"
+      }
+    },
     "navigation": {
       "user-guide": "User Guide",
       "interpretive-guide": "Interpretive Guide"


### PR DESCRIPTION
…us request and result UX development.

This PR just adds a route and sub-route for `/aggregate-reports/reports` with two placeholder components that are ready to be saturated with a UI for both requesting report data from the backend and displaying the report data in the UI.