### PR TITLE
Bugfix/fix column sorting in ie11

### DIFF
--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -783,9 +783,11 @@ aggregate-report-organization-list {
 //TODO convert from DataTable to the new TurboTable
 .ui-column-title > * {
   pointer-events: none;
+  display: inline-block;
 
   button {
-    pointer-events: all;
+    pointer-events: auto;
+    position: relative;
   }
 }
 


### PR DESCRIPTION
`pointer-events: none;` is only respected in IE11 and Edge if the element is also `display: block` or `display: inline-block`