### PR TITLE
Feature/dwr 1348 misc cleanup

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -109,10 +109,13 @@
               class="btn btn-default">{{'labels.groups.results.value-as-number' | translate}}
       </button>
     </div>
+
     <button class="btn btn-default btn-xs pull-right" (click)="allCollapsed = !allCollapsed">
       <span *ngIf="!allCollapsed">{{'labels.groups.results.collapse-all' | translate}} <i class="fa fa-angle-up"></i></span>
       <span *ngIf="allCollapsed">{{'labels.groups.results.expand-all' | translate}} <i class="fa fa-angle-down"></i></span>
     </button>
+
+    <button class="btn btn-default btn-xs pull-right mr-sm" (click)="callExport()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
   </div>
 </h2>
 

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import {Component, EventEmitter, Input, OnInit, Output} from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { ordering } from "@kourge/ordering";
 import { FilterBy } from "./model/filter-by.model";
@@ -58,6 +58,9 @@ export class AssessmentsComponent implements OnInit {
    */
   @Input()
   allowFilterBySessions: boolean = true;
+
+  @Output()
+  export: EventEmitter<any> = new EventEmitter<any>();
 
   showValuesAsPercent: boolean = true;
   filterDisplayOptions: any = {
@@ -236,6 +239,10 @@ export class AssessmentsComponent implements OnInit {
     setTimeout(() => {
       document.getElementById('results-adv-filters').scrollIntoView();
     }, 0);
+  }
+
+  callExport() {
+    this.export.emit();
   }
 
   private updateFilterOptions() {

--- a/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
@@ -19,7 +19,7 @@
               <span class="font-large">
                 <span class="score">{{ statistics.total }}</span>
               </span>
-              <span class="pl-xs">{{ (statistics.total == 1 ? 'labels.assessments.student' : 'labels.assessments.students') | translate }}</span>
+              <span class="pl-xs">{{ (statistics.total == 1 ? 'labels.assessments.result' : 'labels.assessments.results') | translate }}</span>
             </span>
           </div>
         </td>

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -1,7 +1,6 @@
 <div class="mb-md" *ngIf="currentGroup">
   <span class="h3 blue-dark">{{'labels.groups.name' | translate}}</span>
   <span class="pull-right text-right">
-    <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
     <a *hasPermission="'INDIVIDUAL_PII_READ'" routerLink="/custom-export" class="btn btn-sm btn-default ml-xs"><i class="fa fa-table"></i> {{'labels.organization-export.title' | translate}}</a>
     <button class="btn btn-default btn-sm ml-xs" (click)="reportDownloader.modal.show()"><i class="fa fa-cloud-download" aria-hidden="true"></i> {{'labels.reports.button-label.group' | translate}}</button>
     <span group-report-download #reportDownloader
@@ -18,6 +17,7 @@
 <assessments [assessmentExams]="assessmentExams"
              [assessmentProvider]="assessmentProvider"
              [assessmentExporter]="assessmentExporter"
+             (export)="exportCsv()"
              [allowFilterBySessions]="true">
 
   <!-- Group Select -->

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -6,7 +6,6 @@
   <div class="mb-md">
     <span class="h3 blue-dark">{{currentSchool.name}}<span *ngIf="currentGrade"> - {{currentGrade.code | gradeDisplay:'long-name'}}</span></span>
     <span class="pull-right text-right">
-      <button class="btn btn-default btn-sm" (click)="exportCsv()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
       <a *hasPermission="'INDIVIDUAL_PII_READ'" routerLink="/custom-export" class="btn btn-sm btn-default ml-xs"><i class="fa fa-table"></i> {{'labels.organization-export.title' | translate}}</a>
       <button class="btn btn-default btn-sm ml-xs" (click)="reportDownloader.modal.show()"><i class="fa fa-cloud-download" aria-hidden="true"></i> {{'labels.reports.button-label.school-grade' | translate}}</button>
       <span school-grade-report-download #reportDownloader
@@ -22,6 +21,7 @@
                [hideAssessments]="gradesAreUnavailable"
                [assessmentProvider]="assessmentProvider"
                [assessmentExporter]="assessmentExporter"
+               (export)="exportCsv()"
                [allowFilterBySessions]="false">
 
     <!-- School Select -->

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -410,7 +410,7 @@
     "results-view-state": {
       "ByItem": "Results By Item",
       "ByStudent": "Results By Student",
-      "DistractorAnalysis": "Distractor Analysis",
+      "DistractorAnalysis": "Key / Distractor Analysis",
       "WritingTraitScores": "Writing Trait Scores"
     },
     "status": {
@@ -1007,7 +1007,7 @@
         "target": "Target"
       },
       "csv": "Export CSV",
-      "distractor-analysis": "Export Distractor Analysis",
+      "distractor-analysis": "Export Key / Distractor Analysis",
       "items-by-points-earned": "Export Results By Item",
       "title": "Export"
     },
@@ -1566,8 +1566,8 @@
     "coming-soon": "{{featureName}} is coming soon.",
     "loading": "Loading",
     "logout": "Logout",
-    "no-distractor-analysis": "Distractor analysis is not available for assessments administered prior to 2017-18 school year.",
-    "no-distractor-analysis-for-summative-exams": "Distractor analysis is not available for summative assessments.",
+    "no-distractor-analysis": "Key / Distractor Analysis is not available for assessments administered prior to 2017-18 school year.",
+    "no-distractor-analysis-for-summative-exams": "Key / Distractor Analysis is not available for summative assessments.",
     "no-results-by-item": "Results by item is not available for assessments administered prior to 2017-18 school year.",
     "no-results-by-item-for-summative-exams": "Results by item is not available for summative assessments.",
     "no-results-found": "No test results are available for the current selection.  If a new school year has begun recently, please check the year selected above.",

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1007,8 +1007,6 @@
         "target": "Target"
       },
       "csv": "Export CSV",
-      "distractor-analysis": "Export Key / Distractor Analysis",
-      "items-by-points-earned": "Export Results By Item",
       "title": "Export"
     },
     "filters": {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -865,11 +865,11 @@
           "student-scores-intro-text": "Expand each student row to view their response to this item."
         }
       },
+      "result": "Result",
+      "results": "Results",
       "student-score-distribution": {
         "title": "Student Score Distribution"
-      },
-      "student": "Student",
-      "students": "Students"
+      }
     },
     "instructional-resources": {
       "link": {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1371,7 +1371,7 @@
           "success-html": "Creating export."
         }
       },
-      "title": "Custom Exports"
+      "title": "District / School Exports"
     },
     "organization-tree": {
       "header": "Selected Organizations",


### PR DESCRIPTION
1. "Distractor Analysis" shall be replaced with "Key / Distractor Analysis".
2. In the "Average" summary at the top, replace "# Students" with "# Results".
3. "Custom Exports" shall be replaced with "District / School Exports"; both the button and the page title (and anywhere else you see it).
4. Move the "Export CSV" button down to the "Results" header line, perhaps just to the left of "Show value as".

![image](https://user-images.githubusercontent.com/341584/35552832-7055df12-054a-11e8-98e3-ee17aa540bb2.png)
