### PR TITLE
Fix User deserialization in report processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-58"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-312"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-313"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/User.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/User.java
@@ -83,7 +83,7 @@ public class User extends org.springframework.security.core.userdetails.User {
         private String lastName;
         private Map<String, Permission> permissionsById;
         private Map<Long, GroupGrant> groupsById;
-        private String password;
+        private String password = "[REDACTED]";
         private String username;
         private Collection<? extends GrantedAuthority> authorities;
         private boolean accountNonExpired;

--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/jwt/JwtWebSecurityConfiguration.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/jwt/JwtWebSecurityConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ApplicationConfiguration.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ApplicationConfiguration.java
@@ -5,8 +5,6 @@ import org.opentestsystem.rdw.common.status.StatusConfiguration;
 import org.opentestsystem.rdw.reporting.common.i18n.MessageSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
-import org.opentestsystem.rdw.reporting.common.web.security.User;
-import org.opentestsystem.rdw.reporting.common.web.security.jackson2.UserMixin;
 import org.opentestsystem.rdw.reporting.common.web.security.jwt.JwtWebSecurityConfiguration;
 import org.opentestsystem.rdw.reporting.processor.configuration.RemoveStaleReportsConfiguration;
 import org.opentestsystem.rdw.reporting.processor.service.WkhtmltopdfWebServiceClient;
@@ -41,7 +39,7 @@ public class ApplicationConfiguration {
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer customizeObjectMapper() {
-        return builder -> builder.mixIn(User.class, UserMixin.class);
+        return builder -> builder.failOnUnknownProperties(false);
     }
 
     @Bean

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ApplicationConfiguration.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ApplicationConfiguration.java
@@ -5,6 +5,8 @@ import org.opentestsystem.rdw.common.status.StatusConfiguration;
 import org.opentestsystem.rdw.reporting.common.i18n.MessageSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.common.web.security.jackson2.UserMixin;
 import org.opentestsystem.rdw.reporting.common.web.security.jwt.JwtWebSecurityConfiguration;
 import org.opentestsystem.rdw.reporting.processor.configuration.RemoveStaleReportsConfiguration;
 import org.opentestsystem.rdw.reporting.processor.service.WkhtmltopdfWebServiceClient;
@@ -12,6 +14,7 @@ import org.opentestsystem.rdw.utils.ResourceLoaderConfiguration;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +38,11 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 @EnableCaching
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class ApplicationConfiguration {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customizeObjectMapper() {
+        return builder -> builder.mixIn(User.class, UserMixin.class);
+    }
 
     @Bean
     public ClientHttpRequestFactory requestFactory() {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplication.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplication.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.reporting.processor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
 import org.springframework.context.annotation.PropertySource;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ReportRequestMessage.java
@@ -1,27 +1,17 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
-import org.opentestsystem.rdw.reporting.common.web.security.User;
-
 /**
  * This message represents a basic report processing message.
  */
 public class ReportRequestMessage {
 
     protected long reportId;
-    protected User user;
 
     /**
      * @return The report id
      */
     public long getReportId() {
         return reportId;
-    }
-
-    /**
-     * @return The requesting user
-     */
-    public User getUser() {
-        return user;
     }
 
     /**
@@ -42,14 +32,12 @@ public class ReportRequestMessage {
     public abstract static class BaseBuilder<A extends ReportRequestMessage, B extends ReportRequestMessage.BaseBuilder<A, B>> {
 
         private long reportId;
-        private User user;
 
         protected abstract A createInstance();
 
         public A build() {
             final A message = createInstance();
             message.reportId = reportId;
-            message.user = user;
             return message;
         }
 
@@ -57,11 +45,5 @@ public class ReportRequestMessage {
             this.reportId = reportId;
             return (B) this;
         }
-
-        public B user(final User user) {
-            this.user = user;
-            return (B) this;
-        }
-
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/DefaultMessageSecurityService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/DefaultMessageSecurityService.java
@@ -1,0 +1,56 @@
+package org.opentestsystem.rdw.reporting.processor.service;
+
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.common.web.security.jwt.JwtService;
+import org.opentestsystem.rdw.reporting.common.web.security.jwt.support.BearerAuthorizationHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+
+/**
+ * Default implementation of a MessageSecurityService using JWT and Bearer tokens as a message header.
+ */
+@Service
+public class DefaultMessageSecurityService implements MessageSecurityService {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMessageSecurityService.class);
+
+    private final JwtService jwtService;
+
+    @Autowired
+    public DefaultMessageSecurityService(final JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public <T> Message<T> withUser(final Message<T> message, final User user) {
+        final String jwt = jwtService.encode(user);
+        final String bearerToken = BearerAuthorizationHeaders.create(jwt);
+
+        return MessageBuilder.fromMessage(message)
+                .setHeader(AUTHORIZATION, bearerToken)
+                .build();
+    }
+
+    @Override
+    public User getUser(final Message<?> message) {
+        final MessageHeaders headers = message.getHeaders();
+        final String header = headers.get(AUTHORIZATION) == null ? null : headers.get(AUTHORIZATION).toString();
+        BearerAuthorizationHeaders.checkIsValid(header);
+
+        try {
+            return jwtService.decode(BearerAuthorizationHeaders.getToken(header));
+        }
+        catch (final Exception failed) {
+            logger.error(
+                    "An internal error occurred while trying to authenticate the user.",
+                    failed);
+            throw failed;
+        }
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/MessageSecurityService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/MessageSecurityService.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.reporting.processor.service;
+
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.messaging.Message;
+
+/**
+ * Implementations of this interface are responsible for appending and retrieving
+ * authentication information to and from messages.
+ */
+public interface MessageSecurityService {
+
+    /**
+     * Append the user authentication to the given message.
+     *
+     * @param message   A message
+     * @param user      An authenticated user
+     * @param <T>       The message payload class
+     * @return  The message with user authentication
+     */
+    <T> Message<T> withUser(Message<T> message, User user);
+
+    /**
+     * Retrieve the user authentication from the given message.
+     *
+     * @param message   A message
+     * @return  The message's user authentication
+     */
+    User getUser(Message<?> message);
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGenerator.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGenerator.java
@@ -32,16 +32,19 @@ public class SpringStreamReportGenerator implements ReportGenerator {
     private final ExportExamsSource exportReportSource;
     private final FetchStudentsSource pdfReportSource;
     private final AggregateReportsSource aggregateReportsSource;
+    private final MessageSecurityService messageSecurityService;
 
     @Autowired
     public SpringStreamReportGenerator(final ReportService reportService,
                                        final ExportExamsSource exportReportSource,
                                        final FetchStudentsSource pdfReportSource,
-                                       final AggregateReportsSource aggregateReportsSource) {
+                                       final AggregateReportsSource aggregateReportsSource,
+                                       final MessageSecurityService messageSecurityService) {
         this.reportService = reportService;
         this.exportReportSource = exportReportSource;
         this.pdfReportSource = pdfReportSource;
         this.aggregateReportsSource = aggregateReportsSource;
+        this.messageSecurityService = messageSecurityService;
     }
 
     @Override
@@ -76,10 +79,11 @@ public class SpringStreamReportGenerator implements ReportGenerator {
         logger.debug("Publishing report generation request: {}", report.getId());
         final ReportRequestMessage payload = ReportRequestMessage.builder()
                 .reportId(report.getId())
-                .user(user)
                 .build();
 
-        final Message<ReportRequestMessage> message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
+        final Message<ReportRequestMessage> message = messageSecurityService.withUser(
+                MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>())),
+                user);
 
         switch (report.getReportRequest().getReportType()) {
             case ExamExport:

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportGenerator.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportGenerator.java
@@ -1,11 +1,14 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.service.AggregateReportService;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
 import static org.opentestsystem.rdw.reporting.processor.model.ReportStatus.FAILED;
@@ -20,21 +23,27 @@ public class AggregateReportGenerator {
 
     private final ReportService reportService;
     private final AggregateReportService aggregateReportService;
+    private final MessageSecurityService messageSecurityService;
 
     @Autowired
     public AggregateReportGenerator(final ReportService reportService,
-                                    final AggregateReportService aggregateReportService) {
+                                    final AggregateReportService aggregateReportService,
+                                    final MessageSecurityService messageSecurityService) {
         this.reportService = reportService;
         this.aggregateReportService = aggregateReportService;
+        this.messageSecurityService = messageSecurityService;
     }
 
     @StreamListener(AggregateReports)
-    public void collateReportPdf(final ReportRequestMessage message) {
-        Report report = reportService.findOneById(message.getReportId())
-                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + message.getReportId()));
+    public void collateReportPdf(final Message<ReportRequestMessage> message) {
+        final ReportRequestMessage payload = message.getPayload();
+        final User user = messageSecurityService.getUser(message);
+
+        Report report = reportService.findOneById(payload.getReportId())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + payload.getReportId()));
         if (report.getStatus() == FAILED) return;
 
-        report = aggregateReportService.generateReport(report, message.getUser());
+        report = aggregateReportService.generateReport(report, user);
 
         reportService.update(report);
     }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/ExportExams.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/ExportExams.java
@@ -1,15 +1,18 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
+import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.processor.model.ExportExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.service.ExamExportService;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -23,32 +26,38 @@ import static org.opentestsystem.rdw.reporting.processor.stream.ExportExamsSourc
 public class ExportExams {
 
     private final static Logger logger = LoggerFactory.getLogger(ExportExams.class);
-    private ExamExportService exportService;
-    private ReportService reportService;
+    private final ExamExportService exportService;
+    private final ReportService reportService;
+    private final MessageSecurityService messageSecurityService;
 
     @Autowired
     public ExportExams(final ExamExportService exportService,
-                       final ReportService reportService) {
+                       final ReportService reportService,
+                       final MessageSecurityService messageSecurityService) {
 
         this.exportService = exportService;
         this.reportService = reportService;
+        this.messageSecurityService = messageSecurityService;
     }
 
     @StreamListener(ReportExportExams)
-    public void exportExams(final ReportRequestMessage message) {
-        logger.debug("Exporting exams for report request: {}", message.getReportId());
-        final long reportId = message.getReportId();
+    public void exportExams(final Message<ReportRequestMessage> message) {
+        final ReportRequestMessage payload = message.getPayload();
+        final long reportId = payload.getReportId();
+        logger.debug("Exporting exams for report request: {}", reportId);
+
+        final User user = messageSecurityService.getUser(message);
 
         final Report report = reportService
-                .findOneById(message.getReportId())
-                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + message.getReportId()));
+                .findOneById(payload.getReportId())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + reportId));
 
         if (report.getStatus() == ReportStatus.FAILED) {
             return;
         }
 
         final ExportExamReportRequest request = (ExportExamReportRequest) report.getReportRequest();
-        final URI exportUri = exportService.exportExam(message.getUser(), request, reportId);
+        final URI exportUri = exportService.exportExam(user, request, reportId);
 
         final Report updated = Report.builder()
                 .copy(report)

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudents.java
@@ -15,6 +15,7 @@ import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.repository.StudentRepository;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,26 +55,30 @@ public class FetchStudents {
     private final ReportService reportService;
     private final ReportGenerationProperties reportGenerationProperties;
     private final FetchStudentsProcessor processor;
+    private final MessageSecurityService messageSecurityService;
 
     @Autowired
     public FetchStudents(final Set<ExamQueryParamsParser> queryParamsParsers,
                          final StudentRepository studentRepository,
                          final ReportService reportService,
                          final ReportGenerationProperties reportGenerationProperties,
-                         final FetchStudentsProcessor processor) {
+                         final FetchStudentsProcessor processor,
+                         final MessageSecurityService messageSecurityService) {
         this.queryParamsParsers = queryParamsParsers;
         this.studentRepository = studentRepository;
         this.reportService = reportService;
         this.reportGenerationProperties = reportGenerationProperties;
         this.processor = processor;
+        this.messageSecurityService = messageSecurityService;
     }
 
     @StreamListener(ReportFetchStudents)
-    public void fetchAndPublishStudents(final ReportRequestMessage message) {
-        logger.debug("Fetching students for report request: {}", message.getReportId());
-        final User user = message.getUser();
-        final Report report = reportService.findOneById(message.getReportId())
-                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + message.getReportId()));
+    public void fetchAndPublishStudents(final Message<ReportRequestMessage> message) {
+        logger.debug("Fetching students for report request: {}", message.getPayload().getReportId());
+        final User user = messageSecurityService.getUser(message);
+
+        final Report report = reportService.findOneById(message.getPayload().getReportId())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown Report: " + message.getPayload().getReportId()));
         if (report.getStatus() == ReportStatus.FAILED) return;
 
         //Find a registered ExamQueryParamsParser that can handle the request.
@@ -103,9 +108,9 @@ public class FetchStudents {
         reportService.update(updated);
 
         for (int chunkIdx = 0; chunkIdx < chunks.size(); chunkIdx++) {
-            publishProcessingMessage(user, message.getReportId(), chunkIdx, chunks.get(chunkIdx));
+            publishProcessingMessage(user, message.getPayload().getReportId(), chunkIdx, chunks.get(chunkIdx));
         }
-        logger.debug("Dispatched chunks for processing: {}", message.getReportId());
+        logger.debug("Dispatched chunks for processing: {}", message.getPayload().getReportId());
     }
 
     private Ordering<Student> getOrdering(final AbstractExamReportRequest reportRequest) {
@@ -132,11 +137,12 @@ public class FetchStudents {
                                           final List<Student> students) {
         final ProcessStudentChunkMessage payload = ProcessStudentChunkMessage.builder()
                 .reportId(reportId)
-                .user(user)
                 .index(chunkIdx)
                 .students(students)
                 .build();
-        final Message<ProcessStudentChunkMessage> message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
+        final Message<ProcessStudentChunkMessage> message = messageSecurityService.withUser(
+                MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>())),
+                user);
         processor.generateStudentReport().send(message);
     }
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
@@ -52,6 +52,7 @@ public class GeneratePdf {
     @StreamListener(ReportCollate)
     public void collateReportPdf(final ReportRequestMessage message) {
         logger.debug("Received report collation message for report: {}", message.getReportId());
+
         final Report report = reportService.findOneById(message.getReportId())
                 .orElseThrow(() -> new IllegalArgumentException("Unknown Report ID: " + message.getReportId()));
         if (report.getStatus() == ReportStatus.FAILED) return;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/ReportFailingChannelInterceptor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/ReportFailingChannelInterceptor.java
@@ -1,8 +1,8 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
-import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +13,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -25,10 +26,13 @@ public class ReportFailingChannelInterceptor extends ChannelInterceptorAdapter {
     private static final Logger logger = LoggerFactory.getLogger(ReportFailingChannelInterceptor.class);
 
     private final ReportService reportService;
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public ReportFailingChannelInterceptor(final ReportService reportService) {
+    public ReportFailingChannelInterceptor(final ReportService reportService,
+                                           final ObjectMapper objectMapper) {
         this.reportService = reportService;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -49,13 +53,21 @@ public class ReportFailingChannelInterceptor extends ChannelInterceptorAdapter {
     private void failReport(final Exception ex, final Message<?> message) {
         if (ex == null) return;
 
-        if (!ReportRequestMessage.class.isInstance(message.getPayload())) {
+        logger.debug("Problem processing report", ex);
+
+        ReportIdContainer container;
+        try {
+            container = objectMapper.readValue(message.getPayload().toString(), ReportIdContainer.class);
+        } catch (final IOException e) {
+            container = null;
+        }
+
+        if (container == null) {
             logger.warn("Unknown message payload: {}", message.getPayload());
             return;
         }
 
-        final ReportRequestMessage requestMessage = (ReportRequestMessage) message.getPayload();
-        final Optional<Report> reportOptional = reportService.findOneById(requestMessage.getReportId());
+        final Optional<Report> reportOptional = reportService.findOneById(container.getReportId());
         if (!reportOptional.isPresent()) return;
 
         final Report failedReport = Report.builder()
@@ -63,5 +75,17 @@ public class ReportFailingChannelInterceptor extends ChannelInterceptorAdapter {
                 .status(ReportStatus.FAILED)
                 .build();
         reportService.update(failedReport);
+    }
+
+    private static class ReportIdContainer {
+        private long reportId;
+
+        public long getReportId() {
+            return reportId;
+        }
+
+        public void setReportId(final long reportId) {
+            this.reportId = reportId;
+        }
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -19,6 +19,7 @@ import org.opentestsystem.rdw.reporting.processor.repository.IabReportRepository
 import org.opentestsystem.rdw.reporting.processor.repository.IcaReportRepository;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
 import org.opentestsystem.rdw.reporting.processor.service.HtmlToPdfProcessor;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportViewSupport;
@@ -74,6 +75,7 @@ public class StudentReportProcessor {
     private final HtmlToPdfProcessor htmlToPdfProcessor;
     private final RetryTemplate retryTemplate;
     private final GenerateStudentsReportProcessor processor;
+    private final MessageSecurityService messageSecurityService;
 
     @Autowired
     public StudentReportProcessor(final Set<ExamQueryParamsParser> queryParamsParsers,
@@ -85,7 +87,8 @@ public class StudentReportProcessor {
                                   final TemplateProcessor templateProcessor,
                                   final HtmlToPdfProcessor htmlToPdfProcessor,
                                   final RetryTemplate retryTemplate,
-                                  final GenerateStudentsReportProcessor processor) {
+                                  final GenerateStudentsReportProcessor processor,
+                                  final MessageSecurityService messageSecurityService) {
         this.queryParamsParsers = queryParamsParsers;
         this.iabReportRepository = iabReportRepository;
         this.icaReportRepository = icaReportRepository;
@@ -96,18 +99,24 @@ public class StudentReportProcessor {
         this.htmlToPdfProcessor = htmlToPdfProcessor;
         this.retryTemplate = retryTemplate;
         this.processor = processor;
+        this.messageSecurityService = messageSecurityService;
     }
 
     @StreamListener(ReportGenerateForStudents)
-    public void generateStudentChunkReport(final ProcessStudentChunkMessage message) {
+    public void generateStudentChunkReport(final Message<ProcessStudentChunkMessage> message) {
+        final ProcessStudentChunkMessage payload = message.getPayload();
         logger.debug("Received chunk report generation message for reportId: {} chunk: {}",
-                message.getReportId(),
-                message.getIndex());
-        final Report report = reportService.findOneById(message.getReportId())
-                .orElseThrow(() -> new IllegalArgumentException("Unknown report: " + message.getReportId()));
+                payload.getReportId(),
+                payload.getIndex());
+
+
+        final Report report = reportService.findOneById(payload.getReportId())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown report: " + payload.getReportId()));
         if (report.getStatus() == ReportStatus.FAILED) return;
 
-        final Map<Long, StudentCompositeReport> studentReports = message.getStudents().stream()
+        final User user = messageSecurityService.getUser(message);
+
+        final Map<Long, StudentCompositeReport> studentReports = payload.getStudents().stream()
                 .collect(Collectors.toMap(
                         Student::getId,
                         student -> StudentCompositeReport.builder()
@@ -115,44 +124,44 @@ public class StudentReportProcessor {
                                 .build()
                 ));
 
-        final ExamQueryParams queryParams = getQueryParams(message.getReportId(), report.getReportRequest());
+        final ExamQueryParams queryParams = getQueryParams(payload.getReportId(), report.getReportRequest());
 
         if (includeReports(IAB, queryParams)) {
-            appendIABReports(studentReports, message.getUser(), studentReports.keySet(), queryParams);
+            appendIABReports(studentReports, user, studentReports.keySet(), queryParams);
         }
         if (includeReports(ICA, queryParams)) {
-            appendICAReports(studentReports, message.getUser(), studentReports.keySet(), queryParams);
+            appendICAReports(studentReports, user, studentReports.keySet(), queryParams);
         }
         //TODO Append Summative Reports
 
-        final List<StudentCompositeReport> orderedReports = message.getStudents().stream()
+        final List<StudentCompositeReport> orderedReports = payload.getStudents().stream()
                 .map(student -> studentReports.get(student.getId()))
                 .collect(Collectors.toList());
 
-        logger.debug("Processing report: {} chunk: {} writing html", report.getId(), message.getIndex());
+        logger.debug("Processing report: {} chunk: {} writing html", report.getId(), payload.getIndex());
         final byte[] html = writeReportHtml(orderedReports, report.getReportRequest());
 
         try {
             retryTemplate.execute((RetryCallback<Void, IOException>) retryContext -> {
                 try (final InputStream pdfStream = htmlToPdfProcessor.process(html, (PrintOptions) report.getReportRequest().getOptions())) {
                     //Store chunk PDF contents
-                    logger.debug("Processing report: {} chunk: {} writing pdf bytes", report.getId(), message.getIndex());
-                    temporaryStorage.writeChunk(message.getReportId(), message.getIndex(), pdfStream);
+                    logger.debug("Processing report: {} chunk: {} writing pdf bytes", report.getId(), payload.getIndex());
+                    temporaryStorage.writeChunk(payload.getReportId(), payload.getIndex(), pdfStream);
                 }
                 return null;
             }, retryContext -> {
                 logger.warn("Unable to convert report chunk HTML to PDF report: {} chunk: {}",
                         report.getId(),
-                        message.getIndex(),
+                        payload.getIndex(),
                         retryContext.getLastThrowable());
                 throw new IllegalStateException("Unable to convert report chunk HTML to PDF");
             });
 
-            logger.debug("Report: {} Chunk: {} complete", report.getId(), message.getIndex());
+            logger.debug("Report: {} Chunk: {} complete", report.getId(), payload.getIndex());
         } catch (final IOException e) {
             throw new RuntimeException(
-                    "Failed to generate report chunk. ReportId: " + message.getReportId() +
-                            " ChunkIdx: " + message.getIndex(),
+                    "Failed to generate report chunk. ReportId: " + payload.getReportId() +
+                            " ChunkIdx: " + payload.getIndex(),
                     e);
         }
 
@@ -165,8 +174,8 @@ public class StudentReportProcessor {
                 ? 0
                 : parseInt(metadata.get(CompletedChunk));
         if (completedChunkCount == totalChunkCount) {
-            publishCollationMessage(completed);
-            logger.debug("Report: {} all chunks complete", message.getReportId());
+            publishCollationMessage(completed, user);
+            logger.debug("Report: {} all chunks complete", payload.getReportId());
         }
     }
 
@@ -228,11 +237,13 @@ public class StudentReportProcessor {
         return parser.parseQueryParams(request);
     }
 
-    private void publishCollationMessage(final Report report) {
+    private void publishCollationMessage(final Report report, final User user) {
         final ReportRequestMessage payload = ReportRequestMessage.builder()
                 .reportId(report.getId())
                 .build();
-        final Message<ReportRequestMessage> message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
+        final Message<ReportRequestMessage> message = messageSecurityService.withUser(
+                MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>())),
+                user);
         processor.collateStudentReportsOutput().send(message);
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplicationIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplicationIT.java
@@ -1,17 +1,42 @@
 package org.opentestsystem.rdw.reporting.processor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
+import org.opentestsystem.rdw.reporting.processor.test.support.UserTestBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @SpringBootTest
 public class ReportProcessorApplicationIT {
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     public void contextLoads() {
+    }
+
+    @Test
+    public void itShouldSerializeAndDeserializeReportRequestMessages() throws Exception {
+        final User user = UserTestBuilder.user();
+
+        final ReportRequestMessage message = ReportRequestMessage.builder()
+                .user(user)
+                .reportId(123L)
+                .build();
+        final String serializedMessage = objectMapper.writeValueAsString(message);
+
+        final ReportRequestMessage deserializedMessage = objectMapper.readValue(serializedMessage, ReportRequestMessage.class);
+        assertThat(deserializedMessage.getReportId()).isEqualTo(123L);
+        assertThat(message.getUser()).isEqualToComparingFieldByFieldRecursively(user);
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplicationIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/ReportProcessorApplicationIT.java
@@ -1,42 +1,17 @@
 package org.opentestsystem.rdw.reporting.processor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.reporting.common.web.security.User;
-import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
-import org.opentestsystem.rdw.reporting.processor.test.support.UserTestBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @SpringBootTest
 public class ReportProcessorApplicationIT {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @Test
     public void contextLoads() {
-    }
-
-    @Test
-    public void itShouldSerializeAndDeserializeReportRequestMessages() throws Exception {
-        final User user = UserTestBuilder.user();
-
-        final ReportRequestMessage message = ReportRequestMessage.builder()
-                .user(user)
-                .reportId(123L)
-                .build();
-        final String serializedMessage = objectMapper.writeValueAsString(message);
-
-        final ReportRequestMessage deserializedMessage = objectMapper.readValue(serializedMessage, ReportRequestMessage.class);
-        assertThat(deserializedMessage.getReportId()).isEqualTo(123L);
-        assertThat(message.getUser()).isEqualToComparingFieldByFieldRecursively(user);
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultMessageSecurityServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultMessageSecurityServiceTest.java
@@ -1,0 +1,62 @@
+package org.opentestsystem.rdw.reporting.processor.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.common.web.security.jwt.JwtService;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultMessageSecurityServiceTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private User user;
+
+    private DefaultMessageSecurityService service;
+
+    @Before
+    public void setup() {
+        when(jwtService.encode(any(User.class))).thenReturn("encoded_user");
+        when(jwtService.decode(any(String.class))).thenReturn(user);
+
+        service = new DefaultMessageSecurityService(jwtService);
+    }
+
+    @Test
+    public void itShouldEncodeAUserAsAMessageHeader() {
+        final Message<String> original = MessageBuilder.createMessage("payload", new MessageHeaders(new HashMap<>()));
+        final Message<String> encoded = service.withUser(original, user);
+        assertThat(encoded.getHeaders().get(AUTHORIZATION)).isEqualTo("Bearer encoded_user");
+    }
+
+    @Test
+    public void itShouldDecodeAUserAsAMessageHeader() {
+        final MessageHeaders authHeaders = new MessageHeaders(ImmutableMap.of(AUTHORIZATION, "Bearer some_user"));
+        final Message<String> message = MessageBuilder.createMessage("payload", authHeaders);
+
+        final User decodedUser = service.getUser(message);
+        assertThat(decodedUser).isEqualTo(user);
+
+        final ArgumentCaptor<String> encodedUserCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jwtService).decode(encodedUserCaptor.capture());
+        assertThat(encodedUserCaptor.getValue()).isEqualTo("some_user");
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/SpringStreamReportGeneratorTest.java
@@ -44,6 +44,9 @@ public class SpringStreamReportGeneratorTest {
     @Mock
     private AggregateReportsSource aggregateReportsSource;
 
+    @Mock
+    private MessageSecurityService messageSecurityService;
+
     @Captor
     private ArgumentCaptor<Message<ReportRequestMessage>> messageCaptor;
 
@@ -54,7 +57,10 @@ public class SpringStreamReportGeneratorTest {
         final MessageChannel channel = mock(MessageChannel.class);
         when(pdfSource.fetchStudents()).thenReturn(channel);
 
-        generator = new SpringStreamReportGenerator(reportService, exportSource, pdfSource, aggregateReportsSource);
+        when(messageSecurityService.withUser(any(Message.class), any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgumentAt(0, Message.class));
+
+        generator = new SpringStreamReportGenerator(reportService, exportSource, pdfSource, aggregateReportsSource, messageSecurityService);
     }
 
     @Test
@@ -78,7 +84,6 @@ public class SpringStreamReportGeneratorTest {
         verify(pdfSource.fetchStudents()).send(messageCaptor.capture());
         final ReportRequestMessage payload = messageCaptor.getValue().getPayload();
         assertThat(payload.getReportId()).isEqualTo(report.getId());
-        assertThat(payload.getUser()).isEqualTo(user);
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/ExportExamsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/ExportExamsTest.java
@@ -12,15 +12,20 @@ import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.service.ExamExportService;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
-import org.opentestsystem.rdw.reporting.processor.test.support.UserTestBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,11 +41,16 @@ public class ExportExamsTest {
     @Mock
     private ReportService reportService;
 
-    private final ReportRequestMessage message = ReportRequestMessage
+    @Mock
+    private MessageSecurityService messageSecurityService;
+
+    private final ReportRequestMessage payload = ReportRequestMessage
             .builder()
             .reportId(1L)
-            .user(UserTestBuilder.user())
             .build();
+
+    private final Message<ReportRequestMessage> message = MessageBuilder
+            .createMessage(payload, new MessageHeaders(Collections.emptyMap()));
 
     private final Report report = Report
             .builder()
@@ -51,7 +61,9 @@ public class ExportExamsTest {
 
     @Before
     public void setup() {
-        component = new ExportExams(exportService, reportService);
+        final User mockUser = mock(User.class);
+        when(messageSecurityService.getUser(any(Message.class))).thenReturn(mockUser);
+        component = new ExportExams(exportService, reportService, messageSecurityService);
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/FetchStudentsTest.java
@@ -18,10 +18,14 @@ import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.repository.StudentRepository;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
 
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -57,23 +61,33 @@ public class FetchStudentsTest {
     @Mock
     private FetchStudentsProcessor processor;
 
+    @Mock
+    private MessageSecurityService messageSecurityService;
+
     @Captor
     private ArgumentCaptor<Report> reportCaptor;
 
     @Captor
     private ArgumentCaptor<Message<ProcessStudentChunkMessage>> messageCaptor;
 
-    private ReportRequestMessage message;
+    private ReportRequestMessage payload;
+    private Message<ReportRequestMessage> message;
     private Set<ExamQueryParamsParser> queryParamsParsers;
     private ReportGenerationProperties reportGenerationProperties;
     private FetchStudents component;
 
     @Before
     public void setup() throws Exception {
-        message = ReportRequestMessage.builder()
+        payload = ReportRequestMessage.builder()
                 .reportId(123L)
-                .user(mock(User.class))
                 .build();
+        message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
+
+        final User mockUser = mock(User.class);
+        when(messageSecurityService.getUser(any(Message.class))).thenReturn(mockUser);
+        when(messageSecurityService.withUser(any(Message.class), any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgumentAt(0, Message.class));
+
 
         when(reportService.findOneById(123L)).thenReturn(Optional.of(report));
 
@@ -83,7 +97,7 @@ public class FetchStudentsTest {
         when(processor.generateStudentReport()).thenReturn(channel);
 
         queryParamsParsers = new LinkedHashSet<>();
-        component = new FetchStudents(queryParamsParsers, studentRepository, reportService, reportGenerationProperties, processor);
+        component = new FetchStudents(queryParamsParsers, studentRepository, reportService, reportGenerationProperties, processor, messageSecurityService);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/ReportFailingChannelInterceptorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/ReportFailingChannelInterceptorTest.java
@@ -1,15 +1,19 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.model.Student;
+import org.opentestsystem.rdw.reporting.processor.model.ProcessStudentChunkMessage;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.model.ReportStatus;
-import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -35,17 +39,21 @@ public class ReportFailingChannelInterceptorTest {
     @Mock
     private MessageChannel channel;
 
-    private Message<ReportRequestMessage> message;
+    private Message<?> message;
     private ReportFailingChannelInterceptor interceptor;
 
     @Before
-    public void setup() {
-        interceptor = new ReportFailingChannelInterceptor(service);
+    public void setup() throws Exception {
+        final ObjectMapper objectMapper = new Jackson2ObjectMapperBuilder().failOnUnknownProperties(false).build();
 
-        final ReportRequestMessage reportMessage = ReportRequestMessage.builder()
+        interceptor = new ReportFailingChannelInterceptor(service, objectMapper);
+
+        final ProcessStudentChunkMessage reportMessage = ProcessStudentChunkMessage.builder()
                 .reportId(ReportId)
+                .index(0)
+                .students(ImmutableList.of(Student.builder().id(123).ssid("123").build()))
                 .build();
-        message = MessageBuilder.createMessage(reportMessage, new MessageHeaders(new HashMap<>()));
+        message = MessageBuilder.createMessage(objectMapper.writeValueAsString(reportMessage), new MessageHeaders(new HashMap<>()));
 
         final Report report = report(ReportId);
         when(service.findOneById(ReportId)).thenReturn(Optional.of(report));

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
@@ -26,10 +26,14 @@ import org.opentestsystem.rdw.reporting.processor.repository.IabReportRepository
 import org.opentestsystem.rdw.reporting.processor.repository.IcaReportRepository;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
 import org.opentestsystem.rdw.reporting.processor.service.HtmlToPdfProcessor;
+import org.opentestsystem.rdw.reporting.processor.service.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
 import org.opentestsystem.rdw.reporting.processor.service.ReportService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportViewSupport;
 import org.opentestsystem.rdw.reporting.processor.service.TemplateProcessor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -93,6 +97,12 @@ public class StudentReportProcessorTest {
     @Mock
     private GenerateStudentsReportProcessor processor;
 
+    @Mock
+    private MessageSecurityService messageSecurityService;
+
+    @Mock
+    private User user;
+
     @Captor
     private ArgumentCaptor<ExamQueryParams> examFilterCaptor;
 
@@ -102,7 +112,8 @@ public class StudentReportProcessorTest {
     @Captor
     private ArgumentCaptor<Map<String, Object>> templateProcessorModelCaptor;
 
-    private ProcessStudentChunkMessage message;
+    private ProcessStudentChunkMessage payload;
+    private Message<ProcessStudentChunkMessage> message;
     private Set<ExamQueryParamsParser> queryParamsParsers;
     private StudentReportProcessor writer;
 
@@ -122,12 +133,13 @@ public class StudentReportProcessorTest {
         when(reportService.completeChunk(any(Report.class))).thenAnswer(invocation ->
                 invocation.getArgumentAt(0, Report.class));
 
-        message = ProcessStudentChunkMessage.builder()
+        payload = ProcessStudentChunkMessage.builder()
                 .reportId(ReportId)
                 .students(newArrayList(
                         student(1L).copy().lastName("LastA").build(),
                         student(2L).copy().lastName("LastB").build()))
                 .build();
+        message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
 
         queryParamsParsers = new LinkedHashSet<>();
         final ExamQueryParamsParser accepting = accepting();
@@ -154,6 +166,10 @@ public class StudentReportProcessorTest {
         when(htmlToPdfProcessor.process(eq(htmlContent), eq(printOptions)))
                 .thenAnswer(invocation -> new ByteArrayInputStream(pdfConetnt));
 
+        when(messageSecurityService.getUser(any(Message.class))).thenReturn(user);
+        when(messageSecurityService.withUser(any(Message.class), any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgumentAt(0, Message.class));
+
         writer = new StudentReportProcessor(
                 queryParamsParsers,
                 iabReportRepository,
@@ -164,7 +180,8 @@ public class StudentReportProcessorTest {
                 templateProcessor,
                 htmlToPdfProcessor,
                 retryTemplate,
-                processor);
+                processor,
+                messageSecurityService);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -314,7 +331,7 @@ public class StudentReportProcessorTest {
     public void itShouldWritePdfContentsToTemporaryStorage() throws Exception {
         writer.generateStudentChunkReport(message);
 
-        verify(temporaryStorage).writeChunk(eq(message.getReportId()), eq(0), any(InputStream.class));
+        verify(temporaryStorage).writeChunk(eq(payload.getReportId()), eq(0), any(InputStream.class));
     }
 
     private ExamQueryParamsParser accepting() {


### PR DESCRIPTION
In QA we're having issues deserializing User instances as part of a ReportRequestMessage.  This PR registers a mixin that tells Jackson how to deserialize User instances.