### PR TITLE
Clean up home page links when screen is at a specific width

### DIFF
--- a/webapp/src/main/webapp/src/app/home/home.component.html
+++ b/webapp/src/main/webapp/src/app/home/home.component.html
@@ -5,23 +5,31 @@
       <h1 class="sr-only">{{'labels.homepage.title' | translate}}</h1>
       <h1 class="blue-dark h1 mb-md">{{'labels.homepage.title' | translate}}</h1>
     </div>
-    <div class="col-md-6">
-      <div class="pull-right">
+    <div class="col-md-6 text-right">
 
-        <!-- Aggregate Reports Link -->
+      <!-- Aggregate Reports Link -->
+      <span class="flex-child">
         <a *hasPermission="'CUSTOM_AGGREGATE_READ'"
-           routerLink="/aggregate-reports" class="btn btn-xs btn-default">{{'aggregate-reports.form.heading' | translate}}</a>
+           routerLink="/aggregate-reports"
+           class="btn btn-xs btn-default">
+          {{'aggregate-reports.form.heading' | translate}}
+        </a>
+      </span>
 
-        <!-- Custom Exports Link -->
+      <!-- Custom Exports Link -->
+      <span class="flex-child">
         <a *hasPermission="'INDIVIDUAL_PII_READ'"
-           routerLink="/custom-export" class="btn btn-xs btn-default ml-xs"><i class="fa fa-bold fa-table"></i>
-          {{'labels.organization-export.title' | translate}}</a>
+           routerLink="/custom-export"
+           class="btn btn-xs btn-default">
+          <i class="fa fa-bold fa-table"></i>
+          {{'labels.organization-export.title' | translate}}
+        </a>
+      </span>
 
-        <span class="ml-xs">
-          <admin-dropdown *hasAnyPermission="['GROUP_WRITE', 'INSTRUCTIONAL_RESOURCE_WRITE', 'EMBARGO_WRITE']"></admin-dropdown>
-        </span>
+      <span class="flex-child">
+        <admin-dropdown *hasAnyPermission="['GROUP_WRITE', 'INSTRUCTIONAL_RESOURCE_WRITE', 'EMBARGO_WRITE']"></admin-dropdown>
+      </span>
 
-      </div>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
When slowly shrinking browser width on the home page, the links are temporarily in an awkward view state:
![home-page-links-small-screen-before](https://user-images.githubusercontent.com/617828/36229536-6dc9a46a-118c-11e8-8ae2-006de3c38e6f.png)

This fix uses flex layout to better position the links when the view is too narrow to display them all side-by-side:
![home-page-links-small-screen-after](https://user-images.githubusercontent.com/617828/36229551-80236880-118c-11e8-9b3e-6c39efd3479e.png)
