### PR TITLE
when expanding an item while viewing the writing trait score aggregat…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -11,21 +11,41 @@
     </ng-template>
   </p-column>
   <p-column field="session" header="{{'labels.groups.results.assessment.exams.cols.session' | translate}}" [sortable]="true"></p-column>
-  <p-column class="text-center" field="enrolledGrade" header="{{'labels.groups.results.assessment.exams.cols.grade' | translate}}" [sortable]="true">
+  <p-column field="enrolledGrade" header="{{'labels.groups.results.assessment.exams.cols.grade' | translate}}" [sortable]="true">
     <ng-template let-score="rowData" pTemplate="body">
       {{ score.enrolledGrade | gradeDisplay:'enrolled-name' }}
     </ng-template>
   </p-column>
-  <p-column field="school.name" header="{{'labels.groups.results.assessment.exams.cols.school' | translate }}" sortable="true"></p-column>
+  <p-column field="school.name" header="{{'labels.groups.results.assessment.exams.cols.school' | translate }}" [sortable]="true"></p-column>
   <p-column *ngIf="includeResponse" field="response" header="{{'labels.assessments.items.tabs.scores.response' | translate}}" [sortable]="true"></p-column>
-  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.evidence" header="{{'enum.writing-trait.evidence' | translate}}" [sortable]="true"></p-column>
-  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.organization" header="{{'enum.writing-trait.organization' | translate}}" [sortable]="true"></p-column>
-  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.conventions" header="{{'enum.writing-trait.conventions' | translate}}" [sortable]="true"></p-column>
-  <p-column field="score" header="{{(includeWritingTraitScores ? 'enum.writing-trait.total' : 'labels.assessments.items.tabs.scores.score') | translate}}" [sortable]="true"></p-column>
-  <p-column *ngIf="!includeWritingTraitScores" field="maxScore" header="{{'labels.assessments.items.tabs.scores.max' | translate}}" [sortable]="true"></p-column>
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.evidence" header="{{'enum.writing-trait.evidence' | translate}}" [sortable]="true">
+    <ng-template let-score="rowData" pTemplate="body">
+      <div class="text-center">{{ (score.writingTraitScores ? score.writingTraitScores.evidence : null) | optional }}</div>
+    </ng-template>
+  </p-column>
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.organization" header="{{'enum.writing-trait.organization' | translate}}" [sortable]="true">
+    <ng-template let-score="rowData" pTemplate="body">
+      <div class="text-center">{{ (score.writingTraitScores ? score.writingTraitScores.organization : null) | optional }}</div>
+    </ng-template>
+  </p-column>
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.conventions" header="{{'enum.writing-trait.conventions' | translate}}" [sortable]="true">
+    <ng-template let-score="rowData" pTemplate="body">
+      <div class="text-center">{{ (score.writingTraitScores ? score.writingTraitScores.conventions : null) | optional }}</div>
+    </ng-template>
+  </p-column>
+  <p-column field="score" header="{{(includeWritingTraitScores ? 'enum.writing-trait.total' : 'labels.assessments.items.tabs.scores.score') | translate}}" [sortable]="true">
+    <ng-template let-score="rowData" pTemplate="body">
+      <div class="text-center">{{ score.score | optional }}</div>
+    </ng-template>
+  </p-column>
+  <p-column *ngIf="!includeWritingTraitScores" field="maxScore" header="{{'labels.assessments.items.tabs.scores.max' | translate}}" [sortable]="true">
+    <ng-template let-score="rowData" pTemplate="body">
+      <div class="text-center">{{ score.maxScore }}</div>
+    </ng-template>
+  </p-column>
   <p-column *ngIf="!includeWritingTraitScores" field="correctness" header="{{'labels.assessments.items.tabs.scores.correctness' | translate}}" [sortable]="true">
     <ng-template let-correctness="rowData.correctness" pTemplate="body">
-      {{ correctness | number:'1.2-2' }}
+      <div class="text-center">{{ correctness | number:'1.2-2' }}</div>
     </ng-template>
   </p-column>
   <ng-template let-score pTemplate="rowexpansion">

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -18,9 +18,12 @@
   </p-column>
   <p-column field="school.name" header="{{'labels.groups.results.assessment.exams.cols.school' | translate }}" sortable="true"></p-column>
   <p-column *ngIf="includeResponse" field="response" header="{{'labels.assessments.items.tabs.scores.response' | translate}}" [sortable]="true"></p-column>
-  <p-column field="score" header="{{'labels.assessments.items.tabs.scores.score' | translate}}" [sortable]="true"></p-column>
-  <p-column field="maxScore" header="{{'labels.assessments.items.tabs.scores.max' | translate}}" [sortable]="true"></p-column>
-  <p-column field="correctness" header="{{'labels.assessments.items.tabs.scores.correctness' | translate}}" [sortable]="true">
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.evidence" header="{{'enum.writing-trait.evidence' | translate}}" [sortable]="true"></p-column>
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.organization" header="{{'enum.writing-trait.organization' | translate}}" [sortable]="true"></p-column>
+  <p-column *ngIf="includeWritingTraitScores" field="writingTraitScores.conventions" header="{{'enum.writing-trait.conventions' | translate}}" [sortable]="true"></p-column>
+  <p-column field="score" header="{{(includeWritingTraitScores ? 'enum.writing-trait.total' : 'labels.assessments.items.tabs.scores.score') | translate}}" [sortable]="true"></p-column>
+  <p-column *ngIf="!includeWritingTraitScores" field="maxScore" header="{{'labels.assessments.items.tabs.scores.max' | translate}}" [sortable]="true"></p-column>
+  <p-column *ngIf="!includeWritingTraitScores" field="correctness" header="{{'labels.assessments.items.tabs.scores.correctness' | translate}}" [sortable]="true">
     <ng-template let-correctness="rowData.correctness" pTemplate="body">
       {{ correctness | number:'1.2-2' }}
     </ng-template>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.ts
@@ -28,6 +28,9 @@ export class ItemScoresComponent implements OnInit {
   @Input()
   includeResponse: boolean;
 
+  @Input()
+  includeWritingTraitScores: boolean = false;
+
   scores: StudentScore[];
 
   constructor(private service: StudentScoreService) { }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
@@ -1,6 +1,6 @@
 import { Student } from "../../../student/model/student.model";
 import { School } from "../../../user/model/school.model";
-import {WritingTraitScores} from "../../model/writing-trait-scores.model";
+import { WritingTraitScores } from "../../model/writing-trait-scores.model";
 
 export class StudentScore {
   student: Student;

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.model.ts
@@ -1,5 +1,6 @@
 import { Student } from "../../../student/model/student.model";
 import { School } from "../../../user/model/school.model";
+import {WritingTraitScores} from "../../model/writing-trait-scores.model";
 
 export class StudentScore {
   student: Student;
@@ -11,4 +12,5 @@ export class StudentScore {
   maxScore: number;
   correctness: number;
   response: string;
+  writingTraitScores: WritingTraitScores;
 }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.service.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/student-score.service.ts
@@ -30,6 +30,7 @@ export class StudentScoreService {
     }
 
     score.response = itemScore.response;
+    score.writingTraitScores = itemScore.writingTraitScores;
 
     return score;
   }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
@@ -3,7 +3,8 @@
     <div class="tab-content well">
       <item-scores [item]="item"
                    [exams]="exams"
-                   [includeResponse]="includeResponseInStudentScores">
+                   [includeResponse]="includeResponseInStudentScores"
+                   [includeWritingTraitScores]="includeWritingTraitScores">
       </item-scores>
     </div>
   </tab>

--- a/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.ts
@@ -55,6 +55,9 @@ export class ItemTabComponent implements OnInit {
   includeResponseInStudentScores: boolean = false;
 
   @Input()
+  includeWritingTraitScores: boolean = false;
+
+  @Input()
   set position(value: number) {
     this._position = value;
   }

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
@@ -91,8 +91,8 @@
   </p-column>
   <p-column field="score" [sortable]="true" [hidden]="isClaimScoreSelected">
     <ng-template pTemplate="header">
-              <span info-button title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
-                    content="{{'labels.groups.results.assessment.exams.cols.score-info' | translate}}"></span>
+      <span info-button title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
+            content="{{'labels.groups.results.assessment.exams.cols.score-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData" pTemplate="body">
       <scale-score [score]="exam.score" [standardError]="exam.standardError"></scale-score>

--- a/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.html
@@ -65,7 +65,7 @@
       <item-tab [item]="item"
                 [showResponse]="false"
                 [exams]="exams"
-                [includeResponseInStudentScores]="false"
+                [includeWritingTraitScores]="true"
                 [showItemDetails]="assessment.isInterim"
       ></item-tab>
     </ng-template>


### PR DESCRIPTION
…e view, change the columns to include the individual traits

@malaffoon and I were going through some use cases for Writing Trait Scores and realized there wasn't a clean way to see each individual students trait breakdown when viewing a group.  you had to go back and forth to view an individual student response which was less than ideal.  we thought when in the context of viewing the Writing Trait Scores if you expand the item and it shows the "Student Scores and Response" that the writing trait sub scores were more relevant than the max points and the correctness since each item is always the same max score those aren't super useful.

![image](https://user-images.githubusercontent.com/341584/35664700-fb88dda8-06d7-11e8-94aa-198f3ab35e42.png)
