### PR TITLE
Add report metadata to allow storing/retrieving type-specific values …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-58"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-311"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-312"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/Report.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/Report.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The model represents the request, generation, and current status of a report.
@@ -16,9 +18,8 @@ public class Report {
     private URI reportResourceUri;
     private String label;
     private AbstractExamReportRequest reportRequest;
-    private int totalChunkCount;
-    private int completeChunkCount;
     private Instant created;
+    private Map<String, String> metadata;
 
     /**
      * @return The report id
@@ -66,24 +67,17 @@ public class Report {
     }
 
     /**
-     * @return The total number of student chunks for this report
-     */
-    public int getTotalChunkCount() {
-        return totalChunkCount;
-    }
-
-    /**
-     * @return The number of completed student chunks for this report
-     */
-    public int getCompleteChunkCount() {
-        return completeChunkCount;
-    }
-
-    /**
      * @return The report request submission date-time
      */
     public Instant getCreated() {
         return created;
+    }
+
+    /**
+     * @return The optional report metadata
+     */
+    public Map<String, String> getMetadata() {
+        return metadata;
     }
 
     /**
@@ -107,9 +101,8 @@ public class Report {
         private URI reportResourceUri;
         private String label;
         private AbstractExamReportRequest<?> reportRequest;
-        private int totalChunkCount;
-        private int completeChunkCount;
         private Instant created;
+        private final Map<String, String> metadata = new HashMap<>();
 
         public Report build() {
             final Report report = new Report();
@@ -119,9 +112,8 @@ public class Report {
             report.reportResourceUri = reportResourceUri;
             report.label = label;
             report.reportRequest = reportRequest;
-            report.totalChunkCount = totalChunkCount;
-            report.completeChunkCount = completeChunkCount;
             report.created = created;
+            report.metadata = metadata;
 
             return report;
         }
@@ -133,9 +125,8 @@ public class Report {
             reportResourceUri(report.getReportResourceUri());
             label(report.getLabel());
             reportRequest(report.getReportRequest());
-            totalChunkCount(report.getTotalChunkCount());
-            completeChunkCount(report.getCompleteChunkCount());
             created(report.getCreated());
+            metadata(report.getMetadata());
 
             return this;
         }
@@ -170,18 +161,19 @@ public class Report {
             return this;
         }
 
-        public Builder totalChunkCount(final int totalChunkCount) {
-            this.totalChunkCount = totalChunkCount;
-            return this;
-        }
-
-        public Builder completeChunkCount(final int completeChunkCount) {
-            this.completeChunkCount = completeChunkCount;
-            return this;
-        }
-
         public Builder created(final Instant created) {
             this.created = created;
+            return this;
+        }
+
+        public Builder metadata(final Map<String, String> metadata) {
+            this.metadata.clear();
+            this.metadata.putAll(metadata);
+            return this;
+        }
+
+        public Builder metadata(final String key, final String value) {
+            this.metadata.put(key, value);
             return this;
         }
     }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
@@ -2,15 +2,15 @@ package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
-import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.jackson.ReportModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -22,10 +22,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static org.apache.http.util.TextUtils.isBlank;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
 
 /**
  * A JDBC implementation of a ReportRepository.
@@ -58,6 +63,15 @@ public class JdbcReportRepository implements ReportRepository {
     @Value("${sql.report.completeChunk}")
     private String completeChunk;
 
+    @Value("${sql.report.findMetadataForReports}")
+    private String findMetadataForReports;
+
+    @Value("${sql.report.deleteMetadataForReport}")
+    private String deleteMetadataForReport;
+
+    @Value("${sql.report.insertMetadataForReport}")
+    private String insertMetadataForReport;
+
     private final ObjectMapper objectMapper;
     private final NamedParameterJdbcTemplate template;
 
@@ -76,7 +90,6 @@ public class JdbcReportRepository implements ReportRepository {
         final int insertCount = this.template.update(create,
                 new MapSqlParameterSource()
                         .addValue("user_login", report.getUser())
-                        .addValue("total_chunk_count", report.getTotalChunkCount())
                         .addValue("status", report.getStatus().id())
                         .addValue("report_resource_uri", uriAsString(report.getReportResourceUri()))
                         .addValue("label", report.getLabel())
@@ -99,7 +112,6 @@ public class JdbcReportRepository implements ReportRepository {
                 new MapSqlParameterSource()
                         .addValue("id", report.getId())
                         .addValue("user_login", report.getUser())
-                        .addValue("total_chunk_count", report.getTotalChunkCount())
                         .addValue("status", report.getStatus().id())
                         .addValue("report_resource_uri", uriAsString(report.getReportResourceUri()))
                         .addValue("label", report.getLabel())
@@ -109,6 +121,12 @@ public class JdbcReportRepository implements ReportRepository {
         if (updated != 1) {
             throw new IllegalStateException("Unable to update report: " + report.getId());
         }
+
+        deleteMetadataForReport(report.getId());
+        for (final Map.Entry<String, String> entry : report.getMetadata().entrySet()) {
+            insertMetadataForReport(report.getId(), entry.getKey(), entry.getValue());
+        }
+
         return report;
     }
 
@@ -116,33 +134,29 @@ public class JdbcReportRepository implements ReportRepository {
     public List<Report> findByUserAndIds(final String user, final Collection<Long> reportIds) {
         final String query = reportIds.isEmpty() ? findAllByUser : findAllByUserAndId;
 
-        return template.query(query,
+        return saturateMetadata(template.query(query,
                 new MapSqlParameterSource()
                         .addValue("user", user)
                         .addValue("report_ids", reportIds),
-                (row, rowNum) -> asReport(row)
-        );
+                (row, num) -> asReport(row)
+        ));
     }
 
     @Override
     public Report findById(final long reportId) {
-        try {
-            return template.queryForObject(findById,
-                    new MapSqlParameterSource()
-                            .addValue("report_id", reportId),
-                    (row, rowNum) -> asReport(row)
-            );
-        } catch (final EmptyResultDataAccessException e) {
-            return null;
-        }
+        return saturateMetadata(template.query(findById,
+                new MapSqlParameterSource()
+                        .addValue("report_id", reportId),
+                (row, num) -> asReport(row)
+        )).stream().findFirst().orElse(null);
     }
 
     @Override
     public List<Report> findAllOlderThanNumberOfDays(final int numberOfDays) {
-        return template.query(findAllOlderThanNumberOfDays,
+        return saturateMetadata(template.query(findAllOlderThanNumberOfDays,
                 new MapSqlParameterSource("number_of_days", numberOfDays),
-                (row, rowNum) -> asReport(row)
-        );
+                (row, num) -> asReport(row)
+        ));
     }
 
     @Override
@@ -163,8 +177,32 @@ public class JdbcReportRepository implements ReportRepository {
         }
         return Report.builder()
                 .copy(report)
-                .completeChunkCount(keyHolder.getKey().intValue())
+                .metadata(CompletedChunk, String.valueOf(keyHolder.getKey().intValue()))
                 .build();
+    }
+
+    private Map<Long, Map<String, String>> getMetadataForReports(final Collection<Long> reportIds) {
+        if (reportIds.isEmpty()) return Collections.emptyMap();
+
+        final Map<Long, Map<String, String>> metadata = new HashMap<>();
+
+        template.query(findMetadataForReports,
+                new MapSqlParameterSource("report_ids", reportIds),
+                asReportMetadata(metadata)
+        );
+        return metadata;
+    }
+
+    private void deleteMetadataForReport(final long reportId) {
+        template.update(deleteMetadataForReport, new MapSqlParameterSource("report_id", reportId));
+    }
+
+    private void insertMetadataForReport(final long reportId, final String name, final String value) {
+        template.update(insertMetadataForReport,
+                new MapSqlParameterSource()
+                        .addValue("report_id", reportId)
+                        .addValue("name", name)
+                        .addValue("value", value));
     }
 
     private String serializeReportRequest(final AbstractExamReportRequest reportRequest) {
@@ -199,6 +237,25 @@ public class JdbcReportRepository implements ReportRepository {
         return value.toASCIIString();
     }
 
+    private List<Report> saturateMetadata(final Collection<Report> reports) {
+        final Map<Long, Map<String, String>> metadata = getMetadataForReports(reports.stream()
+                .map(Report::getId)
+                .collect(Collectors.toSet()));
+
+        return reports.stream()
+                .map((report) -> {
+                    final Map<String, String> reportMetadata = metadata.get(report.getId());
+                    if (reportMetadata == null) {
+                        return report;
+                    }
+
+                    return report.copy()
+                            .metadata(reportMetadata)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
     private Report asReport(final ResultSet row) throws SQLException {
         return Report.builder()
                 .id(row.getLong("id"))
@@ -206,10 +263,19 @@ public class JdbcReportRepository implements ReportRepository {
                 .status(ReportStatus.valueOf(row.getInt("status")))
                 .reportResourceUri(asUri(row.getString("report_resource_uri")))
                 .label(row.getString("label"))
-                .totalChunkCount(row.getInt("total_chunk_count"))
-                .completeChunkCount(row.getInt("complete_chunk_count"))
                 .reportRequest(deserializeReportRequest(row.getString("report_request")))
                 .created(row.getTimestamp("created").toInstant())
                 .build();
+    }
+
+    private RowCallbackHandler asReportMetadata(final Map<Long, Map<String, String>> metadata) {
+        return (row) -> {
+            final Long reportId = row.getLong("report_id");
+            final Map<String, String> reportMetadata = metadata.computeIfAbsent(reportId, (id) -> new HashMap<>());
+            reportMetadata.put(
+                    row.getString("name"),
+                    row.getString("value")
+            );
+        };
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
@@ -40,6 +40,9 @@ import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudentsSou
 public class FetchStudents {
     private final static Logger logger = LoggerFactory.getLogger(FetchStudents.class);
 
+    public final static String TotalChunk = "total_chunk_count";
+    public final static String CompletedChunk = "completed_chunk_count";
+
     private static final Ordering<Student> StudentSSIDOrdering = Ordering.natural()
             .onResultOf(Student::getSsid);
 
@@ -94,7 +97,7 @@ public class FetchStudents {
         final List<List<Student>> chunks = Lists.partition(orderedStudents, reportGenerationProperties.getChunkSize());
         final Report updated = Report.builder()
                 .copy(report)
-                .totalChunkCount(chunks.size())
+                .metadata(TotalChunk, String.valueOf(chunks.size()))
                 .build();
         reportService.update(updated);
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
@@ -1,9 +1,9 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
-import org.opentestsystem.rdw.reporting.processor.model.Report;
-import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
+import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
 import org.opentestsystem.rdw.reporting.processor.service.ReportMergeService;
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static java.lang.Integer.parseInt;
 import static org.opentestsystem.rdw.reporting.processor.stream.GenerateStudentsReportProcessor.ReportCollate;
 
 /**
@@ -56,7 +57,9 @@ public class GeneratePdf {
         if (report.getStatus() == ReportStatus.FAILED) return;
 
         try {
-            final List<Supplier<InputStream>> chunkPdfs = reportGenerationTemporaryStorage.getChunks(report.getId(), report.getTotalChunkCount());
+            final List<Supplier<InputStream>> chunkPdfs = reportGenerationTemporaryStorage.getChunks(
+                    report.getId(),
+                    parseInt(report.getMetadata().get(FetchStudents.TotalChunk)));
             final MergedReport mergedReport = pdfMerger.mergePdfs(report, chunkPdfs);
 
             logger.debug("Merged Report: {}", message.getReportId());

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -43,10 +43,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.lang.Integer.parseInt;
 import static org.opentestsystem.rdw.common.model.AssessmentType.IAB;
 import static org.opentestsystem.rdw.common.model.AssessmentType.ICA;
 import static org.opentestsystem.rdw.common.model.Subject.ELA;
 import static org.opentestsystem.rdw.common.model.Subject.MATH;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudentsProcessor.ReportGenerateForStudents;
 
 /**
@@ -154,7 +157,14 @@ public class StudentReportProcessor {
         }
 
         final Report completed = reportService.completeChunk(report);
-        if (completed.getTotalChunkCount() == completed.getCompleteChunkCount()) {
+        final Map<String, String> metadata = completed.getMetadata();
+        final int totalChunkCount = metadata.get(TotalChunk) == null
+                ? 0
+                : parseInt(completed.getMetadata().get(TotalChunk));
+        final int completedChunkCount = metadata.get(CompletedChunk) == null
+                ? 0
+                : parseInt(metadata.get(CompletedChunk));
+        if (completedChunkCount == totalChunkCount) {
             publishCollationMessage(completed);
             logger.debug("Report: {} all chunks complete", message.getReportId());
         }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportResource.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportResource.java
@@ -2,11 +2,12 @@ package org.opentestsystem.rdw.reporting.processor.web;
 
 import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.Subject;
-import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
+import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.model.ReportType;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * This resource contains {@link Report}
@@ -22,6 +23,7 @@ public class ReportResource {
     private Subject subject;
     private Integer schoolYear;
     private Instant created;
+    private Map<String, String> metadata;
 
     public Long getId() {
         return id;
@@ -85,5 +87,13 @@ public class ReportResource {
 
     void setCreated(final Instant created) {
         this.created = created;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    void setMetadata(final Map<String, String> metadata) {
+        this.metadata = metadata;
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportResourceAssembler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportResourceAssembler.java
@@ -1,7 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.web;
 
-import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +17,7 @@ public class ReportResourceAssembler {
         resource.setStatus(report.getStatus());
         resource.setLabel(report.getLabel());
         resource.setCreated(report.getCreated());
+        resource.setMetadata(report.getMetadata());
 
         final AbstractExamReportRequest request = report.getReportRequest();
         if (request != null) {

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -235,9 +235,9 @@ sql:
 
     create: >-
       insert into user_report
-        (user_login, total_chunk_count, status, report_resource_uri, label, report_request, created)
+        (user_login, status, report_resource_uri, label, report_request, created)
         values
-        (:user_login, :total_chunk_count, :status, :report_resource_uri, :label, :report_request, :created)
+        (:user_login, :status, :report_resource_uri, :label, :report_request, :created)
 
     update: >-
       update user_report
@@ -247,7 +247,6 @@ sql:
         report_resource_uri = :report_resource_uri,
         label = :label,
         report_request = :report_request,
-        total_chunk_count = :total_chunk_count,
         created = :created
       where
         id = :id
@@ -279,6 +278,22 @@ sql:
         set complete_chunk_count = LAST_INSERT_ID(complete_chunk_count + 1)
       where
         id = :report_id;
+
+    insertMetadataForReport: >-
+      insert into user_report_metadata
+        (report_id, name, value)
+        values
+        (:report_id, :name, :value);
+
+    deleteMetadataForReport: >-
+      delete from user_report_metadata
+      where
+        report_id = :report_id;
+
+    findMetadataForReports: >-
+      select * from user_report_metadata
+      where
+        report_id IN (:report_ids);
 
   student:
     findByExamQueryParamsUnknownPermissions: >-
@@ -420,8 +435,6 @@ sql:
               r.report_resource_uri,
               r.label,
               r.report_request,
-              r.total_chunk_count,
-              r.complete_chunk_count,
               r.created
             from user_report r
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
@@ -2,24 +2,30 @@ package org.opentestsystem.rdw.reporting.processor.repository;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.reporting.processor.model.Report;
-import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
+import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.Integer.parseInt;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.opentestsystem.rdw.reporting.processor.model.ReportStatus.PENDING;
 import static org.opentestsystem.rdw.reporting.processor.MockBuilder.report;
+import static org.opentestsystem.rdw.reporting.processor.model.ReportStatus.PENDING;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
@@ -33,6 +39,9 @@ public class JdbcReportRepositoryIT {
 
     @Autowired
     private JdbcReportRepository repository;
+
+    @Autowired
+    private NamedParameterJdbcTemplate template;
 
     @Test
     public void itShouldInsertAReport() throws Exception {
@@ -126,16 +135,19 @@ public class JdbcReportRepositoryIT {
     public void itShouldMarkChunksCompleted() {
         Report report = Report.builder()
                 .copy(report())
-                .totalChunkCount(10)
-                .completeChunkCount(0)
+                .metadata(TotalChunk, "10")
+                .metadata(CompletedChunk, "0")
                 .build();
 
         report = repository.create(report);
         report = repository.completeChunk(report);
-        assertThat(report.getCompleteChunkCount()).isEqualTo(1);
+        int completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
+
+        assertThat(completedChunkCount).isEqualTo(1);
 
         report = repository.completeChunk(report);
-        assertThat(report.getCompleteChunkCount()).isEqualTo(2);
+        completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
+        assertThat(completedChunkCount).isEqualTo(2);
     }
 
     @Test
@@ -168,6 +180,47 @@ public class JdbcReportRepositoryIT {
         repository.deleteIds(newHashSet(123L));
         final Report found = repository.findById(123L);
         assertThat(found).isNull();
+    }
+
+    @Test
+    public void itShouldUpsertMetadataOnReportUpdate() {
+        final Report original = repository.create(report());
+        Report updateSrc = original.copy()
+                .metadata("some_metadata", "some_value")
+                .build();
+        repository.update(updateSrc);
+        Report updateResult = repository.findById(original.getId());
+        assertThat(updateResult.getMetadata().size()).isEqualTo(1);
+        assertThat(updateResult.getMetadata().get("some_metadata")).isEqualTo("some_value");
+
+        updateSrc = updateResult.copy()
+                .metadata("some_metadata", "new_value")
+                .metadata("new_metadata", "another_value")
+                .build();
+        repository.update(updateSrc);
+        updateResult = repository.findById(original.getId());
+        assertThat(updateResult.getMetadata().size()).isEqualTo(2);
+        assertThat(updateResult.getMetadata().get("some_metadata")).isEqualTo("new_value");
+        assertThat(updateResult.getMetadata().get("new_metadata")).isEqualTo("another_value");
+    }
+
+    @Test
+    public void itShouldDeleteMetadataWhenDeletingAReport() {
+        final Report original = repository.create(report());
+        original.getMetadata().put("some_metadata", "some_value");
+        repository.update(original);
+
+        int metadataCount = template.queryForObject("SELECT count(*) from user_report_metadata",
+                new MapSqlParameterSource(),
+                Integer.class);
+        assertThat(metadataCount).isEqualTo(1);
+
+        repository.deleteIds(Collections.singleton(original.getId()));
+
+        metadataCount = template.queryForObject("SELECT count(*) from user_report_metadata",
+                new MapSqlParameterSource(),
+                Integer.class);
+        assertThat(metadataCount).isEqualTo(0);
     }
 
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportServiceIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportServiceIT.java
@@ -4,8 +4,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.repository.JdbcReportRepository;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,8 +25,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.Integer.parseInt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.reporting.processor.MockBuilder.report;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 
 @ContextConfiguration(classes = TestConfiguration.class)
 @SpringBootTest(classes = {
@@ -71,7 +74,7 @@ public class DefaultReportServiceIT {
     public void itShouldOnlyReturnChunksCompletedOnce() throws Exception {
         final Report report = service.create(Report.builder()
                 .copy(report())
-                .totalChunkCount(chunkCount)
+                .metadata(TotalChunk, String.valueOf(chunkCount))
                 .build());
         reportId = report.getId();
 
@@ -86,8 +89,10 @@ public class DefaultReportServiceIT {
                 try {
                     startSemaphore.tryAcquire(30, TimeUnit.SECONDS);
                     final Report updated = service.completeChunk(report);
-                    isLastChunkResults.add(updated.getTotalChunkCount() == updated.getCompleteChunkCount());
-                    completeCount.add(updated.getCompleteChunkCount());
+                    final int totalChunkCount = parseInt(updated.getMetadata().get(TotalChunk));
+                    final int completedChunkCount = parseInt(updated.getMetadata().get(CompletedChunk));
+                    isLastChunkResults.add(totalChunkCount == completedChunkCount);
+                    completeCount.add(completedChunkCount);
                     endSemaphore.release(1);
                 } catch (final InterruptedException e) {
                     throw new RuntimeException("Failed to acquire chunk permit", e);

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.Integer.parseInt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -39,6 +40,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.opentestsystem.rdw.reporting.processor.MockBuilder.student;
 import static org.opentestsystem.rdw.reporting.processor.model.ExamReportOrder.STUDENT_SSID;
 import static org.opentestsystem.rdw.reporting.processor.model.ReportStatus.NO_RESULTS;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FetchStudentsTest {
@@ -118,7 +120,8 @@ public class FetchStudentsTest {
         component.fetchAndPublishStudents(message);
 
         verify(reportService).update(reportCaptor.capture());
-        assertThat(reportCaptor.getValue().getTotalChunkCount()).isEqualTo(1);
+        final int totalChunkCount = parseInt(reportCaptor.getValue().getMetadata().get(TotalChunk));
+        assertThat(totalChunkCount).isEqualTo(1);
         verify(processor.generateStudentReport()).send(messageCaptor.capture());
         assertThat(messageCaptor.getValue().getPayload().getStudents())
                 .containsExactlyElementsOf(students);
@@ -146,7 +149,8 @@ public class FetchStudentsTest {
         component.fetchAndPublishStudents(message);
 
         verify(reportService).update(reportCaptor.capture());
-        assertThat(reportCaptor.getValue().getTotalChunkCount()).isEqualTo(2);
+        final int totalChunkCount = parseInt(reportCaptor.getValue().getMetadata().get(TotalChunk));
+        assertThat(totalChunkCount).isEqualTo(2);
         verify(processor.generateStudentReport(), times(2)).send(messageCaptor.capture());
         assertThat(messageCaptor.getAllValues().get(0).getPayload().getStudents().stream().map(Student::getId))
                 .containsExactly(1L, 2L);
@@ -179,7 +183,8 @@ public class FetchStudentsTest {
         component.fetchAndPublishStudents(message);
 
         verify(reportService).update(reportCaptor.capture());
-        assertThat(reportCaptor.getValue().getTotalChunkCount()).isEqualTo(2);
+        final int totalChunkCount = parseInt(reportCaptor.getValue().getMetadata().get(TotalChunk));
+        assertThat(totalChunkCount).isEqualTo(2);
         verify(processor.generateStudentReport(), times(2)).send(messageCaptor.capture());
         assertThat(messageCaptor.getAllValues().get(0).getPayload().getStudents().stream().map(Student::getId))
                 .containsExactly(1L, 2L);

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
@@ -39,6 +39,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.APPLICATION_PDF_UTF8;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GeneratePdfTest {
@@ -73,8 +75,8 @@ public class GeneratePdfTest {
 
         report = spy(Report.builder()
                 .id(ReportId)
-                .totalChunkCount(3)
-                .completeChunkCount(3)
+                .metadata(TotalChunk, "3")
+                .metadata(CompletedChunk, "3")
                 .build());
         when(reportService.findOneById(ReportId)).thenReturn(Optional.of(report));
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.processor.MockBuilder.student;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StudentReportProcessorTest {
@@ -114,7 +115,7 @@ public class StudentReportProcessorTest {
 
         final Report report = Report.builder()
                 .id(ReportId)
-                .totalChunkCount(10)
+                .metadata(TotalChunk, "10")
                 .reportRequest(reportRequest)
                 .build();
         when(reportService.findOneById(ReportId)).thenReturn(Optional.of(report));

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -32,6 +32,8 @@ import java.util.NoSuchElementException;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
+import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.TotalChunk;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -106,8 +108,8 @@ public class ReportControllerIT {
                         .id(1L)
                         .status(ReportStatus.PENDING)
                         .reportResourceUri(URI.create("/somewhere.pdf"))
-                        .completeChunkCount(0)
-                        .totalChunkCount(123)
+                        .metadata(CompletedChunk, "0")
+                        .metadata(TotalChunk, "123")
                         .user("my-user")
                         .label("my-label")
                         .created(Instant.now())
@@ -119,7 +121,7 @@ public class ReportControllerIT {
                 .content(mapper.writeValueAsString(studentRequest))
                 .with(user(user)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.*", hasSize(8)))
+                .andExpect(jsonPath("$.*", hasSize(9)))
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("PENDING"))
                 .andExpect(jsonPath("$.label").value("my-label"))
@@ -127,7 +129,9 @@ public class ReportControllerIT {
                 .andExpect(jsonPath("$.assessmentType").value("ICA"))
                 .andExpect(jsonPath("$.subject").value("MATH"))
                 .andExpect(jsonPath("$.schoolYear").value(2))
-                .andExpect(jsonPath("$.created").isNotEmpty());
+                .andExpect(jsonPath("$.created").isNotEmpty())
+                .andExpect(jsonPath("$.metadata.completed_chunk_count").value("0"))
+                .andExpect(jsonPath("$.metadata.total_chunk_count").value("123"));
 
     }
 


### PR DESCRIPTION
…for a Report

The goal is to be able to store the actual aggregate report result count in the Report when it comes back from the aggregate-service AS WELL AS return that value to the front-end so it knows whether or not to enable the "View" link in my "My Reports" view.