### PR TITLE
Add column ordering to the aggregate report results view

### DIFF
--- a/webapp/src/main/webapp/package-lock.json
+++ b/webapp/src/main/webapp/package-lock.json
@@ -247,6 +247,20 @@
         "@angular-devkit/core": "0.0.21"
       }
     },
+    "@swimlane/ngx-dnd": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-dnd/-/ngx-dnd-3.1.3.tgz",
+      "integrity": "sha512-pi++ndW2FQFcaPPE5lgzOWJ7Fa3pp5cnSXSYm2XVtltHrf+4I9cn32w2kGYwj7qVx3Z1ie2/8I+FgRelrarjLA==",
+      "requires": {
+        "@types/dragula": "2.1.32",
+        "dragula": "3.7.2"
+      }
+    },
+    "@types/dragula": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/@types/dragula/-/dragula-2.1.32.tgz",
+      "integrity": "sha512-67nXH/pjZPTrbQ+Sr/Wy/luKVJPOOy7ErML58TgoO4A0vokIvvSt3+x1FHwp6Q455Kj03xGjCyHkhaelAdQMWA=="
+    },
     "@types/file-saver": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-0.0.1.tgz",
@@ -641,6 +655,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "atoa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -1666,6 +1685,15 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
+    "contra": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
+      "integrity": "sha1-9TveQtfltZhcrk2ZqNYQUm3o8o0=",
+      "requires": {
+        "atoa": "1.0.0",
+        "ticky": "1.0.1"
+      }
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -1807,6 +1835,21 @@
       "requires": {
         "lru-cache": "4.1.1",
         "which": "1.3.0"
+      }
+    },
+    "crossvent": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+      "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
+      "requires": {
+        "custom-event": "1.0.0"
+      },
+      "dependencies": {
+        "custom-event": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
+          "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI="
+        }
       }
     },
     "crypt": {
@@ -2304,6 +2347,15 @@
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
+      }
+    },
+    "dragula": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.2.tgz",
+      "integrity": "sha1-SjXJ05gf+sGpScKcpyhQWOhzk84=",
+      "requires": {
+        "contra": "1.9.4",
+        "crossvent": "1.5.4"
       }
     },
     "duplexer2": {
@@ -10258,6 +10310,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
       "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
       "dev": true
+    },
+    "ticky": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
+      "integrity": "sha1-t8+nHnaPHJAAxJe5FRswlHxQ5G0="
     },
     "time-stamp": {
       "version": "2.0.0",

--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -27,6 +27,7 @@
     "@ngx-translate/core": "^9.0.1",
     "@ngx-translate/http-loader": "^2.0.0",
     "@sbac/sbac-ui-kit": "0.0.24",
+    "@swimlane/ngx-dnd": "3.1.3",
     "angular-2-dropdown-multiselect": "^1.6.3",
     "angular2-cookie": "^1.2.6",
     "angular2-csv": "^0.2.3",

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -35,25 +35,25 @@
       <div *ngFor="let table of reportTables" class="well wide-content-container">
         <div class="row">
           <div class="col-md-12">
-
-            <h3 class="h3 label-group green pull-left">
-              <span class="label">{{'common.assessment-type.' + query.assessmentTypeCode + '.short-name' | translate}}</span><span class="label">{{'common.subject.' + table.subjectCode + '.short-name' | translate}}</span>
-            </h3>
-
-            <button class="btn btn-sm btn-default ml-sm"
-                    (click)="reportTable.exportTable(getExportName(table))"><i class="fa fa-cloud-download"></i> {{'common.export' | translate}}</button>
-
-            <div class="pull-right">
-              <span>
-                <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
-                <sb-radio-button-group [options]="displayOptions.performanceLevelDisplayTypes"
-                           [(ngModel)]="table.performanceLevelDisplayType"
-                           buttonGroupStyles="btn-group-xs"
-                           buttonStyles="btn-default"
-                           analyticsCategory="AggregateReportControl"
-                           analyticsEvent="Change"></sb-radio-button-group>
+            <div>
+              <h3 class="h3 label-group green pull-left">
+                <span class="label">{{'common.assessment-type.' + query.assessmentTypeCode + '.short-name' | translate}}</span><span class="label">{{'common.subject.' + table.subjectCode + '.short-name' | translate}}</span>
+              </h3>
+              <button class="btn btn-sm btn-default ml-sm"
+                      (click)="reportTable.exportTable(getExportName(table))"><i class="fa fa-cloud-download"></i> {{'common.export' | translate}}</button>
+            </div>
+            <div class="clearfix"></div>
+            <div>
+              <span class="pull-left flex-child">
+                <label class="mr-xs">
+                  <info-button title="{{'aggregate-report.column-order' | translate}}"
+                               content="{{'aggregate-report.column-order-info' | translate}}">
+                  </info-button>
+                </label>
+                <order-selector [items]="table.columnOrderingItems"
+                                (itemsChange)="onColumnOrderChange(table, $event)"></order-selector>
               </span>
-              <span class="ml-sm">
+              <span class="pull-right flex-child ml-xs">
                 <label class="mr-xs">{{'common.value-display-type-input-label' | translate}}</label>
                 <sb-radio-button-group [options]="displayOptions.valueDisplayTypes"
                            [(ngModel)]="table.valueDisplayType"
@@ -61,6 +61,15 @@
                            buttonStyles="btn-default"
                            analyticsCategory="AggregateReportControl"
                            analyticsEvent="Change"></sb-radio-button-group>
+              </span>
+              <span class="pull-right flex-child ml-xs">
+                <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
+                <sb-radio-button-group [options]="displayOptions.performanceLevelDisplayTypes"
+                                       [(ngModel)]="table.performanceLevelDisplayType"
+                                       buttonGroupStyles="btn-group-xs"
+                                       buttonStyles="btn-default"
+                                       analyticsCategory="AggregateReportControl"
+                                       analyticsEvent="Change"></sb-radio-button-group>
               </span>
             </div>
           </div>
@@ -72,7 +81,7 @@
                                     [table]="table.table"
                                     [valueDisplayType]="table.valueDisplayType"
                                     [performanceLevelDisplayType]="table.performanceLevelDisplayType"
-                                    [columnOrdering]="['organization', 'assessmentGrade', 'schoolYear', 'dimension']"></aggregate-report-table>
+                                    [columnOrdering]="table.columnOrdering"></aggregate-report-table>
           </div>
         </div>
       </div>

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -39,6 +39,8 @@ import { ScrollNavComponent } from "./nav/scroll-nav.component";
 import { OptionalPipe } from "./optional.pipe";
 import { RdwDisplayOptionsModule } from "./display-options/rdw-display-options.module";
 import { RdwAssessmentModule } from "./assessment/rdw-assessment.module";
+import { OrderSelectorComponent } from "./order-selector/order-selector.component";
+import { NgxDnDModule } from "@swimlane/ngx-dnd";
 
 
 @NgModule({
@@ -47,6 +49,7 @@ import { RdwAssessmentModule } from "./assessment/rdw-assessment.module";
     GradeDisplayPipe,
     InformationButtonComponent,
     OptionalPipe,
+    OrderSelectorComponent,
     ScrollNavComponent,
     NotificationComponent,
     RemoveCommaPipe,
@@ -61,6 +64,7 @@ import { RdwAssessmentModule } from "./assessment/rdw-assessment.module";
     BrowserModule,
     FormsModule,
     HttpModule,
+    NgxDnDModule,
     OrganizationModule,
     PopoverModule.forRoot(),
     RdwAssessmentModule,
@@ -88,6 +92,7 @@ import { RdwAssessmentModule } from "./assessment/rdw-assessment.module";
     GradeDisplayPipe,
     InformationButtonComponent,
     OptionalPipe,
+    OrderSelectorComponent,
     NotificationComponent,
     ScrollNavComponent,
     OrganizationModule,

--- a/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.html
+++ b/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.html
@@ -1,0 +1,38 @@
+<span class="order-selector">
+  <span ngxDroppable
+        class="ngx-dnd-container"
+        [model]="items"
+        (drag)="onDrag()"
+        (drop)="onDrop()">
+    <span *ngFor="let item of items"
+          class="ngx-dnd-item"
+          ngxDraggable
+          [model]="item">
+      <span class="btn btn-sm"
+            [ngClass]="{
+              'btn-primary': item === selectedItem,
+              'btn-default': item !== selectedItem
+              }"
+            (click)="selectItem(item)">
+        <span *ngIf="item.label">{{item.label}}</span>
+        <span *ngIf="item.labelKey">{{item.labelKey | translate}}</span>
+      </span>
+    </span>
+  </span>
+  <span class="btn-group flex-child">
+    <button class="btn btn-primary icon-only"
+            [disabled]="!selectedItem || selectedIdx == 0"
+            title="{{ 'order-selector.move-left' | translate }}"
+            (click)="moveLeft()">
+      <span class="sr-only">{{ 'order-selector.move-left' | translate }}</span>
+      <i class="fa fa-arrow-left"></i>
+    </button>
+    <button class="btn btn-primary icon-only"
+            title="{{ 'order-selector.move-right' | translate }}"
+            [disabled]="!selectedItem || selectedIdx == items.length - 1"
+            (click)="moveRight()">
+      <span class="sr-only">{{ 'order-selector.move-right' | translate }}</span>
+      <i class="fa fa-arrow-right"></i>
+    </button>
+  </span>
+</span>

--- a/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.ts
@@ -48,7 +48,6 @@ export class OrderSelectorComponent {
   }
 
   public onDrop() {
-    console.log("items", this.items);
     this.itemsChange.emit(this.items);
   }
 }

--- a/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/order-selector/order-selector.component.ts
@@ -1,0 +1,70 @@
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+
+/**
+ * This component is responsible for displaying a UX to allow the user
+ * to arbitrarily order a collection of items.
+ */
+@Component({
+  selector: 'order-selector',
+  templateUrl: 'order-selector.component.html'
+})
+export class OrderSelectorComponent {
+
+  @Input()
+  public items: OrderableItem[];
+
+  @Output()
+  public itemsChange: EventEmitter<OrderableItem[]> = new EventEmitter();
+
+  public selectedItem: OrderableItem;
+  public selectedIdx: number;
+
+  public selectItem(item: OrderableItem) {
+    this.selectedItem = item;
+    this.selectedIdx = this.items.indexOf(this.selectedItem);
+  }
+
+  /**
+   * Move the selected item to the left.
+   */
+  public moveLeft(): void {
+    this.items.splice(this.selectedIdx - 1, 0, this.items.splice(this.selectedIdx, 1)[0]);
+    this.selectedIdx--;
+    this.itemsChange.emit(this.items);
+  }
+
+  /**
+   * Move the selected item to the right.
+   */
+  public moveRight(): void {
+    this.items.splice(this.selectedIdx + 1, 0, this.items.splice(this.selectedIdx, 1)[0]);
+    this.selectedIdx++;
+    this.itemsChange.emit(this.items);
+  }
+
+  public onDrag() {
+    this.selectedIdx = undefined;
+    this.selectedItem = undefined;
+  }
+
+  public onDrop() {
+    console.log("items", this.items);
+    this.itemsChange.emit(this.items);
+  }
+}
+
+/**
+ * This interface represents an orderable item.
+ */
+export interface OrderableItem {
+  //The item value
+  value: any;
+
+  //The display text for the item.
+  //Do not supply both a label and translation labelKey
+  label?: string;
+
+  //The translation label key for the item.
+  //Do not supply both a label and a translation labelKey
+  labelKey?: string;
+}

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -14,6 +14,8 @@
     "organization-name-format": "School / District {{id}}"
   },
   "aggregate-report": {
+    "column-order": "Column Order",
+    "column-order-info": "Change your result column order to easily compare your results broken down in different ways.",
     "heading": "Aggregate Report",
     "form-link": "View Query",
     "processing": "Your report is being generated. This may take several minutes. ",
@@ -256,6 +258,10 @@
       "hide": "Hide",
       "show": "Show"
     }
+  },
+  "order-selector": {
+    "move-left": "Move Left",
+    "move-right": "Move Right"
   },
   "organization-typeahead": {
     "type-label": "Type",

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -18,6 +18,9 @@
 // Font Awesome
 @import "@{library-path}/font-awesome/less/font-awesome.less";
 
+// ngx drag and drop
+@import "@{library-path}/@swimlane/ngx-dnd/release/ngx-dnd.css";
+
 // SBAC UI Kit
 @import "@{library-path}/@sbac/sbac-ui-kit/src/less/sbac-ui-kit.less";
 @import "primeng-overrides.less";
@@ -118,6 +121,33 @@ h1 + p.pull-left, .h1 + p.pull-left, h2 + p.pull-left, .h2 + p.pull-left, h3 + p
 
 .btn.btn-borderless.btn-default, .scale-score-graph .bar-container .bar .bar-label, .table .scale-score .error-band {
   color: darken(@gray-mid, 10%);
+}
+
+// ------------------------------
+// Drag-and-Drop default style overrides
+// ------------------------------
+
+.ngx-dnd-container {
+  border: inherit;
+  background-color: inherit;
+  margin: inherit;
+  padding: inherit;
+
+  &:nth-child(odd), &:nth-child(even) {
+    background-color: inherit;
+  }
+}
+
+.ngx-dnd-item {
+  margin: inherit;
+  padding: inherit;
+  background-color: transparent;
+  border: inherit;
+  display: inherit;
+
+  &:hover {
+    border: inherit;
+  }
 }
 
 // ------------------------------
@@ -724,4 +754,5 @@ aggregate-report-organization-list {
     opacity: .65;
   }
 }
+
 


### PR DESCRIPTION
This PR adds the ability to order Aggregate Report results table columns.

The order can be modified by selecting a column identifier and pressing the left/right buttons or by drag-and-drop re-ordering.

![image](https://user-images.githubusercontent.com/617828/36333892-67e61364-132e-11e8-8df7-79e5535f31b9.png)
