### PR TITLE
DWR-1324 OLAP API: modify Report Query object and API - part 2

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.olap.repository.impl;
 
-import com.google.common.collect.ImmutableList;
 import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.olap.model.Assessment;
 import org.opentestsystem.rdw.olap.model.Dimension;
@@ -25,12 +24,9 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
-import static org.opentestsystem.rdw.reporting.common.model.ReportQuery.checkIsValid;
 
 @Repository
 class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRepository {
-
-    private static final List<Integer> UNMATCHABLE_INT_IDS = ImmutableList.of(-1);
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final ReportQueryProvider customAggregateQueryProvider;
@@ -46,7 +42,6 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     }
 
     private static void validate(final ReportQuery query) {
-        checkIsValid(query);
         checkArgument(query.getAssessmentTypeId() != AssessmentType.IAB.id(), "custom aggregate report for IAB is not supported yet");
     }
 
@@ -102,8 +97,7 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     @Override
     public int estimateReportRowCount(@NotNull final ReportQuery query) {
 
-        validate(query);
-
+//        validate(query);
 //        final Set<DimensionType> dimensionTypes = query.getDimensionTypes();
 //        final MapSqlParameterSource parameterSource = new MapSqlParameterSource()
 //                .addValue("school_years", query.getSchoolYears())

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
@@ -1,17 +1,6 @@
 package org.opentestsystem.rdw.olap.sqlbuilder;
 
 import com.google.common.collect.ImmutableList;
-import org.opentestsystem.rdw.olap.model.Assessment;
-import org.opentestsystem.rdw.olap.model.CodedEntity;
-import org.opentestsystem.rdw.olap.model.Dimension;
-import org.opentestsystem.rdw.olap.repository.ActiveAssessmentRepository;
-import org.opentestsystem.rdw.olap.repository.BooleanRepository;
-import org.opentestsystem.rdw.olap.repository.CodedEntityRepository;
-import org.opentestsystem.rdw.olap.repository.EthnicityRepository;
-import org.opentestsystem.rdw.olap.repository.GenderRepository;
-import org.opentestsystem.rdw.olap.repository.OrganizationRepository;
-import org.opentestsystem.rdw.olap.repository.StrictBooleanRepository;
-import org.opentestsystem.rdw.olap.repository.SubjectRepository;
 import org.opentestsystem.rdw.olap.sqlbuilder.QueryWithReportTemplate.Builder;
 import org.opentestsystem.rdw.reporting.common.model.DimensionType;
 import org.opentestsystem.rdw.reporting.common.model.Organization;
@@ -24,9 +13,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 import static org.opentestsystem.rdw.olap.sqlbuilder.QueryWithReportTemplate.builder;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.EconomicDisadvantage;
@@ -35,8 +25,8 @@ import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Gender
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.IEP;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.LEP;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.MigrantStatus;
-import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Section504;
+import static org.opentestsystem.rdw.reporting.common.model.ReportQuery.checkIsValid;
 
 /**
  * This implementation is responsible for constructing a custom aggregate query.
@@ -54,81 +44,64 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
 
     private final Organization state;
     private final QueryProvider queryProvider;
-    private final OrganizationRepository organizationRepository;
-    private final ActiveAssessmentRepository activeAssessmentRepository;
-    private final GenderRepository genderRepository;
-    private final EthnicityRepository ethnicityRepository;
-    private final BooleanRepository booleanRepository;
-    private final StrictBooleanRepository strictBooleanRepository;
-    private final SubjectRepository subjectRepository;
+    private final ReportQueryRepositoryHelper repositoryHelper;
 
     @Autowired
     public CustomAggregateQueryProvider(@Value("${app.state.name}") final String stateName,
                                         final QueryProvider queryProvider,
-                                        final OrganizationRepository organizationRepository,
-                                        final ActiveAssessmentRepository activeAssessmentRepository,
-                                        final GenderRepository genderRepository,
-                                        final EthnicityRepository ethnicityRepository,
-                                        final BooleanRepository booleanRepository,
-                                        final StrictBooleanRepository strictBooleanRepository,
-                                        final SubjectRepository subjectRepository) {
+                                        final ReportQueryRepositoryHelper repositoryHelper) {
         this.queryProvider = queryProvider;
-        this.organizationRepository = organizationRepository;
-        this.activeAssessmentRepository = activeAssessmentRepository;
-        this.genderRepository = genderRepository;
-        this.ethnicityRepository = ethnicityRepository;
-        this.booleanRepository = booleanRepository;
-        this.strictBooleanRepository = strictBooleanRepository;
-        this.subjectRepository = subjectRepository;
+        this.repositoryHelper = repositoryHelper;
 
         state = Organization.builder().name(stateName).organizationType(OrganizationType.State).build();
     }
 
     public Iterable<QueryWithReportTemplate> toQuery(final ReportQuery query) {
-
-        final List<QueryWithReportTemplate> queries = newArrayList();
+        checkIsValid(query);
 
         final Builder templateBuilder = toBuilderWithCommonAttributes(query);
 
+        final List<QueryWithReportTemplate> queries = newArrayList();
         for (final DimensionType dimension : query.getDimensionTypes()) {
-
             final Builder dimensionTemplateBuilder = toBuilderWithFiltersAndDimensions(dimension, query).copy(templateBuilder);
-
-            // build queries for each level of organization included into the query
-            if (query.isIncludeState()) {
-                queries.add(buildQuery(builder()
-                        .addOn(stateAddOn)
-                        .state(state)
-                        .copy(dimensionTemplateBuilder)));
-            }
-
-            if (query.isIncludeAllDistricts()) {
-                queries.add(buildQuery(builder()
-                        .addOn(allDistrictsAddOn)
-                        .districts(organizationRepository.findMapOfDistrictsByIds().values())
-                        .copy(dimensionTemplateBuilder)));
-            } else if (!query.getDistrictIds().isEmpty()) {
-                queries.add(buildQuery(toBuilderWithDistrictIds(query.getDistrictIds()).
-                        copy(dimensionTemplateBuilder)));
-            }
-
-            if (query.isIncludeAllSchoolsOfDistricts()) {
-                queries.add(buildQuery(toBuilderWithAllSchoolsOfDistricts(query.getDistrictIds())
-                        .copy(dimensionTemplateBuilder)));
-            }
-
-            if (query.isIncludeAllDistrictsOfSchools()) {
-                //TODO:
-            }
-
-
-            if (!query.getSchoolIds().isEmpty()) {
-                queries.add(buildQuery(toBuilderWithSchoolIds(query.getSchoolIds())
-                        .copy(dimensionTemplateBuilder)));
-            }
-
+            appendState(query, queries, dimensionTemplateBuilder);
+            appendDistricts(query, queries, dimensionTemplateBuilder);
+            appendSchools(query, queries, dimensionTemplateBuilder);
         }
         return queries;
+    }
+
+    private void appendState(final ReportQuery query, final List<QueryWithReportTemplate> queries, final Builder dimensionTemplateBuilder) {
+        if (query.isIncludeState()) {
+            queries.add(buildQuery(builder().addOn(stateAddOn).state(state).copy(dimensionTemplateBuilder)));
+        }
+    }
+
+    private void appendDistricts(final ReportQuery query, final List<QueryWithReportTemplate> queries, final Builder dimensionTemplateBuilder) {
+        if (query.isIncludeAllDistricts()) {
+            queries.add(buildQuery(builder().addOn(allDistrictsAddOn).districts(repositoryHelper.findAllDistricts()).copy(dimensionTemplateBuilder)));
+        } else if (!query.getDistrictIds().isEmpty() || query.isIncludeAllDistrictsOfSchools()) {
+            queries.add(buildQuery(toBuilderWithDistrictIds(query).copy(dimensionTemplateBuilder)));
+        }
+    }
+
+    private void appendSchools(final ReportQuery query, final List<QueryWithReportTemplate> queries, final Builder dimensionTemplateBuilder) {
+        //schools could be selected individually or as part of a district selection
+        final Set<Long> districtsWithAllSchools = newHashSet();
+        if (query.isIncludeAllSchoolsOfDistricts()) {
+            districtsWithAllSchools.addAll(query.isIncludeAllDistricts() ? repositoryHelper.findAllDistrictIds() : query.getDistrictIds());
+            queries.add(buildQuery(toBuilderWithAllSchoolsOfDistricts(districtsWithAllSchools).copy(dimensionTemplateBuilder)));
+        }
+
+        if (!query.getSchoolIds().isEmpty()) {
+            //to avoid duplicate schools we need to filter those that are already included as part of districts selection
+            Set<Long> schoolIds = query.getSchoolIds();
+            if (query.isIncludeAllSchoolsOfDistricts()) {
+                final Set<Long> schoolsIncludedAsAllOfDistricts = repositoryHelper.findSchoolsIdsByDistrictIds(districtsWithAllSchools);
+                schoolIds = schoolIds.stream().filter(s -> !schoolsIncludedAsAllOfDistricts.contains(s)).collect(toSet());
+            }
+            if (!schoolIds.isEmpty()) queries.add(buildQuery(toBuilderWithSchoolIds(schoolIds).copy(dimensionTemplateBuilder)));
+        }
     }
 
     /**
@@ -139,62 +112,36 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
      * @return {@link ReportQuery.Builder} initialized with the common parameters
      */
     private Builder toBuilderWithCommonAttributes(final ReportQuery query) {
-
-        final Builder builder = builder()
+        return builder()
                 .parameter("school_years", query.getSchoolYears())
                 .parameter("asmt_grade_ids", query.getAssessmentGradeIds())
                 .parameter("subject_ids", query.getSubjectIds())
-                .parameter("asmt_type_id", query.getAssessmentTypeId());
-
-
-        for (final Assessment assessment : activeAssessmentRepository.findAllByTypeId(query.getAssessmentTypeId())) {
-            if (query.getSchoolYears().contains(assessment.getExamSchoolYear())
-                    && query.getSubjectIds().contains(toId(assessment.getSubjectCode(), subjectRepository))
-                    && query.getAssessmentGradeIds().contains(assessment.getGradeId())) {
-                builder.assessment(assessment);
-            }
-        }
-        return builder;
+                .parameter("asmt_type_id", query.getAssessmentTypeId())
+                .assessments(repositoryHelper.findAssessmentsForQuery(query));
     }
 
-    private Builder toBuilderWithDistrictIds(final Set<Long> districtIds) {
-        final Builder builder = builder()
+    private Builder toBuilderWithDistrictIds(final ReportQuery query) {
+        final Set<Long> districtIds = newHashSet(query.getDistrictIds());
+        if (query.isIncludeAllDistrictsOfSchools()) districtIds.addAll(repositoryHelper.findAllDistrictsOfSchools(query.getSchoolIds()));
+        return builder()
                 .addOn(allDistrictsAddOn)
                 .addOn(districtsAddOn)
-                .parameter("district_ids", districtIds);
-
-        for (final Long districtId : districtIds) {
-            if (organizationRepository.findMapOfDistrictsByIds().containsKey(districtId)) {
-                builder.district(organizationRepository.findMapOfDistrictsByIds().get(districtId));
-            }
-        }
-        return builder;
+                .parameter("district_ids", districtIds)
+                .districts(repositoryHelper.findDistrictsByIds(districtIds));
     }
 
     private Builder toBuilderWithAllSchoolsOfDistricts(final Set<Long> districtIds) {
-        final Builder builder = builder()
+        return builder()
                 .addOn(allSchoolsInDistrictsAddOn)
-                .parameter("school_district_ids", districtIds);
-
-        for (final Long districtId : districtIds) {
-            if (organizationRepository.findAllSchoolsByDistrictId().containsKey(districtId)) {
-                builder.schools(organizationRepository.findAllSchoolsByDistrictId().get(districtId));
-            }
-        }
-        return builder;
+                .parameter("school_district_ids", districtIds)
+                .schools(repositoryHelper.findSchoolsByDistrictIds(districtIds));
     }
 
     private Builder toBuilderWithSchoolIds(final Set<Long> schoolIds) {
-        final Builder builder = builder()
+        return builder()
                 .addOn(schoolsAddOn)
-                .parameter("school_ids", schoolIds);
-
-        for (final Long schoolId : schoolIds) {
-            if (organizationRepository.findMapOfSchoolsById().containsKey(schoolId)) {
-                builder.school(organizationRepository.findMapOfSchoolsById().get(schoolId));
-            }
-        }
-        return builder;
+                .parameter("school_ids", schoolIds)
+                .schools(repositoryHelper.findSchoolsByIds(schoolIds));
     }
 
     private QueryWithReportTemplate buildQuery(final Builder builder) {
@@ -224,30 +171,29 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
         addFilter(queryBuilder, IEP, query.getIepIds(), dimensionType == IEP);
         addFilter(queryBuilder, EconomicDisadvantage, query.getEconomicDisadvantageIds(), dimensionType == EconomicDisadvantage);
 
+        queryBuilder.dimensions(repositoryHelper.findDimensionsByTypeAndQueryFilters(dimensionType, query));
+
         switch (dimensionType) {
-            case Overall:
-                queryBuilder.dimension(new Dimension(null, Overall));
-                break;
             case Gender:
-                addDimension(queryBuilder, dimensionType, query.getGenderIds(), genderRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getGenderIds());
                 break;
             case Ethnicity:
-                addDimension(queryBuilder, dimensionType, query.getEthnicityIds(), ethnicityRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getEthnicityIds());
                 break;
             case LEP:
-                addDimension(queryBuilder, dimensionType, query.getLepIds(), strictBooleanRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getLepIds());
                 break;
             case MigrantStatus:
-                addDimension(queryBuilder, dimensionType, query.getMigrantStatusIds(), booleanRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getMigrantStatusIds());
                 break;
             case Section504:
-                addDimension(queryBuilder, dimensionType, query.getSection504Ids(), booleanRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getSection504Ids());
                 break;
             case IEP:
-                addDimension(queryBuilder, dimensionType, query.getIepIds(), strictBooleanRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getIepIds());
                 break;
             case EconomicDisadvantage:
-                addDimension(queryBuilder, dimensionType, query.getEconomicDisadvantageIds(), strictBooleanRepository);
+                addFilterParams(queryBuilder, dimensionType, query.getEconomicDisadvantageIds());
                 break;
         }
         return queryBuilder;
@@ -261,19 +207,6 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
             queryBuilder.addOn(dimensionType.name() + "_filter");
             addFilterParams(queryBuilder, dimensionType, dimensionFilters);
         }
-    }
-
-    private void addDimension(final Builder queryBuilder,
-                              final DimensionType dimensionType,
-                              final Set<Integer> dimensionFilters,
-                              final CodedEntityRepository repository) {
-
-        if (!dimensionFilters.isEmpty()) {
-            queryBuilder.dimensions(repository.findAll().stream().filter(g -> dimensionFilters.contains(g.getId())).map(g -> new Dimension(g.getCode(), dimensionType)).collect(Collectors.toList()));
-        } else {
-            queryBuilder.dimensions(repository.findAll().stream().map(g -> new Dimension(g.getCode(), dimensionType)).collect(Collectors.toList()));
-        }
-        addFilterParams(queryBuilder, dimensionType, dimensionFilters);
     }
 
     private void addFilterParams(final Builder queryBuilder,
@@ -314,12 +247,5 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
                         .parameter("economic_disadvantage_ids", nullOrEmptyToDefault(dimensionFilters, UNMATCHABLE_INT_IDS));
                 break;
         }
-    }
-
-    private int toId(final String code, final CodedEntityRepository repository) {
-        for (final CodedEntity e : repository.findAll()) {
-            if (e.getCode().equals(code)) return e.getId();
-        }
-        throw new IllegalArgumentException("unable to find code " + code);
     }
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProvider.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.util.stream.Collectors.toSet;
+import static java.util.Collections.emptySet;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 import static org.opentestsystem.rdw.olap.sqlbuilder.QueryWithReportTemplate.builder;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
@@ -80,28 +80,42 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
     private void appendDistricts(final ReportQuery query, final List<QueryWithReportTemplate> queries, final Builder dimensionTemplateBuilder) {
         if (query.isIncludeAllDistricts()) {
             queries.add(buildQuery(builder().addOn(allDistrictsAddOn).districts(repositoryHelper.findAllDistricts()).copy(dimensionTemplateBuilder)));
-        } else if (!query.getDistrictIds().isEmpty() || query.isIncludeAllDistrictsOfSchools()) {
-            queries.add(buildQuery(toBuilderWithDistrictIds(query).copy(dimensionTemplateBuilder)));
+
+        } else if (!query.getDistrictIds().isEmpty() || isIncludeAllDistrictsOfSchools(query)) {
+            //districts could be included two ways: by ids or via 'isIncludeAllDistrictsOfSchools' flag
+            final Set<Long> districtIds = newHashSet(query.getDistrictIds());
+            if (isIncludeAllDistrictsOfSchools(query)) districtIds.addAll(repositoryHelper.findAllDistrictsOfSchools(query.getSchoolIds()));
+
+            if (!districtIds.isEmpty()) queries.add(buildQuery(toBuilderWithDistrictIds(districtIds).copy(dimensionTemplateBuilder)));
         }
     }
 
     private void appendSchools(final ReportQuery query, final List<QueryWithReportTemplate> queries, final Builder dimensionTemplateBuilder) {
         //schools could be selected individually or as part of a district selection
         final Set<Long> districtsWithAllSchools = newHashSet();
-        if (query.isIncludeAllSchoolsOfDistricts()) {
-            districtsWithAllSchools.addAll(query.isIncludeAllDistricts() ? repositoryHelper.findAllDistrictIds() : query.getDistrictIds());
-            queries.add(buildQuery(toBuilderWithAllSchoolsOfDistricts(districtsWithAllSchools).copy(dimensionTemplateBuilder)));
+        if (isIncludeAllSchoolsOfDistricts(query)) {
+            final Set<Long> districtIds = query.isIncludeAllDistricts() ? repositoryHelper.findAllDistrictIds() : query.getDistrictIds();
+            districtsWithAllSchools.addAll(districtIds);
+
+            if (!districtsWithAllSchools.isEmpty()) queries.add(buildQuery(toBuilderWithAllSchoolsOfDistricts(districtsWithAllSchools).copy(dimensionTemplateBuilder)));
         }
 
         if (!query.getSchoolIds().isEmpty()) {
             //to avoid duplicate schools we need to filter those that are already included as part of districts selection
-            Set<Long> schoolIds = query.getSchoolIds();
-            if (query.isIncludeAllSchoolsOfDistricts()) {
-                final Set<Long> schoolsIncludedAsAllOfDistricts = repositoryHelper.findSchoolsIdsByDistrictIds(districtsWithAllSchools);
-                schoolIds = schoolIds.stream().filter(s -> !schoolsIncludedAsAllOfDistricts.contains(s)).collect(toSet());
-            }
+            final Set<Long> schoolIds = query.getSchoolIds();
+            final Set<Long> schoolsIncludedAsAllOfDistricts = isIncludeAllSchoolsOfDistricts(query) ? repositoryHelper.findSchoolsIdsByDistrictIds(districtsWithAllSchools) : emptySet();
+            schoolIds.removeAll(schoolsIncludedAsAllOfDistricts);
+
             if (!schoolIds.isEmpty()) queries.add(buildQuery(toBuilderWithSchoolIds(schoolIds).copy(dimensionTemplateBuilder)));
         }
+    }
+
+    private boolean isIncludeAllSchoolsOfDistricts(final ReportQuery query) {
+        return query.isIncludeAllSchoolsOfDistricts() && !query.getDistrictIds().isEmpty();
+    }
+
+    private boolean isIncludeAllDistrictsOfSchools(final ReportQuery query) {
+        return query.isIncludeAllDistrictsOfSchools() && !query.getSchoolIds().isEmpty();
     }
 
     /**
@@ -120,9 +134,7 @@ public class CustomAggregateQueryProvider implements ReportQueryProvider {
                 .assessments(repositoryHelper.findAssessmentsForQuery(query));
     }
 
-    private Builder toBuilderWithDistrictIds(final ReportQuery query) {
-        final Set<Long> districtIds = newHashSet(query.getDistrictIds());
-        if (query.isIncludeAllDistrictsOfSchools()) districtIds.addAll(repositoryHelper.findAllDistrictsOfSchools(query.getSchoolIds()));
+    private Builder toBuilderWithDistrictIds(final Set<Long> districtIds) {
         return builder()
                 .addOn(allDistrictsAddOn)
                 .addOn(districtsAddOn)

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/QueryWithReportTemplate.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/QueryWithReportTemplate.java
@@ -12,7 +12,6 @@ import org.opentestsystem.rdw.reporting.common.sqlbuilder.QueryProvider;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -49,9 +48,9 @@ public class QueryWithReportTemplate {
         private final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         private final List<String> addOns = newArrayList();
 
-        private final Set<Organization> organizations = new HashSet();
-        private final Set<Assessment> assessments = new HashSet();
-        private final Set<Dimension> dimensions = new HashSet();
+        private Set<Organization> organizations = newHashSet();
+        private Set<Assessment> assessments = newHashSet();
+        private Set<Dimension> dimensions = newHashSet();
 
         public QueryWithReportTemplate build(final QueryProvider queryProvider, final String templateSql) {
 
@@ -94,8 +93,8 @@ public class QueryWithReportTemplate {
             return this;
         }
 
-        Builder assessment(final Assessment assessment) {
-            assessments.add(assessment);
+        Builder assessments(final Collection<Assessment> assessments) {
+            this.assessments.addAll(assessments);
             return this;
         }
 
@@ -104,28 +103,13 @@ public class QueryWithReportTemplate {
             return this;
         }
 
-        Builder district(final District district) {
-            this.organizations.add(district);
-            return this;
-        }
-
         Builder schools(final Collection<School> schools) {
             this.organizations.addAll(schools);
             return this;
         }
 
-        Builder school(final School school) {
-            this.organizations.add(school);
-            return this;
-        }
-
         Builder state(final Organization state) {
             this.organizations.add(state);
-            return this;
-        }
-
-        Builder dimension(final Dimension dimension) {
-            this.dimensions.add(dimension);
             return this;
         }
 

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/ReportQueryRepositoryHelper.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/ReportQueryRepositoryHelper.java
@@ -1,0 +1,202 @@
+package org.opentestsystem.rdw.olap.sqlbuilder;
+
+import com.google.common.collect.ImmutableList;
+import org.opentestsystem.rdw.olap.model.Assessment;
+import org.opentestsystem.rdw.olap.model.CodedEntity;
+import org.opentestsystem.rdw.olap.model.Dimension;
+import org.opentestsystem.rdw.olap.repository.ActiveAssessmentRepository;
+import org.opentestsystem.rdw.olap.repository.BooleanRepository;
+import org.opentestsystem.rdw.olap.repository.CodedEntityRepository;
+import org.opentestsystem.rdw.olap.repository.EthnicityRepository;
+import org.opentestsystem.rdw.olap.repository.GenderRepository;
+import org.opentestsystem.rdw.olap.repository.OrganizationRepository;
+import org.opentestsystem.rdw.olap.repository.StrictBooleanRepository;
+import org.opentestsystem.rdw.olap.repository.SubjectRepository;
+import org.opentestsystem.rdw.reporting.common.model.DimensionType;
+import org.opentestsystem.rdw.reporting.common.model.District;
+import org.opentestsystem.rdw.reporting.common.model.ReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.School;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.stream.Collectors.toSet;
+import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
+import static org.opentestsystem.rdw.reporting.common.model.DimensionType.StudentEnrolledGrade;
+
+/**
+ * Helper to manipulate the data from different repositories into format suitable for the query builders.
+ * This helpers uses multiple repositories that are expected to be `cacheable`.
+ * It is only here to avoid multiple round-trips to Redshift.
+ */
+@Service
+public class ReportQueryRepositoryHelper {
+
+    private final OrganizationRepository organizationRepository;
+    private final ActiveAssessmentRepository activeAssessmentRepository;
+    private final GenderRepository genderRepository;
+    private final EthnicityRepository ethnicityRepository;
+    private final BooleanRepository booleanRepository;
+    private final StrictBooleanRepository strictBooleanRepository;
+    private final SubjectRepository subjectRepository;
+
+    @Autowired
+    public ReportQueryRepositoryHelper(final OrganizationRepository organizationRepository,
+                                       final ActiveAssessmentRepository activeAssessmentRepository,
+                                       final GenderRepository genderRepository,
+                                       final EthnicityRepository ethnicityRepository,
+                                       final BooleanRepository booleanRepository,
+                                       final StrictBooleanRepository strictBooleanRepository,
+                                       final SubjectRepository subjectRepository) {
+        this.organizationRepository = organizationRepository;
+        this.activeAssessmentRepository = activeAssessmentRepository;
+        this.genderRepository = genderRepository;
+        this.ethnicityRepository = ethnicityRepository;
+        this.booleanRepository = booleanRepository;
+        this.strictBooleanRepository = strictBooleanRepository;
+        this.subjectRepository = subjectRepository;
+    }
+
+    /**
+     * Finds all {@link Assessment} represented by the given {@link ReportQuery}.
+     * It is used to fill in gap data in the custom aggregate report.
+     *
+     * @param query the {@link ReportQuery}
+     * @return a set of {@link Assessment}s
+     */
+    public Set<Assessment> findAssessmentsForQuery(final ReportQuery query) {
+        final Set<Assessment> assessments = newHashSet();
+        for (final Assessment assessment : activeAssessmentRepository.findAllByTypeId(query.getAssessmentTypeId())) {
+            if (query.getSchoolYears().contains(assessment.getExamSchoolYear())
+                    && query.getSubjectIds().contains(toId(assessment.getSubjectCode(), subjectRepository))
+                    && query.getAssessmentGradeIds().contains(assessment.getGradeId())) {
+                assessments.add(assessment);
+            }
+        }
+        return assessments;
+    }
+
+    /**
+     * Return all possible values for the given {@link DimensionType} filtered based on the given {@link ReportQuery}
+     * This is used to fill in the gaps of the missing data in the custom aggregate report
+     *
+     * @param dimensionType the {@link DimensionType}
+     * @param query         the {@link ReportQuery}
+     * @return all possible values for the given {@link DimensionType} filtered based on the given {@link ReportQuery}
+     */
+    public List<Dimension> findDimensionsByTypeAndQueryFilters(final DimensionType dimensionType, final ReportQuery query) {
+
+        //we do not back-fill data for this dimension type
+        if (dimensionType.equals(StudentEnrolledGrade)) return ImmutableList.of();
+
+        if (dimensionType.equals(Overall)) return ImmutableList.of(new Dimension(null, Overall));
+
+        final Set<Integer> filters = newHashSet();
+        final CodedEntityRepository repository = getRepositoryAndAddFilterByDimensionType(dimensionType, query, filters);
+
+        if (filters.isEmpty()) return repository.findAll().stream().map(g -> new Dimension(g.getCode(), dimensionType)).collect(Collectors.toList());
+
+        return repository.findAll().stream().filter(g -> filters.contains(g.getId())).map(g -> new Dimension(g.getCode(), dimensionType)).collect(Collectors.toList());
+
+    }
+
+    public Set<District> findDistrictsByIds(final Set<Long> districtIds) {
+        final Set<District> districts = newHashSet();
+        for (final Long districtId : districtIds) {
+            if (organizationRepository.findMapOfDistrictsByIds().containsKey(districtId)) {
+                districts.add(organizationRepository.findMapOfDistrictsByIds().get(districtId));
+            }
+        }
+        return districts;
+    }
+
+    public Set<School> findSchoolsByDistrictIds(final Set<Long> districtIds) {
+        final Set<School> schools = newHashSet();
+        for (final Long districtId : districtIds) {
+            if (organizationRepository.findAllSchoolsByDistrictId().containsKey(districtId)) {
+                schools.addAll(organizationRepository.findAllSchoolsByDistrictId().get(districtId));
+            }
+        }
+        return schools;
+    }
+
+    public Set<Long> findSchoolsIdsByDistrictIds(final Set<Long> districtIds) {
+        return findSchoolsByDistrictIds(districtIds).stream().map(School::getId).collect(toSet());
+    }
+
+    public Set<School> findSchoolsByIds(final Set<Long> schoolIds) {
+        final Set<School> schools = newHashSet();
+        for (final Long schoolId : schoolIds) {
+            if (organizationRepository.findMapOfSchoolsById().containsKey(schoolId)) {
+                schools.add(organizationRepository.findMapOfSchoolsById().get(schoolId));
+            }
+        }
+        return schools;
+    }
+
+    public Collection<District> findAllDistricts() {
+        return organizationRepository.findMapOfDistrictsByIds().values();
+    }
+
+    public Set<Long> findAllDistrictIds() {
+        return organizationRepository.findMapOfDistrictsByIds().keySet();
+    }
+
+    public Set<Long> findAllDistrictsOfSchools(final Set<Long> schoolIds) {
+        final Set<Long> districtIds = newHashSet();
+        final Set<Long> schoolIdsLeftToProcess = newHashSet(schoolIds);
+        final Map<Long, List<School>> schoolsByDistrictId = organizationRepository.findAllSchoolsByDistrictId();
+        for (final Long districtId : schoolsByDistrictId.keySet()) {
+            for (final School school : schoolsByDistrictId.get(districtId)) {
+                if (schoolIds.contains(school.getId())) {
+                    schoolIdsLeftToProcess.remove(school.getId());
+                    districtIds.add(school.getId());
+                }
+                if (schoolIdsLeftToProcess.isEmpty()) return districtIds;
+            }
+
+        }
+        return districtIds;
+    }
+
+    private CodedEntityRepository getRepositoryAndAddFilterByDimensionType(final DimensionType dimensionType, final ReportQuery query, Set<Integer> ids) {
+        switch (dimensionType) {
+            case Gender:
+                ids.addAll(query.getGenderIds());
+                return genderRepository;
+            case Ethnicity:
+                ids.addAll(query.getEthnicityIds());
+                return ethnicityRepository;
+            case LEP:
+                ids.addAll(query.getLepIds());
+                return strictBooleanRepository;
+            case MigrantStatus:
+                ids.addAll(query.getMigrantStatusIds());
+                return booleanRepository;
+            case Section504:
+                ids.addAll(query.getSection504Ids());
+                return booleanRepository;
+            case IEP:
+                ids.addAll(query.getIepIds());
+                return strictBooleanRepository;
+            case EconomicDisadvantage:
+                ids.addAll(query.getEconomicDisadvantageIds());
+                return strictBooleanRepository;
+            default:
+                throw new IllegalArgumentException("unsupported request to findDimensions for dimensionType " + dimensionType);
+        }
+    }
+
+    private int toId(final String code, final CodedEntityRepository repository) {
+        for (final CodedEntity e : repository.findAll()) {
+            if (e.getCode().equals(code)) return e.getId();
+        }
+        throw new IllegalArgumentException("unable to find code " + code);
+    }
+}

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepositoryRST.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepositoryRST.java
@@ -555,52 +555,59 @@ public class JdbcCustomAggregateReportRowRepositoryRST extends RepositoryBackedI
     }
 
     @Test
-    public void itShouldFindByQueryWithAllSchoolsForDistricts() {
+    public void itShouldFindByQueryWithDiffSelectionsOfSchoolsAndDistricts() {
         final ReportQuery query = queryBuilder
                 .includeState(false)
                 .includeAllDistricts(false)
+                .includeAllDistrictsOfSchools(false)
                 .districtIds(of(-9L))
-                .includeAllSchoolsOfDistricts(true)
-                .build();
+                .includeAllSchoolsOfDistricts(true).build();
 
-        final List<ReportRow> expectedRows = reportRepository.findByQuery(query
-                .copy()
-                .districtIds(of(-9L))
+        final List<ReportRow> expectedRows = reportRepository.findByQuery(query.copy()
                 .includeAllSchoolsOfDistricts(false)
-                .schoolIds(of(-9L, -10L))
-                .build());
+                .schoolIds(of(-9L, -10L)).build());
 
         assertThat(reportRepository.findByQuery(query)).usingFieldByFieldElementComparator().containsOnlyElementsOf(expectedRows);
 
         // (1 state + 3 districts + 2 schools) = 6
-        assertThat(reportRepository.findByQuery(query
-                .copy()
+        assertThat(reportRepository.findByQuery(queryBuilder
                 .includeState(true)
                 .includeAllDistricts(true)
-                .districtIds(of(-9L, -8L, -7L))
+                .districtIds(of(-7L))
                 .includeAllSchoolsOfDistricts(false)
                 .schoolIds(of(-9L, -8L)).build()).size()).isEqualTo(6);
 
-        // (1 state + 3 districts + 2 schools) X 5 dim = 30
-        assertThat(reportRepository.findByQuery(query
-                .copy()
+        // (1 state + [2 districts with 3 schools]=5 + 1 schools outside of the districts = 7
+        assertThat(reportRepository.findByQuery(queryBuilder
                 .includeState(true)
-                .includeAllDistricts(true)
-                .dimensionTypes(of(Overall, Gender, Ethnicity))
-                .districtIds(of(-9L, -8L, -7L))
-                .includeAllSchoolsOfDistricts(false)
-                .schoolIds(of(-9L, -8L)).build()).size()).isEqualTo(30);
-
-
-        // (1 state + 3 districts + 2 schools(in district 9) + 4 schools) = 8
-        //NOTE: in this case we get duplicate school -9, but this should not happen with the UI controlling the selection
-        assertThat(reportRepository.findByQuery(query
-                .copy()
-                .includeState(true)
-                .includeAllDistricts(true)
-                .districtIds(of(-9L, -8L, -7L))
+                .includeAllDistricts(false)
+                .districtIds(of(-9L, -8L))
                 .includeAllSchoolsOfDistricts(true)
-                .schoolIds(of(-9L, -8L)).build()).size()).isEqualTo(10);
+                .schoolIds(of(-9L, -7L)).build()).size()).isEqualTo(7);
+
+        // 3 districts + 4 schools = 7
+        assertThat(reportRepository.findByQuery(queryBuilder
+                .includeState(false)
+                .includeAllDistricts(true)
+                .includeAllSchoolsOfDistricts(true)
+                .schoolIds(of(-9L, -7L)).build()).size()).isEqualTo(7);
+
+        // 2 schools + 1 district + 1 school + 1 district = 5
+        assertThat(reportRepository.findByQuery(queryBuilder
+                .includeState(false)
+                .includeAllDistricts(false)
+                .includeAllSchoolsOfDistricts(true)
+                .includeAllDistrictsOfSchools(true)
+                .districtIds(of(-9L))
+                .schoolIds(of(-7L)).build()).size()).isEqualTo(5);
+
+        assertThat(reportRepository.findByQuery(queryBuilder
+                .includeState(false)
+                .includeAllDistricts(false)
+                .includeAllSchoolsOfDistricts(false)
+                .includeAllDistrictsOfSchools(true)
+                .districtIds(of())
+                .schoolIds(of(-7L)).build()).size()).isEqualTo(2);
     }
 
     @Test

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepositoryRST.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepositoryRST.java
@@ -598,16 +598,35 @@ public class JdbcCustomAggregateReportRowRepositoryRST extends RepositoryBackedI
                 .includeAllDistricts(false)
                 .includeAllSchoolsOfDistricts(true)
                 .includeAllDistrictsOfSchools(true)
-                .districtIds(of(-9L))
-                .schoolIds(of(-7L)).build()).size()).isEqualTo(5);
+                .districtIds(of(-9L, -99L))
+                .schoolIds(of(-7L, -77L)).build()).size()).isEqualTo(5);
 
+        //check that includeAllSchoolsOfDistricts without given districts is ignored
         assertThat(reportRepository.findByQuery(queryBuilder
                 .includeState(false)
                 .includeAllDistricts(false)
-                .includeAllSchoolsOfDistricts(false)
+                .includeAllSchoolsOfDistricts(true)
                 .includeAllDistrictsOfSchools(true)
                 .districtIds(of())
                 .schoolIds(of(-7L)).build()).size()).isEqualTo(2);
+
+        //check that includeAllDistrictsOfSchools without given schools is ignored
+        assertThat(reportRepository.findByQuery(queryBuilder
+                .includeState(true)
+                .includeAllDistricts(false)
+                .includeAllSchoolsOfDistricts(true)
+                .includeAllDistrictsOfSchools(true)
+                .districtIds(of())
+                .schoolIds(of()).build()).size()).isEqualTo(1);
+
+        //check that ids or non-existent school or district do not break the SQL
+        assertThat(reportRepository.findByQuery(queryBuilder
+                .includeState(true)
+                .includeAllDistricts(false)
+                .includeAllSchoolsOfDistricts(true)
+                .includeAllDistrictsOfSchools(true)
+                .districtIds(of(-77L))
+                .schoolIds(of(-77L)).build()).size()).isEqualTo(1);
     }
 
     @Test

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
@@ -140,13 +140,6 @@ public class ReportQuery {
         checkArgument(!query.getSchoolYears().isEmpty(), "report query is missing school years");
         checkArgument(!query.getDimensionTypes().isEmpty(), "report query is missing dimensionTypes");
         checkArgument(!(!query.isIncludeState() && !query.isIncludeAllDistricts() && query.getDistrictIds().isEmpty() && query.getSchoolIds().isEmpty()), "report query is missing organization");
-
-        if (query.isIncludeAllDistrictsOfSchools()) {
-            checkArgument(!query.getSchoolIds().isEmpty(), "report query is missing schools");
-        }
-        if (query.isIncludeAllSchoolsOfDistricts()) {
-            checkArgument(!query.getDistrictIds().isEmpty() || query.isIncludeAllDistricts(), "report query is missing districts");
-        }
     }
 
     public static ReportQuery.Builder builder() {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
@@ -10,7 +10,7 @@ import static com.google.common.collect.Sets.newHashSet;
  * Represents a query for the custom aggregate report
  */
 public class ReportQuery {
-    private Integer assessmentTypeId;
+    private int assessmentTypeId;
     private Set<Integer> subjectIds;
     private Set<Integer> schoolYears;
     private Set<Integer> assessmentGradeIds;
@@ -35,7 +35,7 @@ public class ReportQuery {
     private Set<Integer> iepIds;
     private Set<Integer> economicDisadvantageIds;
 
-    public Integer getAssessmentTypeId() {
+    public int getAssessmentTypeId() {
         return assessmentTypeId;
     }
 
@@ -135,12 +135,18 @@ public class ReportQuery {
     }
 
     public static void checkIsValid(@NotNull final ReportQuery query) {
-        checkArgument(query.getAssessmentTypeId() != null, "report query is missing assessment type");
         checkArgument(!query.getSubjectIds().isEmpty(), "report query is missing subjects");
         checkArgument(!query.getAssessmentGradeIds().isEmpty(), "report query is missing asmt grades");
         checkArgument(!query.getSchoolYears().isEmpty(), "report query is missing school years");
         checkArgument(!query.getDimensionTypes().isEmpty(), "report query is missing dimensionTypes");
         checkArgument(!(!query.isIncludeState() && !query.isIncludeAllDistricts() && query.getDistrictIds().isEmpty() && query.getSchoolIds().isEmpty()), "report query is missing organization");
+
+        if (query.isIncludeAllDistrictsOfSchools()) {
+            checkArgument(!query.getSchoolIds().isEmpty(), "report query is missing schools");
+        }
+        if (query.isIncludeAllSchoolsOfDistricts()) {
+            checkArgument(!query.getDistrictIds().isEmpty() || query.isIncludeAllDistricts(), "report query is missing districts");
+        }
     }
 
     public static ReportQuery.Builder builder() {
@@ -148,7 +154,7 @@ public class ReportQuery {
     }
 
     public static class Builder {
-        private Integer assessmentTypeId;
+        private int assessmentTypeId;
         private Set<Integer> subjectIds;
         private Set<Integer> schoolYears;
         private Set<Integer> assessmentGradeIds;
@@ -224,7 +230,7 @@ public class ReportQuery {
             return this;
         }
 
-        public Builder assessmentTypeId(final Integer assessmentTypeId) {
+        public Builder assessmentTypeId(final int assessmentTypeId) {
             this.assessmentTypeId = assessmentTypeId;
             return this;
         }

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/model/ReportQueryTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/model/ReportQueryTest.java
@@ -36,11 +36,6 @@ public class ReportQueryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void itShouldRequireAssessmentType() {
-        ReportQuery.checkIsValid(builder.assessmentTypeId(null).build());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void itShouldRequireSubjectId() {
         ReportQuery.checkIsValid(builder.subjectIds(null).build());
     }


### PR DESCRIPTION
I find this change ...convoluted.

There are three ways to choose districts: 
- includeAllDistricts
- includeAllDistrictsOfSchools
- districtIds

And two ways to select schools:
- includeAllSchoolsOfDistricts
- schoolIds

Since for example 'all districts' are selected with a different query than 'district by ids', and then we combine all results, I need to determine an overlap to avoid duplicate rows.
Additionally, when `includeAllSchoolsOfDistricts` is specified, the district(s) have to be selected (using one of the three above options). And a similar case with 'includeAllDistrictsOfSchools'.