### PR TITLE
Have the item viewer tab pull the answer key from the DB instead of q…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
@@ -161,9 +161,11 @@ export class AssessmentExamMapper {
     uiModel.maxPoints = apiModel.maximumPoints;
     uiModel.commonCoreStandardIds = apiModel.commonCoreStandardIds || [];
     uiModel.type = apiModel.type;
-    uiModel.answerKey = apiModel.answerKey;
     uiModel.numberOfChoices = apiModel.optionsCount;
     uiModel.performanceTaskWritingType = apiModel.performanceTaskWritingType;
+
+    // only multiple choice and multiple select have valid answer keys, so ignore the others
+    uiModel.answerKey = (apiModel.type === 'MC' || apiModel.type === 'MS') ? apiModel.answerKey : undefined;
 
     return uiModel;
   }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="item.validAnswerKey">
+<div *ngIf="item.answerKey">
   <strong>{{translateRoot + 'answer-key' | translate }}</strong>
-  {{ item.validAnswerKey }}
+  {{ item.answerKey }}
 </div>
 
-<div *ngIf="!item.validAnswerKey">
+<div *ngIf="!item.answerKey">
   <div *ngIf="loading" class="loader">
     <div class="inner">
       <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i><span class="text">{{ 'messages.loading' | translate }}</span>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="hasAnswerKey(item)">
+<div *ngIf="item.validAnswerKey">
   <strong>{{translateRoot + 'answer-key' | translate }}</strong>
-  {{item.answerKey}}
+  {{ item.validAnswerKey }}
 </div>
 
-<div *ngIf="!hasAnswerKey(item)">
+<div *ngIf="!item.validAnswerKey">
   <div *ngIf="loading" class="loader">
     <div class="inner">
       <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i><span class="text">{{ 'messages.loading' | translate }}</span>
@@ -16,50 +16,46 @@
       <strong>{{ translateRoot + 'answer-key' | translate }}</strong> {{model.answerKeyValue}}
     </div>
 
-    <div *ngIf="model.rubrics.length > 0">
-      <div *ngIf="model.rubrics.length ==1" [innerHtml]="model.rubrics[0].templateHtml"></div>
+    <!-- rubrics -->
+    <div *ngIf="model.rubrics.length ==1" [innerHtml]="model.rubrics[0].templateHtml"></div>
 
-      <div *ngIf="model.rubrics.length > 1">
-        <h4>{{ translateRoot + 'rubric' | translate }}</h4>
-        <table class="table table-striped">
-          <thead>
-          <tr>
-            <th>{{ translateRoot + 'criterion.points' | translate }}</th>
-            <th>{{ translateRoot + 'criterion.description' | translate }}</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr *ngFor="let rubric of model.rubrics">
-            <td>{{rubric.scorepoint}}</td>
-            <td [innerHTML]="rubric.templateHtml"></td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-
+    <div *ngIf="model.rubrics.length > 1">
+      <h4>{{ translateRoot + 'rubric' | translate }}</h4>
+      <table class="table table-striped">
+        <thead>
+        <tr>
+          <th>{{ translateRoot + 'criterion.points' | translate }}</th>
+          <th>{{ translateRoot + 'criterion.description' | translate }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let rubric of model.rubrics">
+          <td>{{rubric.scorepoint}}</td>
+          <td [innerHTML]="rubric.templateHtml"></td>
+        </tr>
+        </tbody>
+      </table>
     </div>
 
-    <div *ngIf="model.exemplars.length > 0">
-      <div *ngIf="model.exemplars.length ==1" [innerHtml]="model.exemplars[0].templateHtml"></div>
+    <!-- exemplars -->
+    <div *ngIf="model.exemplars.length ==1" [innerHtml]="model.exemplars[0].templateHtml"></div>
 
-      <div *ngIf="model.exemplars.length > 1">
-        <h4>{{ translateRoot + 'exemplar' | translate }}</h4>
-        <table class="table table-striped">
-          <thead>
-          <tr>
-            <th>{{ translateRoot + 'criterion.points' | translate }}</th>
-            <th>{{ translateRoot + 'criterion.description' | translate }}</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr *ngFor="let exemplar of model.exemplars">
-            <td>{{exemplar.scorepoint}}</td>
-            <td [innerHTML]="exemplar.templateHtml"></td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-
+    <div *ngIf="model.exemplars.length > 1">
+      <h4>{{ translateRoot + 'exemplar' | translate }}</h4>
+      <table class="table table-striped">
+        <thead>
+        <tr>
+          <th>{{ translateRoot + 'criterion.points' | translate }}</th>
+          <th>{{ translateRoot + 'criterion.description' | translate }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let exemplar of model.exemplars">
+          <td>{{exemplar.scorepoint}}</td>
+          <td [innerHTML]="exemplar.templateHtml"></td>
+        </tr>
+        </tbody>
+      </table>
     </div>
   </div>
   <div *ngIf="notFound" class="alert alert-danger">

--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.ts
@@ -29,25 +29,26 @@ export class ItemExemplarComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.service.getGuide(this.item.bankItemKey)
-      .subscribe(guide => {
-          this.model = guide;
-          this.loading = false;
+    if (Utils.isNullOrUndefined(this.item.answerKey)) {
+      this.service.getGuide(this.item.bankItemKey)
+        .subscribe(guide => {
+            this.model = guide;
+            this.loading = false;
 
-          // TODO re-look at this logic
-          this.notFound = guide.rubrics.length === 0
-            && guide.exemplars.length === 0
-            && Utils.isNullOrUndefined(guide.answerKeyValue);
-        },
-        (response) => {
+            // TODO re-look at this logic
+            this.notFound = guide.rubrics.length === 0
+              && guide.exemplars.length === 0;
+          },
+          (response) => {
 
-          // TODO fix this?
-          if (response.status = 404)
-            this.notFound = true;
-          else
-            this.errorLoading = true;
+            // TODO fix this?
+            if (response.status = 404)
+              this.notFound = true;
+            else
+              this.errorLoading = true;
 
-          this.loading = false;
-        });
+            this.loading = false;
+          });
+    }
   }
 }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.ts
@@ -50,13 +50,4 @@ export class ItemExemplarComponent implements OnInit {
           this.loading = false;
         });
   }
-
-  /**
-   * Returns true if this item is a MC or MS and has an answer key
-   * @param {AssessmentItem} item
-   * @returns {boolean}
-   */
-  hasAnswerKey(item: AssessmentItem): boolean {
-    return (item.type === 'MC' || item.type === 'MC') && (item.answerKey !== undefined || item.answerKey !== null);
-  }
 }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -27,7 +27,7 @@
   </p-column>
   <ng-template let-score pTemplate="rowexpansion">
     <div class="tab-content well">
-      <item-viewer [bankItemKey]="item.bankItemKey"
+      <item-viewer [item]="item"
                    [response]="score.response"
                    [position]="item.position"></item-viewer>
     </div>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
@@ -15,7 +15,7 @@
   <tab *ngIf="showItemDetails" (select)="selectTab('Item Viewer')" heading="{{translateRoot + 'item-viewer' | translate }}">
     <div class="tab-content well">
       <item-viewer *ngIf="loadItemViewer"
-                   [bankItemKey]="item.bankItemKey"
+                   [item]="item"
                    [response]="response"
                    [showResponse]="showResponse"
                    [position]="position"></item-viewer>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -4,13 +4,12 @@
       <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i><span class="text">{{ 'messages.loading' | translate }}</span>
     </div>
   </div>
-  <div *ngIf="rubricModel" style="white-space: normal">
-    <div *ngIf="rubricModel.answerKeyValue" class="mb-md">
-      <strong>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</strong> {{rubricModel.answerKeyValue}}
-    </div>
-    <div *ngIf="!rubricModel.answerKeyValue" class="mb-md">
-      {{ 'labels.assessments.items.tabs.item-viewer-see-rubric' | translate }}
-    </div>
+
+  <div *ngIf="item.validAnswerKey" class="mb-md">
+    <strong>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</strong> {{ item.validAnswerKey }}
+  </div>
+  <div *ngIf="!item.validAnswerKey" class="mb-md">
+    {{ 'labels.assessments.items.tabs.item-viewer-see-rubric' | translate }}
   </div>
   <p>
     {{ 'labels.assessments.items.tabs.item-viewer-intro-text' | translate }}

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.html
@@ -5,10 +5,10 @@
     </div>
   </div>
 
-  <div *ngIf="item.validAnswerKey" class="mb-md">
-    <strong>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</strong> {{ item.validAnswerKey }}
+  <div *ngIf="item.answerKey" class="mb-md">
+    <strong>{{ 'labels.assessments.items.tabs.exemplar.answer-key' | translate }}</strong> {{ item.answerKey }}
   </div>
-  <div *ngIf="!item.validAnswerKey" class="mb-md">
+  <div *ngIf="!item.answerKey" class="mb-md">
     {{ 'labels.assessments.items.tabs.item-viewer-see-rubric' | translate }}
   </div>
   <p>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
@@ -1,8 +1,7 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
 import { UserService } from "../../../user/user.service";
-import { ItemScoringGuide } from "../item-exemplar/model/item-scoring-guide.model";
 import { ItemScoringService } from "../item-exemplar/item-scoring.service";
-import { Utils } from "../../../shared/support/support";
+import { AssessmentItem } from "../../model/assessment-item.model";
 
 /**
  * IRiS is the vendor client which allows us to integrate with the
@@ -21,10 +20,10 @@ declare var IRiS: any;
 })
 export class ItemViewerComponent implements OnInit {
   /**
-   * The bank item key resolvable in Iris.
+   * The item which we want to display the item viewer for.
    */
   @Input()
-  public bankItemKey: string;
+  public item: AssessmentItem;
 
   @Input()
   public response: string;
@@ -36,7 +35,7 @@ export class ItemViewerComponent implements OnInit {
   public showResponse: boolean = true;
 
   public irisIsLoading: boolean = true;
-  public rubricModel: ItemScoringGuide;
+  public answerKeyValue: string;
 
   private vendorId;
   private _irisFrame;
@@ -60,20 +59,7 @@ export class ItemViewerComponent implements OnInit {
       this._irisFrame.addEventListener('load', this.irisframeOnLoad.bind(this));
     });
 
-    //Fetch the rubric for displaying a simple answer key or letting the user know
-    //that more scoring information can be found in the exemplar tab.
-    //NOTE: if the rubric is empty, don't tell the user more info can be found in the exemplar tab
-    this.itemScoringService
-      .getGuide(this.bankItemKey)
-      .subscribe(guide => {
-        if (guide.rubrics.length > 0 ||
-          guide.exemplars.length > 0 ||
-          !Utils.isNullOrUndefined(guide.answerKeyValue)) {
-          this.rubricModel = guide;
-        }
-      }, (response) => {
-        console.warn(response);
-      });
+    this.answerKeyValue = this.item.validAnswerKey;
   }
 
   irisframeOnLoad() {
@@ -87,7 +73,7 @@ export class ItemViewerComponent implements OnInit {
    * Send a request to load the specified assessment item.
    */
   loadToken() {
-    let token = this.getToken(this.bankItemKey);
+    let token = this.getToken(this.item.bankItemKey);
     IRiS.loadToken(this.vendorId, token)
       .done((function () {
         this.loadResponse();

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
 import { UserService } from "../../../user/user.service";
-import { ItemScoringService } from "../item-exemplar/item-scoring.service";
 import { AssessmentItem } from "../../model/assessment-item.model";
 
 /**
@@ -35,7 +34,6 @@ export class ItemViewerComponent implements OnInit {
   public showResponse: boolean = true;
 
   public irisIsLoading: boolean = true;
-  public answerKeyValue: string;
 
   private vendorId;
   private _irisFrame;
@@ -48,8 +46,7 @@ export class ItemViewerComponent implements OnInit {
     }
   }
 
-  constructor(private userService: UserService,
-              private itemScoringService: ItemScoringService) {
+  constructor(private userService: UserService) {
   }
 
   ngOnInit() {

--- a/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-viewer/item-viewer.component.ts
@@ -58,8 +58,6 @@ export class ItemViewerComponent implements OnInit {
 
       this._irisFrame.addEventListener('load', this.irisframeOnLoad.bind(this));
     });
-
-    this.answerKeyValue = this.item.validAnswerKey;
   }
 
   irisframeOnLoad() {

--- a/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
@@ -49,12 +49,4 @@ export class AssessmentItem {
       ? this.fullCredit / this.scores.length * 100
       : 0;
   }
-
-  /**
-   * If this item is MC or MS the answer key is returned, otherwise the data is not a valid answer key
-   * @returns {string}
-   */
-  get validAnswerKey(): string {
-    return (this.type === 'MC' || this.type === 'MS') ? this.answerKey : undefined;
-  }
 }

--- a/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/assessment-item.model.ts
@@ -49,4 +49,12 @@ export class AssessmentItem {
       ? this.fullCredit / this.scores.length * 100
       : 0;
   }
+
+  /**
+   * If this item is MC or MS the answer key is returned, otherwise the data is not a valid answer key
+   * @returns {string}
+   */
+  get validAnswerKey(): string {
+    return (this.type === 'MC' || this.type === 'MS') ? this.answerKey : undefined;
+  }
 }

--- a/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
@@ -1,0 +1,24 @@
+import { Utils } from "./support";
+
+describe('Utils', () => {
+
+  it('should pass isNullOrUndefined', () => {
+    expect(Utils.isNullOrUndefined(null)).toEqual(true);
+    expect(Utils.isNullOrUndefined(undefined)).toEqual(true);
+    expect(Utils.isNullOrUndefined('')).toEqual(false);
+    expect(Utils.isNullOrUndefined('asdf')).toEqual(false);
+  });
+
+  it('should pass isUndefined', () => {
+    expect(Utils.isUndefined(null)).toEqual(false);
+    expect(Utils.isUndefined(undefined)).toEqual(true);
+    expect(Utils.isUndefined('asdf')).toEqual(false);
+  });
+
+  it('should pass isNullOrEmpty', () => {
+    expect(Utils.isNullOrEmpty(null)).toEqual(true);
+    expect(Utils.isNullOrEmpty(undefined)).toEqual(false);
+    expect(Utils.isNullOrEmpty('')).toEqual(true);
+    expect(Utils.isNullOrEmpty('asdf')).toEqual(false);
+  });
+});

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -32,7 +32,7 @@ export class Utils {
   }
 
   static isNullOrEmpty(value: string): boolean {
-    return value === null || value.length === 0;
+    return !Utils.isUndefined(value) && (value === null || value.length === 0);
   }
 
   static isUndefined(value: any): boolean {


### PR DESCRIPTION
…uerying the scoring API endpoint which reads from the Item XML.

Now that we have the answer key in the DB we don't need to query the Item XML to get the data.  We can use the value that we already have on the AssessmentItem to display the answer key for MS and MC on the Item Viewer tab.

For visual context:
![image](https://user-images.githubusercontent.com/341584/35654371-9b4c0aa4-06a1-11e8-9eb8-5d42e32cb50b.png)
