### PR TITLE
 allow for more details on single page for ica reports

### DIFF
--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -70,14 +70,14 @@
 <div th:fragment="bottom">
     <div class="row">
         <div class="col-xs-8">
-            <h4 class="h3 gray-darker" th:text="#{report.faq.header}"></h4>
+            <h4 class="h2 gray-darker" th:text="#{report.faq.header}"></h4>
             <p th:utext="#{report.faq.p1.html}"></p>
             <p>
                 <strong th:text="#{report.faq.p2.header}"></strong>
                 <br/>
                 <span th:utext="#{report.faq.p2.html}" th:remove="tag"></span>
             </p>
-            <hr class="mt-xs mb-sm"/>
+            <hr/>
             <p th:utext="#{report.faq.p3.html}"></p>
         </div>
         <div class="col-xs-4">
@@ -93,15 +93,17 @@
     </div>
 </div>
 
-<footer th:fragment="footer">
-    <div class="container">
-        <div class="row">
-            <div class="col-xs-12">
-                <div class="copyright text-right" th:utext="#{report.copyright}"></div>
+<div th:fragment="footer">
+    <footer>
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-12">
+                    <div class="copyright text-right" th:utext="#{report.copyright}"></div>
+                </div>
             </div>
         </div>
-    </div>
-</footer>
+    </footer>
+</div>
 
 </body>
 </html>

--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -70,14 +70,14 @@
 <div th:fragment="bottom">
     <div class="row">
         <div class="col-xs-8">
-            <h4 class="h2 gray-darker" th:text="#{report.faq.header}"></h4>
+            <h4 class="h3 gray-darker" th:text="#{report.faq.header}"></h4>
             <p th:utext="#{report.faq.p1.html}"></p>
             <p>
                 <strong th:text="#{report.faq.p2.header}"></strong>
                 <br/>
                 <span th:utext="#{report.faq.p2.html}" th:remove="tag"></span>
             </p>
-            <hr/>
+            <hr class="mt-xs mb-sm"/>
             <p th:utext="#{report.faq.p3.html}"></p>
         </div>
         <div class="col-xs-4">
@@ -93,17 +93,15 @@
     </div>
 </div>
 
-<div th:fragment="footer">
-    <footer>
-        <div class="container">
-            <div class="row">
-                <div class="col-xs-12">
-                    <div class="copyright text-right" th:utext="#{report.copyright}"></div>
-                </div>
+<footer th:fragment="footer">
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12">
+                <div class="copyright text-right" th:utext="#{report.copyright}"></div>
             </div>
         </div>
-    </footer>
-</div>
+    </div>
+</footer>
 
 </body>
 </html>

--- a/report-processor/src/main/resources/templates/ica-body.html
+++ b/report-processor/src/main/resources/templates/ica-body.html
@@ -10,7 +10,7 @@
             <div th:replace="fragments::student-header"></div>
 
             <div class="row">
-                <div class="col-xs-7">
+                <div class="col-xs-6">
                     <div>
                     <span class="h3 label-group red">
                         <span class="label" th:text="#{report.ica.short-name}"></span><span class="label" th:text="#{'report.subject.' + ${report.assessment.subject} + '.name'}"></span>
@@ -20,7 +20,7 @@
                         <small><strong th:text="#{report.ica.date.label}"></strong> <span th:text="${#dates.format(report.exam.dateTime, 'MM/dd/yyyy')}" th:remove="tag"></span></small>
                     </div>
                 </div>
-                <div class="col-xs-5">
+                <div class="col-xs-6">
                     <div class="well" th:if="${scored}">
                         <div class="well-body">
                             <p th:text="#{('report.overall-achievement.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject} + '.level.' + ${report.exam.scaleScore.level})(${report.student.firstName})}"></p>
@@ -29,7 +29,7 @@
                 </div>
             </div>
 
-            <hr class="mt-sm mb-sm"/>
+            <hr class="mt-xs mb-xs"/>
 
             <h2 th:if="${!scored}" th:text="#{report.not-scored}" class="gray-darker mt-lg mb-lg"></h2>
 
@@ -71,14 +71,14 @@
                 </div>
             </div>
 
-            <hr class="mt-sm mb-sm"/>
+            <hr class="mt-sm mb-xs"/>
 
             <h2 th:if="${scored}" th:text="#{report.ica.section.claim.header}"></h2>
             <p th:if="${scored}" th:text="#{('report.student-achievement-by-claim.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject})(${report.student.firstName})}"></p>
 
             <div th:if="${scored}" class="row" th:with="columnClass=${report.assessment.claimCodes.size() == 4} ? 'col-xs-3' : 'col-xs-4'">
                 <div th:class="${columnClass}" th:each="claimCode : ${report.assessment.claimCodes}">
-                    <h3 class="text-center" th:text="#{'report.claim.' + ${claimCode} + '.name'}"></h3>
+                    <h4 class="text-center" th:text="#{'report.claim.' + ${claimCode} + '.name'}"></h4>
                     <span class="h4 gray-darkest"><i class="fa fa-5x text-center" th:classappend="#{'report.claim.' + ${claimCode} + '.icon'}"></i></span>
                     <br/>
                     <div th:if="${report.exam.claimScaleScores[claimCodeStat.index] != null}">

--- a/report-processor/src/main/resources/templates/ica-body.html
+++ b/report-processor/src/main/resources/templates/ica-body.html
@@ -10,7 +10,7 @@
             <div th:replace="fragments::student-header"></div>
 
             <div class="row">
-                <div class="col-xs-6">
+                <div class="col-xs-7">
                     <div>
                     <span class="h3 label-group red">
                         <span class="label" th:text="#{report.ica.short-name}"></span><span class="label" th:text="#{'report.subject.' + ${report.assessment.subject} + '.name'}"></span>
@@ -20,7 +20,7 @@
                         <small><strong th:text="#{report.ica.date.label}"></strong> <span th:text="${#dates.format(report.exam.dateTime, 'MM/dd/yyyy')}" th:remove="tag"></span></small>
                     </div>
                 </div>
-                <div class="col-xs-6">
+                <div class="col-xs-5">
                     <div class="well" th:if="${scored}">
                         <div class="well-body">
                             <p th:text="#{('report.overall-achievement.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject} + '.level.' + ${report.exam.scaleScore.level})(${report.student.firstName})}"></p>
@@ -29,7 +29,7 @@
                 </div>
             </div>
 
-            <hr class="mt-xs mb-xs"/>
+            <hr class="mt-sm mb-sm"/>
 
             <h2 th:if="${!scored}" th:text="#{report.not-scored}" class="gray-darker mt-lg mb-lg"></h2>
 
@@ -71,14 +71,14 @@
                 </div>
             </div>
 
-            <hr class="mt-sm mb-xs"/>
+            <hr class="mt-sm mb-sm"/>
 
             <h2 th:if="${scored}" th:text="#{report.ica.section.claim.header}"></h2>
             <p th:if="${scored}" th:text="#{('report.student-achievement-by-claim.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject})(${report.student.firstName})}"></p>
 
             <div th:if="${scored}" class="row" th:with="columnClass=${report.assessment.claimCodes.size() == 4} ? 'col-xs-3' : 'col-xs-4'">
                 <div th:class="${columnClass}" th:each="claimCode : ${report.assessment.claimCodes}">
-                    <h4 class="text-center" th:text="#{'report.claim.' + ${claimCode} + '.name'}"></h4>
+                    <h3 class="text-center" th:text="#{'report.claim.' + ${claimCode} + '.name'}"></h3>
                     <span class="h4 gray-darkest"><i class="fa fa-5x text-center" th:classappend="#{'report.claim.' + ${claimCode} + '.icon'}"></i></span>
                     <br/>
                     <div th:if="${report.exam.claimScaleScores[claimCodeStat.index] != null}">


### PR DESCRIPTION
<img width="818" alt="screen shot 2018-02-13 at 12 43 29 pm" src="https://user-images.githubusercontent.com/33040425/36174724-03e77c9a-10c2-11e8-839b-1af560dad77e.png">

summary of changes:

- Reduced font size of "Frequently Asked Questions"
- Shortened margins between `<hr/>`s
- Widened column containing intro text to student's score