### PR TITLE
Fix PDF report chunk completion

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
@@ -98,6 +98,7 @@ public class FetchStudents {
         final Report updated = Report.builder()
                 .copy(report)
                 .metadata(TotalChunk, String.valueOf(chunks.size()))
+                .metadata(CompletedChunk, "0")
                 .build();
         reportService.update(updated);
 

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -274,10 +274,11 @@ sql:
       delete from `user_report` WHERE `id` in (:ids);
 
     completeChunk: >-
-      update user_report
-        set complete_chunk_count = LAST_INSERT_ID(complete_chunk_count + 1)
+      update user_report_metadata
+        set value = cast(LAST_INSERT_ID(cast(value as unsigned) + 1) AS CHAR)
       where
-        id = :report_id;
+        report_id = :report_id and
+        name = 'completed_chunk_count';
 
     insertMetadataForReport: >-
       insert into user_report_metadata

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
@@ -140,12 +140,21 @@ public class JdbcReportRepositoryIT {
                 .build();
 
         report = repository.create(report);
+        report = repository.update(report);
+
         report = repository.completeChunk(report);
         int completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
+        assertThat(completedChunkCount).isEqualTo(1);
 
+        report = repository.findById(report.getId());
+        completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
         assertThat(completedChunkCount).isEqualTo(1);
 
         report = repository.completeChunk(report);
+        completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
+        assertThat(completedChunkCount).isEqualTo(2);
+
+        report = repository.findById(report.getId());
         completedChunkCount = parseInt(report.getMetadata().get(CompletedChunk));
         assertThat(completedChunkCount).isEqualTo(2);
     }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportServiceIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportServiceIT.java
@@ -75,7 +75,9 @@ public class DefaultReportServiceIT {
         final Report report = service.create(Report.builder()
                 .copy(report())
                 .metadata(TotalChunk, String.valueOf(chunkCount))
+                .metadata(CompletedChunk, "0")
                 .build());
+        service.update(report);
         reportId = report.getId();
 
         final Semaphore startSemaphore = new Semaphore(0);


### PR DESCRIPTION
This fixes an issue with completing student chunks during PDF report generation that was caused by the last PR.  Completing a chunk is a separate repository method that needs to increment the completed_chunk count as a metadata property.