### PR TITLE
Fix report popup menu after back-navigation.

### DIFF
--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -29,10 +29,7 @@ export class ReportActionComponent implements OnInit {
 
   public reportActions: ReportAction[] = [];
 
-  public get menuActions(): PopupMenuAction[] {
-    return this.reportActions
-      .map(reportAction => this.toMenuAction(reportAction));
-  }
+  public menuActions: PopupMenuAction[];
 
   constructor(private actionService: ReportActionService,
               private translateService: TranslateService,
@@ -41,6 +38,8 @@ export class ReportActionComponent implements OnInit {
 
   ngOnInit(): void {
     this.reportActions = this.actionService.getActions(this.report);
+    this.menuActions = this.reportActions
+      .map(reportAction => this.toMenuAction(reportAction));
   }
 
   performAction(reportAction: ReportAction): void {


### PR DESCRIPTION
The root issue is that we're using a `get` accessor method to generate a collection that Angular is binding to.  This means every time the view digest cycle runs Angular rebinds to an entirely new collection instance.

For some reason that I don't understand, this works properly when first loading the My Reports page or after a hard refresh.  When navigating to the page via a browser back button the report popup menu links no longer work.  When clicking on a menu option, Angular gets the collection, which returns a new collection instance, rebuilds the view, then fails to click on the removed element.

This is a good example of why we should avoid binding Angular to `get` accessor methods and instead rely on properties whenever possible.