### PR TITLE
Populate the aggregate report query page from the specified source on…

### DIFF
--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -300,7 +300,6 @@ export const routes: Routes = [
           {
             path: '',
             pathMatch: 'full',
-            data: { canReuse: true },
             resolve: {
               settings: AggregateReportFormSettingsResolve
             },


### PR DESCRIPTION
… navigation.

This fixes an issue with the aggregate report query builder *always* displaying the user's last query due to "route-reuse."