### PR TITLE
adds es7/object polyfill for Object.values support in IE11

### DIFF
--- a/webapp/src/main/webapp/src/polyfills.ts
+++ b/webapp/src/main/webapp/src/polyfills.ts
@@ -74,3 +74,10 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Need to import at least one locale-data with intl.
  */
 // import 'intl/locale-data/jsonp/en';
+
+/***************************************************************************************************
+ * RDW Custom additions
+ */
+
+/** IE11 Object.values() support */
+import 'core-js/es7/object';


### PR DESCRIPTION
Where are you `values`??

![image](https://user-images.githubusercontent.com/23462925/36187188-513b155c-10f8-11e8-88c0-2c9022dd7919.png)

Oh..

![image](https://user-images.githubusercontent.com/23462925/36187202-64887c8a-10f8-11e8-810b-9a3f766305ea.png)

