### PR TITLE
Disable Elasticache AutoConfiguration in aggregate-service

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/Application.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/Application.java
@@ -2,10 +2,12 @@ package org.opentestsystem.rdw.olap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication(exclude = {
+        ElastiCacheAutoConfiguration.class,
         ContextStackAutoConfiguration.class
 })
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)


### PR DESCRIPTION
Bringing the aggregate-service in-line with the other reporting services that already disable this autoconfiguration.