### PR TITLE
corrects 100% average score distro going to two lines when showing as…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
@@ -52,7 +52,7 @@
           <div class="bar-container">
             <div *ngIf="performanceLevel.value != 0" class="bar" [ngClass]="colorService.getPerformanceLevelColor(assessmentExam.assessment, i)"
                  [attr.data-width]="filledLevel(performanceLevel)"></div>
-            <div *ngIf="performanceLevel.value < 100" class="bar gray"
+            <div *ngIf="filledLevel(performanceLevel) < 100" class="bar gray"
                  [attr.data-width]="unfilledLevel(performanceLevel)">
             </div>
           </div>


### PR DESCRIPTION
… number

minor correction.This makes two calls to `filledLevel(performanceLevel)` now. Any suggestions to an alternative approach?