### PR TITLE
Send 401 response for unauthenticated PUT/POST requests

### DIFF
--- a/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/Http401NotAuthorizedNoChallengeEntryPoint.java
+++ b/common-web/src/main/java/org/opentestsystem/rdw/reporting/common/web/security/Http401NotAuthorizedNoChallengeEntryPoint.java
@@ -20,6 +20,6 @@ public class Http401NotAuthorizedNoChallengeEntryPoint implements Authentication
     public void commence(final HttpServletRequest request,
                          final HttpServletResponse response,
                          final AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(SC_UNAUTHORIZED, "Unauthorized");
+        response.setStatus(SC_UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
This PR fixes an issue with unauthenticated (session-expired) PUT/POST requests to /api/** endpoints returning a 405 Method Not Allowed rather than a 401 Unauthorized response.

The issue was do to Spring Security transforming the response under the covers into a request using the same HTTP method for the error page `/assets/public/error` which doesn't support the POST or PUT methods.  This in turn threw a secondary exception of type HttpRequestMethodNotSupportedException which the Spring default exception handler used to override the 401 response as a 405 response.

The change is to make our no-challenge entry point respond with a 401 response rather than a 401 error to avoid Spring error processing.