### PR TITLE
Improve instructional resource display per customer feedback

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/popover/instructional-resource-popover.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/popover/instructional-resource-popover.component.html
@@ -6,7 +6,7 @@
 <div *ngIf="!loading">
   <div *ngIf="resources && resources.length; else noResources">
     <div *ngFor="let instructionalResource of resources"
-         [ngClass]="{'border-bottom': instructionalResource.organizationLevel == 'System' && resources.length > 1}"
+         [ngClass]="{'border-bottom mb-xs': instructionalResource.organizationLevel == 'System' && resources.length > 1}"
          class="popover-link">
       <a href="{{instructionalResource.url}}" target="_blank">{{ ('labels.instructional-resources.link.' + instructionalResource.organizationLevel) | translate:instructionalResource }}</a>
     </div>

--- a/webapp/src/main/webapp/src/app/assessments/popover/instructional-resource-popover.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/popover/instructional-resource-popover.component.html
@@ -5,10 +5,11 @@
 </div>
 <div *ngIf="!loading">
   <div *ngIf="resources && resources.length; else noResources">
-    <p class="popover-link"
-       *ngFor="let instructionalResource of resources">
+    <div *ngFor="let instructionalResource of resources"
+         [ngClass]="{'border-bottom': instructionalResource.organizationLevel == 'System' && resources.length > 1}"
+         class="popover-link">
       <a href="{{instructionalResource.url}}" target="_blank">{{ ('labels.instructional-resources.link.' + instructionalResource.organizationLevel) | translate:instructionalResource }}</a>
-    </p>
+    </div>
   </div>
 </div>
 

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1351,7 +1351,7 @@
             "target": "Target {{target}}",
             "title": "Results By Item"
           },
-          "no-instruct-found": "No resources found.",
+          "no-instruct-found": "Resources Not Yet Available",
           "select-view": "Select View",
           "sessions-title": "Sessions"
         },

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1351,7 +1351,7 @@
             "target": "Target {{target}}",
             "title": "Results By Item"
           },
-          "no-instruct-found": "Resources Not Yet Available",
+          "no-instruct-found": "Resources not yet available",
           "select-view": "Select View",
           "sessions-title": "Sessions"
         },


### PR DESCRIPTION
Added a border between SBAC instructional resources and user-entered instructional resources if both exist:
![image](https://user-images.githubusercontent.com/617828/36183531-7dcc7332-10e3-11e8-918a-64d6df1d65fa.png)

Re-worded the "not found" instructional resource message:
![image](https://user-images.githubusercontent.com/617828/36183558-9ca40ee6-10e3-11e8-9e13-4c187041fe4d.png)
