### PR TITLE
Disable parameter padding for aggregate report queries.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/QueryUtils.java
@@ -6,11 +6,9 @@ import com.google.common.collect.ImmutableList;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.rangeClosed;
 
@@ -91,19 +89,20 @@ public class QueryUtils {
      * @return the given collection padded to the given size
      */
     public static Collection<Integer> padToSize(final Collection<Integer> collection, final int size) {
+        return collection;
 
-        if (collection != null && collection.size() >= size) return collection;
-
-        if (size + (collection == null ? 0 : collection.size()) > UNMATCHABLE_DISTINCT_IDS.size()) throw new IllegalArgumentException("size is too big to pad");
-
-        final List<Integer> padded = newArrayList(UNMATCHABLE_DISTINCT_IDS.subList(0, size));
-
-        if (collection == null) return padded;
-
-        final Iterator<Integer> iterator = collection.iterator();
-        for (int i = 0; i < collection.size(); ++i) {
-            padded.set(i, iterator.next());
-        }
-        return padded;
+//        if (collection != null && collection.size() >= size) return collection;
+//
+//        if (size + (collection == null ? 0 : collection.size()) > UNMATCHABLE_DISTINCT_IDS.size()) throw new IllegalArgumentException("size is too big to pad");
+//
+//        final List<Integer> padded = newArrayList(UNMATCHABLE_DISTINCT_IDS.subList(0, size));
+//
+//        if (collection == null) return padded;
+//
+//        final Iterator<Integer> iterator = collection.iterator();
+//        for (int i = 0; i < collection.size(); ++i) {
+//            padded.set(i, iterator.next());
+//        }
+//        return padded;
     }
 }


### PR DESCRIPTION
Temporarily disable parameter padding to validate that it significantly improves aggregate report query performance.