### PR TITLE
Workaround for recently introduced issue with PrimeNG datatable that …

### DIFF
--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -39,7 +39,7 @@
     "mathjs": "^3.15.0",
     "ng2-file-upload": "^1.3.0",
     "ngx-bootstrap": "^2.0.0-beta.9",
-    "primeng": "^5.2.0",
+    "primeng": "5.2.0",
     "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"
   },

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -776,3 +776,14 @@ aggregate-report-organization-list {
     margin-bottom: 10px; /* was 20 */
   }
 }
+
+//Enable click-through on prime-ng data table headers
+//Workaround for https://github.com/primefaces/primeng/issues/4762
+//TODO convert from DataTable to the new TurboTable
+.ui-column-title > * {
+  pointer-events: none;
+
+  button {
+    pointer-events: all;
+  }
+}


### PR DESCRIPTION
…prevents sorting on table headers using templates

The PrimeNG team have acknowledged the issue with the DataTable component but have declared it deprecated and unsupported in favor of their new TurboTable implementation.
https://github.com/primefaces/primeng/issues/4762

This workaround disables pointer events on templated table headers excepting the "info" icon buttons we use to provide more info, which allows clicks to propagate through to the header element itself and trigger sorting.

The "real" fix will be to convert all of our custom DataTable integration code (row expanders, column ordering in the aggregate table viewer, etc) to use the new TurboTable.  However, that change is likely to be a large effort and out of scope for UAT.