### PR TITLE
limit width of popup-menus to 330px

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/menu/popup-menu.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/menu/popup-menu.component.ts
@@ -16,7 +16,7 @@ import { Utils } from "../support/support";
     <div class="btn-group btn-block" [ngClass]="{'open': open}">
       <button type="button"
               (click)="open = !open"
-              class="btn btn-info btn-xs btn-block text-left dropdown-toggle"
+              class="btn btn-info btn-xs btn-block text-left dropdown-toggle label-max-width"
               [ngClass]="{'icon-only': !hasText}"
               aria-haspopup="true"
               aria-expanded="false">


### PR DESCRIPTION
limits all popup-menu (dark blue buttons with vertical `...`) text to a width of 330px