### PR TITLE
adds basic security to aggregate report services

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/model/AggregateServicePermission.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/model/AggregateServicePermission.java
@@ -5,8 +5,7 @@ package org.opentestsystem.rdw.olap.model;
  */
 public final class AggregateServicePermission {
 
-    // TODO correct this value
-    public static final String AggregateRead = "INDIVIDUAL_PII_READ";
+    public static final String AggregateRead = "CUSTOM_AGGREGATE_READ";
 
     private AggregateServicePermission() {}
 

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/CustomAggregateReportRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/CustomAggregateReportRepository.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.olap.repository;
 import org.opentestsystem.rdw.olap.model.ReportRow;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -15,7 +16,7 @@ public interface CustomAggregateReportRepository {
      * @param query the {@link ReportQuery} for the report
      * @return a list of {@link ReportRow}s
      */
-    List<ReportRow> findByQuery(ReportQuery query);
+    List<ReportRow> findByQuery(@NotNull ReportQuery query);
 
     /**
      * Estimates number of the rows in a custom aggregate report for the given {@link ReportQuery}
@@ -23,5 +24,6 @@ public interface CustomAggregateReportRepository {
      * @param query the {@link ReportQuery} for the report
      * @return an estimated number of rows
      */
-    int estimateReportRowCount(ReportQuery query);
+    int estimateReportRowCount(@NotNull ReportQuery query);
+
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
@@ -1,7 +1,5 @@
 package org.opentestsystem.rdw.olap.repository.impl;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 import com.healthmarketscience.sqlbuilder.CustomSql;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
 import org.opentestsystem.rdw.common.model.AssessmentType;
@@ -38,6 +36,7 @@ import static org.opentestsystem.rdw.reporting.common.model.ReportQuery.checkIsV
 @SuppressWarnings("unchecked")
 @Repository
 class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRepository {
+
     private static final String customAggregateTemplateSql = "customAggregate";
     private static final String customAggregateAllPermutationsTemplateSql = "customAggregateAllPermutations";
     private static final String stateAddOn = "state";
@@ -45,6 +44,9 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     private static final String allDistrictsAddOn = "allDistricts";
     private static final String schoolsAddOn = "schools";
     private static final String allSchoolsInDistrictsAddOn = "allSchoolsInDistricts";
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final QueryProvider queryProvider;
 
     @Value("${sql.customAggregate}")
     private String customAggregateSql;
@@ -55,9 +57,6 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     @Value("${sql.estimateReportRowCount}")
     private String estimateReportRowCountSql;
 
-    private final NamedParameterJdbcTemplate jdbcTemplate;
-    private final QueryProvider queryProvider;
-
     @Autowired
     public JdbcCustomAggregateReportRowRepository(final NamedParameterJdbcTemplate jdbcTemplate,
                                                   final QueryProvider queryProvider) {
@@ -65,33 +64,39 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
         this.queryProvider = queryProvider;
     }
 
+    private static void validate(final ReportQuery query) {
+        checkIsValid(query);
+        checkArgument(!AssessmentType.IAB.equals(query.getAssessmentType()), "custom aggregate report for IAB is not supported yet");
+    }
+
     @Override
     public List<ReportRow> findByQuery(@NotNull final ReportQuery query) {
+
         validate(query);
 
-        final Builder parmBuilder = ImmutableMap.<String, Object>builder()
-                .put("school_years", query.getSchoolYears())
-                .put("asmt_grade_ids", query.getAsmtGrades())
-                .put("subject_ids", query.getSubjectIds())
-                .put("asmt_type_id", query.getAssessmentType().id());
+        final MapSqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("school_years", query.getSchoolYears())
+                .addValue("asmt_grade_ids", query.getAsmtGrades())
+                .addValue("subject_ids", query.getSubjectIds())
+                .addValue("asmt_type_id", query.getAssessmentType().id());
 
         if (!query.isIncludeAllDistricts() && !query.getDistrictIds().isEmpty()) {
-            parmBuilder.put("district_ids", query.getDistrictIds());
+            parameters.addValue("district_ids", query.getDistrictIds());
         }
 
         if (!query.getDistrictIdsWithAllSchools().isEmpty()) {
-            parmBuilder.put("school_district_ids", query.getDistrictIdsWithAllSchools());
+            parameters.addValue("school_district_ids", query.getDistrictIdsWithAllSchools());
         }
 
         if (!query.getSchoolIds().isEmpty()) {
-            parmBuilder.put("school_ids", query.getSchoolIds());
+            parameters.addValue("school_ids", query.getSchoolIds());
         }
 
         final List<SelectQuery> selectQueries = toSelectQueries(query);
 
         return jdbcTemplate.query(
                 selectQueries.size() == 1 ? selectQueries.get(0).toString() : unionAll(copyOf(selectQueries.toArray(), selectQueries.size(), SelectQuery[].class)).toString(),
-                parmBuilder.build(),
+                parameters,
                 (row, index) -> ReportRow.builder()
                         .assessment(new Assessment(row.getInt("asmt_id"), row.getInt("asmt_grade_id"), row.getInt("subject_id")))
                         .examSchoolYear(row.getInt("school_year"))
@@ -109,7 +114,8 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     }
 
     @Override
-    public int estimateReportRowCount(final ReportQuery query) {
+    public int estimateReportRowCount(@NotNull final ReportQuery query) {
+
         validate(query);
 
         final Set<DimensionType> dimensionTypes = query.getDimensionTypes();
@@ -137,11 +143,6 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
                 .addValue("school_ids", !query.getSchoolIds().isEmpty() ? query.getSchoolIds() : -1);
 
         return jdbcTemplate.queryForObject(estimateReportRowCountSql, parameterSource, Integer.class);
-    }
-
-    private static void validate(final ReportQuery query) {
-        checkIsValid(query);
-        checkArgument(!AssessmentType.IAB.equals(query.getAssessmentType()), "custom aggregate report for IAB is not supported yet");
     }
 
     private List<SelectQuery> toSelectQueries(final ReportQuery query) {

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/CustomAggregateService.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/CustomAggregateService.java
@@ -2,27 +2,34 @@ package org.opentestsystem.rdw.olap.service;
 
 import org.opentestsystem.rdw.olap.model.ReportRow;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.security.access.prepost.PreAuthorize;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
  * Implementation of this interface is responsible for retrieving the custom aggregate report
  */
+@PreAuthorize("hasAuthority('PERM_CUSTOM_AGGREGATE_READ')")
 public interface CustomAggregateService {
 
     /**
      * Creates a custom aggregate report for the given {@link ReportQuery}
      *
+     * @param user the {@link User} creating the report
      * @param query the {@link ReportQuery} for the report
      * @return the list of {@link ReportRow}
      */
-    List<ReportRow> findByQuery(ReportQuery query);
+    List<ReportRow> findByQuery(@NotNull User user, @NotNull ReportQuery query);
 
     /**
      * Estimates number of the rows in a custom aggregate report for the given {@link ReportQuery}
      *
+     * @param user the {@link User} creating the report
      * @param query the {@link ReportQuery} for the report
      * @return an estimated number of rows
      */
-    int estimateReportRowCount(ReportQuery query);
+    int estimateReportRowCount(@NotNull User user, @NotNull ReportQuery query);
+
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/OrganizationSearchService.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/OrganizationSearchService.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.olap.service;
 
 import org.opentestsystem.rdw.reporting.common.model.Organization;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.NotNull;
 import java.util.Set;
@@ -9,6 +10,7 @@ import java.util.Set;
 /**
  * Service responsible for managing organizations
  */
+@PreAuthorize("hasAuthority('PERM_CUSTOM_AGGREGATE_READ')")
 public interface OrganizationSearchService {
 
     /**

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/UserReportOptionService.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/UserReportOptionService.java
@@ -2,12 +2,14 @@ package org.opentestsystem.rdw.olap.service;
 
 import org.opentestsystem.rdw.olap.model.ReportOptions;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.NotNull;
 
 /**
  * Service responsible for managing report options
  */
+@PreAuthorize("hasAuthority('PERM_CUSTOM_AGGREGATE_READ')")
 public interface UserReportOptionService {
 
     /**

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/DefaultCustomAggregateService.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/DefaultCustomAggregateService.java
@@ -5,12 +5,13 @@ import org.opentestsystem.rdw.olap.repository.CustomAggregateReportRepository;
 import org.opentestsystem.rdw.olap.service.CustomAggregateService;
 import org.opentestsystem.rdw.reporting.common.model.DimensionType;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.opentestsystem.rdw.olap.model.AggregateServicePermission.AggregateRead;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
 
 /**
@@ -22,23 +23,22 @@ class DefaultCustomAggregateService implements CustomAggregateService {
     private final CustomAggregateReportRepository repository;
 
     @Autowired
-    public DefaultCustomAggregateService(final CustomAggregateReportRepository repository) {
+    DefaultCustomAggregateService(final CustomAggregateReportRepository repository) {
         this.repository = repository;
     }
 
     @Override
-    public List<ReportRow> findByQuery(final ReportQuery query) {
-        checkArgument(query != null, "undefined report query");
+    public List<ReportRow> findByQuery(final User user, final ReportQuery query) {
         return repository.findByQuery(ensureDimension(query, Overall));
     }
 
     @Override
-    public int estimateReportRowCount(final ReportQuery query) {
-        checkArgument(query != null, "undefined report query");
+    public int estimateReportRowCount(final User user, final ReportQuery query) {
         return repository.estimateReportRowCount(ensureDimension(query, Overall));
     }
 
     private ReportQuery ensureDimension(final ReportQuery query, final DimensionType dimension) {
         return query.contains(dimension) ? query : query.copy().dimensionType(Overall).build();
     }
+
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/web/CustomAggregateController.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/web/CustomAggregateController.java
@@ -3,7 +3,9 @@ package org.opentestsystem.rdw.olap.web;
 import org.opentestsystem.rdw.olap.model.ReportRow;
 import org.opentestsystem.rdw.olap.service.CustomAggregateService;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,23 +16,30 @@ import java.util.List;
  * This controller is responsible for providing custom aggregate report
  */
 @RestController
-@RequestMapping("/api")
-public class CustomAggregateController {
+@RequestMapping("/customaggregate")
+class CustomAggregateController {
 
     private final CustomAggregateService service;
 
     @Autowired
-    public CustomAggregateController(final CustomAggregateService service) {
+    CustomAggregateController(final CustomAggregateService service) {
         this.service = service;
     }
 
-    @GetMapping("/customaggregate")
-    public List<ReportRow> getCustomAggregateReport(final ReportQuery query) {
-        return service.findByQuery(query);
+    @GetMapping
+    public List<ReportRow> getCustomAggregateReport(
+            @AuthenticationPrincipal final User user,
+            final ReportQuery query) {
+
+        return service.findByQuery(user, query);
     }
 
-    @GetMapping("/customaggregate/estimateReportRowCount")
-    public int getEstimateReportRowCount(final ReportQuery query) {
-        return service.estimateReportRowCount(query);
+    @GetMapping("/estimateReportRowCount")
+    public int getEstimateReportRowCount(
+            @AuthenticationPrincipal final User user,
+            final ReportQuery query) {
+
+        return service.estimateReportRowCount(user, query);
     }
+
 }

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/service/impl/DefaultCustomAggregateServiceTest.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/service/impl/DefaultCustomAggregateServiceTest.java
@@ -8,6 +8,7 @@ import org.opentestsystem.rdw.olap.repository.CustomAggregateReportRepository;
 import org.opentestsystem.rdw.olap.service.CustomAggregateService;
 import org.opentestsystem.rdw.reporting.common.model.DimensionType;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ public class DefaultCustomAggregateServiceTest {
     private CustomAggregateReportRepository repository;
     private CustomAggregateService service;
     private ReportQuery query;
+    private User user;
 
     @Before
     public void setUp() {
@@ -36,11 +38,17 @@ public class DefaultCustomAggregateServiceTest {
                 .subjectIds(of(1))
                 .dimensionType(Overall)
                 .build();
+
+        user = User.builder()
+                .id("id")
+                .username("username")
+                .password("password")
+                .build();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void itShouldRequireNotNullQuery() {
-        service.findByQuery(null);
+        service.findByQuery(user, null);
     }
 
     @Test
@@ -48,13 +56,13 @@ public class DefaultCustomAggregateServiceTest {
         final List<ReportRow> rows = mock(List.class);
         when(repository.findByQuery(query)).thenReturn(rows);
 
-        assertThat(service.findByQuery(query)).isEqualTo(rows);
+        assertThat(service.findByQuery(user, query)).isEqualTo(rows);
     }
 
     @Test
     public void itShouldAddOverallWhenQueryDoesNotHaveIt() {
         final ArgumentCaptor<ReportQuery> argumentCaptor = ArgumentCaptor.forClass(ReportQuery.class);
-        service.findByQuery(ReportQuery.builder()
+        service.findByQuery(user, ReportQuery.builder()
                 .copy(query)
                 .dimensionTypes(of(Ethnicity))
                 .build());
@@ -65,22 +73,21 @@ public class DefaultCustomAggregateServiceTest {
         assertThat(query.getDimensionTypes()).contains(DimensionType.Overall);
     }
 
-
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void itShouldRequireNotNullQueryToEstimateRowCount() {
-        service.estimateReportRowCount(null);
+        service.estimateReportRowCount(user, null);
     }
 
     @Test
     public void itShouldUseRepositoryToEstimateRowCount() {
         when(repository.estimateReportRowCount(query)).thenReturn(99);
-        assertThat(service.estimateReportRowCount(query)).isEqualTo(99);
+        assertThat(service.estimateReportRowCount(user, query)).isEqualTo(99);
     }
 
     @Test
     public void itShouldAddOverallWhenQueryDoesNotHaveItToEstimateRowCount() {
         final ArgumentCaptor<ReportQuery> argumentCaptor = ArgumentCaptor.forClass(ReportQuery.class);
-        service.estimateReportRowCount(ReportQuery.builder()
+        service.estimateReportRowCount(user, ReportQuery.builder()
                 .copy(query)
                 .dimensionTypes(of(Ethnicity))
                 .build());
@@ -90,4 +97,5 @@ public class DefaultCustomAggregateServiceTest {
         final ReportQuery query = argumentCaptor.getValue();
         assertThat(query.getDimensionTypes()).contains(DimensionType.Overall);
     }
+
 }

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/web/CustomAggregateControllerIT.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/web/CustomAggregateControllerIT.java
@@ -14,6 +14,7 @@ import org.opentestsystem.rdw.olap.service.CustomAggregateService;
 import org.opentestsystem.rdw.reporting.common.model.DimensionType;
 import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
 import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static com.google.common.collect.ImmutableSet.of;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.refEq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,8 +46,9 @@ public class CustomAggregateControllerIT {
 
     @Test
     public void isShouldGetCustomAggregateReport() throws Exception {
-        when(service.findByQuery(refEq(
-                ReportQuery.builder()
+        when(service.findByQuery(
+                any(User.class),
+                refEq(ReportQuery.builder()
                         .asmtGrades(of(4))
                         .includeState(true)
                         .schoolYears(of(2017))
@@ -53,7 +56,8 @@ public class CustomAggregateControllerIT {
                         .schoolIds(of())
                         .districts(ImmutableMap.of())
                         .assessmentType(AssessmentType.ICA)
-                        .build()))
+                        .build())
+                )
         ).thenReturn(ImmutableList.of(
                 ReportRow.builder()
                         .measures(Measures.builder()
@@ -83,7 +87,7 @@ public class CustomAggregateControllerIT {
                         .build()
         ));
 
-        mvc.perform(get("/api/customaggregate?subjectIds=1&schoolYears=2017&asmtGrades=4&state=TF&assessmentType=ICA"))
+        mvc.perform(get("/customaggregate?subjectIds=1&schoolYears=2017&asmtGrades=4&state=TF&assessmentType=ICA"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*", hasSize(2)))
                 .andExpect(jsonPath("$[0].dimension.type", equalTo("Overall")))
@@ -104,8 +108,9 @@ public class CustomAggregateControllerIT {
 
     @Test
     public void isShouldGetEstimateReportRowCount() throws Exception {
-        when(service.estimateReportRowCount(refEq(
-                ReportQuery.builder()
+        when(service.estimateReportRowCount(
+                any(User.class),
+                refEq(ReportQuery.builder()
                         .asmtGrades(of(4))
                         .includeState(true)
                         .schoolYears(of(2017))
@@ -113,11 +118,13 @@ public class CustomAggregateControllerIT {
                         .schoolIds(of())
                         .districts(ImmutableMap.of())
                         .assessmentType(AssessmentType.ICA)
-                        .build()))
+                        .build())
+                )
         ).thenReturn(99);
 
-        mvc.perform(get("/api/customaggregate/estimateReportRowCount?subjectIds=1&schoolYears=2017&asmtGrades=4&state=TF&assessmentType=ICA"))
+        mvc.perform(get("/customaggregate/estimateReportRowCount?subjectIds=1&schoolYears=2017&asmtGrades=4&state=TF&assessmentType=ICA"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("99"));
     }
+
 }

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -49,8 +49,7 @@ services:
     links:
       - config-server
       - admin-service
-#      TODO uncomment when aggregate-service is uncommented
-#      - aggregate-service
+      - aggregate-service
       - report-processor-service
       - reporting-service
     environment:
@@ -78,25 +77,24 @@ services:
     extra_hosts:
       - "dwhost:$DATAWAREHOUSE_HOST"
 
-# TODO uncomment when rdw-reporting-aggregate-service.yml is added to config repo
-#  aggregate-service:
-#    image: smarterbalanced/rdw-reporting-aggregate-service
-#    ports:
-#      - 8380:8080
-#      - 8308:8008
-#    volumes:
-#      - /tmp:/tmp
-#    links:
-#      - config-server
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
+  aggregate-service:
+    image: smarterbalanced/rdw-reporting-aggregate-service
+    ports:
+      - 8380:8080
+      - 8308:8008
+    volumes:
+      - /tmp:/tmp
+    links:
+      - config-server
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
 
   reporting-service:
-    image: smarterbalanced/rdw-reporting-reporting-service
+    image: smarterbalanced/rdw-reporting-service
     ports:
       - 8180:8080
       - 8108:8008


### PR DESCRIPTION
This is part 1 of adding security to custom aggregate reports
This basically just makes sure the user has CUSTOM_AGGREGATE_READ in order to access any aggregate-service endpoints

Part 2 will make sure the user has rights to make reports based on the orgs associated with the permission