### PR TITLE
byString ordering does not handle undefined.  protect against this so…

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/form/sb-typeahead.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-typeahead.component.ts
@@ -70,7 +70,7 @@ export class SBTypeahead implements OnInit {
         ? options
           .sort(
             join(
-              ordering(byString).on<Option>(o => o.group).compare,
+              ordering(byString).on<Option>(o => o.group === undefined ? '' : o.group).compare,
               ordering(byString).on<Option>(o => o.label).compare
             ))
         : [];


### PR DESCRIPTION
… sorting can still happen in the case where there is no group provided in the typeahead Option

The underlying cause is that when the user only has access to schools, when the `/api/organizations/districts' endpoint is called it returns nothing, and that is being used to populate the grouping property for the typeahead options.  So this fix cause the typeahead to work and not blow up.

I'll be creating another lower priority story to refactor some things to better solve the underlying issue.

![image](https://user-images.githubusercontent.com/341584/35596753-0a74cdb2-05d0-11e8-9d09-311e48eb6aa5.png)
