### PR TITLE
change datasource prefix from custom app.datamart to standard spring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The integration tests dealing with Redshift have been separated out because they
 and they take a while to run. To run these tests you must set credentials -- please see the comment in 
 aggregate-service/build.gradle. By default it uses the CI database instances:
 ```bash
-(export APP_DATAMART_OLAP_DATASOURCE_PASSWORD=password; \
+(export SPRING_OLAP_DATASOURCE_PASSWORD=password; \
  ./gradlew rst)
 ```
 

--- a/aggregate-service/build.gradle
+++ b/aggregate-service/build.gradle
@@ -53,12 +53,12 @@ cleanReportingOlapTest migrateReportingOlapTest
 // To run these tests locally, you must either manually adjust the application-redshift.yml file
 // (but don't check in your changes!) or set environment variables. If you are using the default
 // CI data resources with personal schemas you should set:
-//   APP_DATAMART_OLAP_DATASOURCE_USERNAME
-//   APP_DATAMART_OLAP_DATASOURCE_PASSWORD
+//   SPRING_OLAP_DATASOURCE_USERNAME
+//   SPRING_OLAP_DATASOURCE_PASSWORD
 // If you are running from the command-line you can use local bash export to do it in one command, e.g.:
 /*
-(export APP_DATAMART_OLAP_DATASOURCE_USERNAME=bob; \
- export APP_DATAMART_OLAP_DATASOURCE_PASSWORD=password; \
+(export SPRING_OLAP_DATASOURCE_USERNAME=bob; \
+ export SPRING_OLAP_DATASOURCE_PASSWORD=password; \
  gradle rst)
 */
 task RST(type: Test) {

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/DataSourceConfiguration.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/DataSourceConfiguration.java
@@ -21,7 +21,7 @@ public class DataSourceConfiguration {
      * @return DataSource
      */
     @Bean(name = "olapDatasource")
-    @ConfigurationProperties(prefix = "app.datamart.olap_datasource")
+    @ConfigurationProperties(prefix = "spring.olap_datasource")
     public DataSource olapDataSource() {
         return DataSourceBuilder
                 .create()

--- a/aggregate-service/src/main/resources/application.yml
+++ b/aggregate-service/src/main/resources/application.yml
@@ -25,30 +25,6 @@ cloud:
       instance-profile: false
 
 app:
-  state:
-    code: CA
-    name: California
-
-  archive:
-      root: file:///tmp/
-
-  datamart:
-     olap_datasource:
-        url: "\
-           jdbc:redshift://${app.datamart.olap_datasource.url-server:localhost:5432}/${app.datamart.olap_datasource.url-db:dev}\
-           ?ApplicationName=rdw-reporting-aggregate-service\
-           "
-        username: root
-        password:
-        testWhileIdle: true
-        validationQuery: SELECT 1
-        driverClassName: com.amazon.redshift.jdbc42.Driver
-
-  cache:
-    repository:
-      # every day at 1:00 am
-      refresh-cron: "0 0 1 * * *"
-
   aggregate-reports:
     summative-enabled: true
     statewide-interim-enabled: false
@@ -56,30 +32,54 @@ app:
       organization-partition-size: 10
     api-enabled: false
 
-spring:
-  jackson:
-    default-property-inclusion: non_null
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
+  archive:
+      root: file:///tmp/
 
+  cache:
+    repository:
+      # every day at 1:00 am
+      refresh-cron: "0 0 1 * * *"
+
+  state:
+    code: CA
+    name: California
+
+
+spring:
   cache:
     type: SIMPLE
     cache-names: internalTranslationsByCode, reportOptions, administrationConditions, assessmentGrades, assessmentTypes, booleans, strictBooleans, organizations, completenessCodes, ethnicities, genders, schoolYears, subjects, activeAssessments
 
   cloud:
-      stream:
-        bindings:
-          AggregateRequest:
-            content-type: application/json
-            group: default
-            producer:
-              requiredGroups: default
+    stream:
+      bindings:
+        AggregateRequest:
+          content-type: application/json
+          group: default
+          producer:
+            requiredGroups: default
 
-          AggregateResponse:
-            content-type: application/json
-            group: default
-            producer:
-              requiredGroups: default
+        AggregateResponse:
+          content-type: application/json
+          group: default
+          producer:
+            requiredGroups: default
+
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
+  olap_datasource:
+    url: "\
+       jdbc:redshift://${spring.olap_datasource.url-server:localhost:5432}/${spring.olap_datasource.url-db:dev}\
+       ?ApplicationName=rdw-reporting-aggregate-service\
+       "
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.amazon.redshift.jdbc42.Driver
 
 jwt:
   secret: ${rdw.reporting.jwt.secret:secret}

--- a/aggregate-service/src/test/resources/application-redshift.yml
+++ b/aggregate-service/src/test/resources/application-redshift.yml
@@ -1,10 +1,9 @@
 # Testing redshift makes use of the CI environment so this overrides some default properties.
 # All the properties should be set to default to the CI environment settings; developers may
 # override them locally but the CI system assumes the defaults are for CI resources.
-app:
-  datamart:
-    olap_datasource:
-      url-server: rdw-qa.cibkulpjrgtr.us-west-2.redshift.amazonaws.com:5439
-      url-db: ci
-      username: ci
-      password:
+spring:
+  olap_datasource:
+    url-server: rdw-qa.cibkulpjrgtr.us-west-2.redshift.amazonaws.com:5439
+    url-db: ci
+    username: ci
+    password:

--- a/common-web/src/test/resources/application-test.yml
+++ b/common-web/src/test/resources/application-test.yml
@@ -2,9 +2,9 @@ app:
   state:
     code: CA
 
-  datamart:
-    datasource:
-      url: jdbc:mysql://${app.datamart.datasource.url-server:localhost:3306}/${app.datamart.datasource.url-schema:reporting_test}?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8
-      username: root
-      password:
-      driverClassName: com.mysql.jdbc.Driver
+spring:
+  datasource:
+    url: jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:reporting_test}?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8
+    username: root
+    password:
+    driverClassName: com.mysql.jdbc.Driver

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/DataSourceConfiguration.java
@@ -20,7 +20,7 @@ public class DataSourceConfiguration {
      * @return the data mart data source
      */
     @Bean
-    @ConfigurationProperties(prefix = "app.datamart.datasource")
+    @ConfigurationProperties(prefix = "spring.datasource")
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/common/src/test/resources/application-test.yml
+++ b/common/src/test/resources/application-test.yml
@@ -2,9 +2,9 @@ app:
   state:
     code: CA
 
-  datamart:
-    datasource:
-      url: jdbc:mysql://${app.datamart.datasource.url-server:localhost:3306}/${app.datamart.datasource.url-schema:reporting_test}?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8
-      username: root
-      password:
-      driverClassName: com.mysql.jdbc.Driver
+spring:
+  datasource:
+    url: jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:reporting_test}?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8
+    username: root
+    password:
+    driverClassName: com.mysql.jdbc.Driver

--- a/report-processor/src/main/resources/application.yml
+++ b/report-processor/src/main/resources/application.yml
@@ -88,12 +88,23 @@ spring:
           group: default
           producer:
             requiredGroups: default
-
+  datasource:
+    url: "\
+      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:reporting}\
+      ?useSSL=${spring.datasource.use-ssl:false}\
+      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
+      &characterEncoding=${spring.datasource.character-encoding:utf8}\
+      "
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
   jackson:
       default-property-inclusion: non_null
       serialization:
         WRITE_DATES_AS_TIMESTAMPS: false
-
   thymeleaf:
     mode: HTML
 
@@ -114,21 +125,6 @@ app:
 
   archive:
     root: file:///tmp/
-
-  datamart:
-    datasource:
-      url: "\
-        jdbc:mysql://${app.datamart.datasource.url-server:localhost:3306}/${app.datamart.datasource.url-schema:reporting}\
-        ?useSSL=${app.datamart.datasource.use-ssl:false}\
-        &useLegacyDatetimeCode=${app.datamart.datasource.use-legacy-datetime-code:false}\
-        &characterEncoding=${app.datamart.datasource.character-encoding:utf8}\
-        "
-      username: root
-      password:
-      testWhileIdle: true
-      validationQuery: SELECT 1
-      driverClassName: com.mysql.jdbc.Driver
-      initialize: false
 
   wkhtmltopdf:
     url: http://localhost:8082

--- a/report-processor/src/test/resources/application-test.yml
+++ b/report-processor/src/test/resources/application-test.yml
@@ -1,4 +1,3 @@
-app:
-  datamart:
-    datasource:
-      url-schema: reporting_test
+spring:
+  datasource:
+    url-schema: reporting_test

--- a/reporting-service/src/main/resources/application.yml
+++ b/reporting-service/src/main/resources/application.yml
@@ -15,15 +15,30 @@ server:
     mime-types: application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,text/csv
 
 spring:
-  resources:
-    chain:
-      enabled: true
-      gzipped: true
-
+  datasource:
+    url: "\
+      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:reporting}\
+      ?useSSL=${spring.datasource.use-ssl:false}\
+      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
+      &characterEncoding=${spring.datasource.character-encoding:utf8}\
+      &useCompression=${spring.datasource.use-compression:true}\
+      "
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+    initialSize: 4
+    maxActive: 10
   jackson:
     default-property-inclusion: non_null
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+  resources:
+    chain:
+      enabled: true
+      gzipped: true
 
 cloud:
   aws:
@@ -50,22 +65,6 @@ app:
   state:
     code: CA
     name: California
-
-  datamart:
-    datasource:
-      url: "\
-        jdbc:mysql://${app.datamart.datasource.url-server:localhost:3306}/${app.datamart.datasource.url-schema:reporting}\
-        ?useSSL=${app.datamart.datasource.use-ssl:false}\
-        &useLegacyDatetimeCode=${app.datamart.datasource.use-legacy-datetime-code:false}\
-        &characterEncoding=${app.datamart.datasource.character-encoding:utf8}\
-        &useCompression=${app.datamart.datasource.use-compression:true}\
-        "
-      username: root
-      password:
-      testWhileIdle: true
-      validationQuery: SELECT 1
-      driverClassName: com.mysql.jdbc.Driver
-      initialize: false
 
   iris:
     vendorId: ${rdw.reporting.iris.vendorId}

--- a/reporting-service/src/test/resources/application-test.yml
+++ b/reporting-service/src/test/resources/application-test.yml
@@ -10,17 +10,12 @@ permissionservice:
 app:
   state:
     code: CA
-
-  datamart:
-    datasource:
-      url-schema: reporting_test
-      initialSize: 4
-      maxActive: 10
-      maxIdle: 10
-      maxWait: 10000
-
   iris:
     vendorId: vendorId
     url: http://my-iris.somewhere.org/iris/
 
   test-mode: true
+
+spring:
+  datasource:
+    url-schema: reporting_test

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -35,6 +35,23 @@ server:
     mime-types: application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,text/csv
 
 spring:
+  datasource:
+    url: "\
+      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/$spring.datasource.url-schema:reporting}\
+      ?useSSL=${spring.datasource.use-ssl:false}\
+      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
+      &characterEncoding=${spring.datasource.character-encoding:utf8}\
+      &useCompression=${spring.datasource.use-compression:true}\
+      "
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+    initialSize: 4
+    maxActive: 10
+
   resources:
     chain:
       enabled: true
@@ -61,27 +78,9 @@ permissionservice:
   endpoint: ${rdw.permission.service}
 
 app:
-  # todo use tenant.code & name
   state:
     code: CA
     name: California
-
-  datamart:
-    datasource:
-      url: "\
-        jdbc:mysql://${app.datamart.datasource.url-server:localhost:3306}/${app.datamart.datasource.url-schema:reporting}\
-        ?useSSL=${app.datamart.datasource.use-ssl:false}\
-        &useLegacyDatetimeCode=${app.datamart.datasource.use-legacy-datetime-code:false}\
-        &characterEncoding=${app.datamart.datasource.character-encoding:utf8}\
-        &useCompression=${app.datamart.datasource.use-compression:true}\
-        "
-      username: root
-      password:
-      testWhileIdle: true
-      validationQuery: SELECT 1
-      driverClassName: com.mysql.jdbc.Driver
-      initialize: false
-
   iris:
     url: ${rdw.reporting.iris.url}
 

--- a/webapp/src/test/resources/application-test.yml
+++ b/webapp/src/test/resources/application-test.yml
@@ -4,16 +4,14 @@ app:
   state:
     code: CA
 
-  datamart:
-    datasource:
-      url-schema: reporting_test
-      initialSize: 4
-      maxActive: 10
-      maxIdle: 10
-      maxWait: 10000
-
   iris:
     url: http://my-iris.somewhere.org/iris/
 
 permissionservice:
   endpoint:
+
+spring:
+  datasource:
+    url-schema: reporting_test
+    maxWait: 10000
+


### PR DESCRIPTION
I know we've gone back and forth on this in the reporting project but Friday i found myself explaining once again to the IT/Ops folks why some datasources are under `app.datamart` and some are under `spring`. I think in this case consistency, however foolish, is a hobgoblin we want, to make configuration easier (remember, *every* service in *every* deployment requires at least one datasource property to be set). 
