### PR TITLE
Enable general runtime exception request logging

### DIFF
--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/ExceptionHandlerControllerAdvice.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/ExceptionHandlerControllerAdvice.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.reporting.common.web;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.config.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -17,6 +19,7 @@ import java.util.NoSuchElementException;
  */
 @ControllerAdvice
 public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHandler {
+    private static final Logger logger = LoggerFactory.getLogger(ExceptionHandlerControllerAdvice.class);
 
     /**
      * @param exception original exception
@@ -54,6 +57,7 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
      */
     @ExceptionHandler(RuntimeException.class)
     protected ResponseEntity<Object> handleRuntimeExceptions(final RuntimeException exception, final WebRequest request) {
+        logger.warn("Problem handling request", exception);
         return opaqueError(exception, request, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/ExceptionHandlerControllerAdvice.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/ExceptionHandlerControllerAdvice.java
@@ -28,6 +28,7 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
      */
     @ExceptionHandler(IllegalArgumentException.class)
     protected ResponseEntity<Object> handleIllegalArgumentException(final RuntimeException exception, final WebRequest request) {
+        logger.warn("Problem handling request", exception);
         return opaqueError(exception, request, HttpStatus.BAD_REQUEST);
     }
 


### PR DESCRIPTION
This is a fix discussed earlier with @agorina and @esotrope to enable general runtime exception request handler logging in our services.

Currently, if there is an exception during request processing that isn't explicitly handled and logged the request silently fails with no logging.  Examples include SQLExceptions, Request parsing failures, etc.

I'm hitting this currently with Bad Request responses for aggregate reports with no indication of where the error lies: parameters, SQL, random NPE, etc.
This may lead to double-logging of some exceptions, but personally I'd rather double-log than never log at all.