### PR TITLE
adds none state to checkbox group

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.resolve.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.resolve.ts
@@ -36,7 +36,7 @@ export class AggregateReportFormResolve implements Resolve<AggregateReportForm> 
     const valuesOf = options => options.map(option => option.value);
     const firstValueOf = options => options[ 0 ].value;
     return <AggregateReportFormSettings>{
-      assessmentGrades: valuesOf(options.assessmentGrades),
+      assessmentGrades: [],
       assessmentType: firstValueOf(options.assessmentTypes),
       completenesses: valuesOf(options.completenesses),
       ethnicities: valuesOf(options.ethnicities),
@@ -52,7 +52,7 @@ export class AggregateReportFormResolve implements Resolve<AggregateReportForm> 
       economicDisadvantages: valuesOf(options.economicDisadvantages),
       achievementLevelDisplayType: firstValueOf(options.achievementLevelDisplayTypes),
       valueDisplayType: firstValueOf(options.valueDisplayTypes),
-      dimensionTypes: valuesOf(options.dimensionTypes)
+      dimensionTypes: []
     };
   }
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.component.html
@@ -63,6 +63,7 @@
               <sb-checkbox-group [horizontal]="true"
                                  [options]="options.assessmentGrades"
                                  [(ngModel)]="settings.assessmentGrades"
+                                 [allOptionEnabled]="false"
                                  analyticsEvent="FilterClick"
                                  analyticsCategory="AggregateQueryBuilder"
                                  [allOptionAnalyticsProperties]="{label: 'Assessment Grade: All'}"></sb-checkbox-group>
@@ -347,6 +348,7 @@
             <div class="col-md-3">
               <sb-checkbox-group [options]="options.dimensionTypes"
                                  [(ngModel)]="settings.dimensionTypes"
+                                 [allOptionEnabled]="false"
                                  analyticsEvent="FilterClick"
                                  analyticsCategory="AggregateQueryBuilder"
                                  [allOptionAnalyticsProperties]="{label: 'Comparative Subgroups: All'}"></sb-checkbox-group>


### PR DESCRIPTION
Styles probably need some work - but at least functionally now we can default to no selection on assessment grade and comparative subgroups (dimensions)

![image](https://user-images.githubusercontent.com/23462925/35252644-45485c82-ff96-11e7-86f6-981ccba1d27a.png)

![image](https://user-images.githubusercontent.com/23462925/35252652-4e20cc18-ff96-11e7-8fd3-8357b8f2baa5.png)

Note: we will need to add form validation if we go this direction because i think we require at least one assessment grade be selected right?
