### PR TITLE
Replace UNION ALL with java logic.

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Lists.newArrayList;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
 import static org.opentestsystem.rdw.reporting.common.model.ReportQuery.checkIsValid;
@@ -56,33 +57,37 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
 
         validate(query);
 
-        return jdbcTemplate.query(
-                customAggregateQueryProvider.toSqlQueryString(query),
-                buildParameters(query),
-                (row, index) -> ReportRow.builder()
-                        .assessment(Assessment.builder()
-                                .id(row.getInt("asmt_id"))
-                                .gradeId(row.getInt("asmt_grade_id"))
-                                .subjectCode(row.getString("subject_code"))
-                                .label(row.getString("asmt_label"))
-                                .build())
-                        .examSchoolYear(row.getInt("school_year"))
-                        .dimension(new Dimension(getNullable(row, row.getString("dimension_code")), DimensionType.caseInsensitiveValue(row.getString("dimension"))))
-                        .organization(Organization.builder()
-                                .name(row.getString("organization_name"))
-                                .id(getNullable(row, row.getInt("organization_id")))
-                                .type(OrganizationType.caseInsensitiveValue(row.getString("organization_type")))
-                                .naturalId(row.getString("organization_natural_id"))
-                                .build())
-                        .measures(Measures.builder()
-                                .avgScaleScore(row.getInt("score"))
-                                .avgStdErr(row.getInt("std_err"))
-                                .level1Count(row.getInt("level1"))
-                                .level2Count(row.getInt("level2"))
-                                .level3Count(row.getInt("level3"))
-                                .level4Count(row.getInt("level4"))
-                                .build())
-                        .build());
+        final List<ReportRow> reportRows = newArrayList();
+        for (final String sql : customAggregateQueryProvider.toSqlQueryStrings(query)) {
+            reportRows.addAll(jdbcTemplate.query(
+                    sql,
+                    buildParameters(query),
+                    (row, index) -> ReportRow.builder()
+                            .assessment(Assessment.builder()
+                                    .id(row.getInt("asmt_id"))
+                                    .gradeId(row.getInt("asmt_grade_id"))
+                                    .subjectCode(row.getString("subject_code"))
+                                    .label(row.getString("asmt_label"))
+                                    .build())
+                            .examSchoolYear(row.getInt("school_year"))
+                            .dimension(new Dimension(getNullable(row, row.getString("dimension_code")), DimensionType.caseInsensitiveValue(row.getString("dimension"))))
+                            .organization(Organization.builder()
+                                    .name(row.getString("organization_name"))
+                                    .id(getNullable(row, row.getInt("organization_id")))
+                                    .type(OrganizationType.caseInsensitiveValue(row.getString("organization_type")))
+                                    .naturalId(row.getString("organization_natural_id"))
+                                    .build())
+                            .measures(Measures.builder()
+                                    .avgScaleScore(row.getInt("score"))
+                                    .avgStdErr(row.getInt("std_err"))
+                                    .level1Count(row.getInt("level1"))
+                                    .level2Count(row.getInt("level2"))
+                                    .level3Count(row.getInt("level3"))
+                                    .level4Count(row.getInt("level4"))
+                                    .build())
+                            .build()));
+        }
+        return reportRows;
     }
 
     @Override

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
@@ -18,8 +18,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.healthmarketscience.sqlbuilder.SetOperationQuery.unionAll;
-import static java.util.Arrays.copyOf;
+import static java.util.stream.Collectors.toList;
 
 /**
  * This implementation is responsible for constructing a custom aggregate query.
@@ -49,7 +48,7 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
         this.queryProvider = queryProvider;
     }
 
-    public String toSqlQueryString(final ReportQuery query) {
+    public Iterable<String> toSqlQueryStrings(final ReportQuery query) {
         final List<SelectQuery> queries = newArrayList();
 
         // {@link ReportQuery} may include different types of organizations as well as different dimensions.
@@ -74,7 +73,7 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
                 queries.add(buildSql(newArrayList(schoolsAddOn), dimension, query));
             }
         }
-        return queries.size() == 1 ? queries.get(0).toString() : unionAll(copyOf(queries.toArray(), queries.size(), SelectQuery[].class)).toString();
+        return queries.stream().map(SelectQuery::toString).collect(toList());
     }
 
     /**

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/ReportQueryProvider.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/ReportQueryProvider.java
@@ -4,14 +4,14 @@ import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
 
 
 /**
- * Implementation of this interface is responsible for converting a {@link ReportQuery} to a sql query string
+ * Implementation of this interface is responsible for converting a {@link ReportQuery} to a sql query strings
  */
 public interface ReportQueryProvider {
     /**
      * Converts a given {@link ReportQuery} to a sql query string
      *
      * @param query {@link ReportQuery}
-     * @return a sql query string
+     * @return a collection of sql query strings
      */
-    String toSqlQueryString(ReportQuery query);
+    Iterable<String> toSqlQueryStrings(ReportQuery query);
 }


### PR DESCRIPTION
This is based on the latest load testing findings. The goal is to reduce the number of SQL query variations.