### PR TITLE
fixes button sizes. adds update query to failed aggregate reports

### DIFF
--- a/webapp/src/main/webapp/src/app/report/report-action.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.html
@@ -6,7 +6,7 @@
 <!-- One Action -->
 <button *ngIf="reportActions.length == 1"
         [title]="report.label"
-        class="btn btn-info btn-xs label-max-width"
+        class="btn btn-info btn-xs btn-block label-max-width"
         (click)="performAction(reportActions[0])">
   <i *ngIf="reportActions[0].icon"
      class="fa {{ reportActions[0].icon }} mr-xs"

--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -44,6 +44,9 @@ export class ReportActionComponent implements OnInit {
     menuAction.displayName = () => {
       return this.translateService.instant(reportAction.labelKey);
     };
+    menuAction.isDisabled = () => {
+      return reportAction.disabled;
+    };
     return menuAction;
   }
 }


### PR DESCRIPTION
All buttons are `.btn-block` now - this is how we display other buttons in tables

![image](https://user-images.githubusercontent.com/23462925/36233168-7e542a0a-1199-11e8-8120-a55d0a3dfe7a.png)

Added update query option to failed/resultless aggregate reports

![image](https://user-images.githubusercontent.com/23462925/36233148-65a45ffc-1199-11e8-8e6b-166f0d9f1da4.png)
