### PR TITLE
Round-trip column ordering from the aggregate report query table to t…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/ReportQuery.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.reporting.common.model;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**
@@ -24,6 +26,7 @@ public class ReportQuery {
     //pass through values
     private String valueDisplayType;
     private String achievementLevelDisplayType;
+    private List<String> columnOrder;
     // optional filters
     private Set<String> completenessCodes;
     private Set<String> administrativeConditionCodes;
@@ -81,6 +84,10 @@ public class ReportQuery {
 
     public String getAchievementLevelDisplayType() {
         return achievementLevelDisplayType;
+    }
+
+    public List<String> getColumnOrder() {
+        return columnOrder == null ? newArrayList() : newArrayList(columnOrder);
     }
 
     public Set<DimensionType> getDimensionTypes() {
@@ -160,6 +167,7 @@ public class ReportQuery {
         private Set<DimensionType> dimensionTypes;
         private String valueDisplayType;
         private String achievementLevelDisplayType;
+        private List<String> columnOrder;
         private Set<String> completenessCodes;
         private Set<String> administrativeConditionCodes;
         private Set<String> genderCodes;
@@ -185,6 +193,7 @@ public class ReportQuery {
             query.dimensionTypes = dimensionTypes;
             query.valueDisplayType = valueDisplayType;
             query.achievementLevelDisplayType = achievementLevelDisplayType;
+            query.columnOrder = columnOrder;
             query.completenessCodes = completenessCodes;
             query.administrativeConditionCodes = administrativeConditionCodes;
             query.genderCodes = genderCodes;
@@ -211,6 +220,7 @@ public class ReportQuery {
             dimensionTypes = query.getDimensionTypes();
             valueDisplayType = query.getValueDisplayType();
             achievementLevelDisplayType = query.getAchievementLevelDisplayType();
+            columnOrder = query.getColumnOrder();
             completenessCodes = query.getCompletenessCodes();
             administrativeConditionCodes = query.getAdministrativeConditionCodes();
             genderCodes = query.getGenderCodes();

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-column-order-item.provider.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-column-order-item.provider.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@angular/core";
+import { OrderableItem } from "../shared/order-selector/order-selector.component";
+
+const ColumnToLabel: {[key: string]: string} = {
+  organization: 'aggregate-reports.results.cols.organization-name',
+  assessmentGrade: 'aggregate-reports.results.cols.assessment-grade',
+  schoolYear: 'aggregate-reports.results.cols.school-year',
+  dimension: 'aggregate-reports.results.cols.dimension'
+};
+
+/**
+ * Responsible for providing {@link OrderableItem} representations
+ * of aggregate report table columns.
+ */
+@Injectable()
+export class AggregateReportColumnOrderItemProvider {
+
+  /**
+   * Map the given column ids to OrderableItems.
+   *
+   * @param {string[]} columnIds  The column ids
+   * @returns {OrderableItem[]}   The orderable items representing the columns
+   */
+  toOrderableItems(columnIds: string[]): OrderableItem[] {
+    return columnIds.map(column => {
+      return {
+        value: column,
+        labelKey: ColumnToLabel[column]
+      };
+    });
+  }
+}

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form-settings.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form-settings.ts
@@ -92,6 +92,11 @@ export interface AggregateReportFormSettings {
   valueDisplayType: string;
 
   /**
+   * The user-selected result column order
+   */
+  columnOrder?: string[];
+
+  /**
    * Determines if state results will be included in the report
    */
   includeStateResults: boolean;

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
@@ -662,33 +662,43 @@
       <div class="well wide-content-container">
         <div>
           <span class="red label">{{ 'aggregate-reports.preview' | translate }}</span>
-          <div class="pull-right">
-        <span>
-          <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
-          <sb-radio-button-group [options]="options.performanceLevelDisplayTypes"
-                     [(ngModel)]="settings.performanceLevelDisplayType"
-                     buttonGroupStyles="btn-group-xs"
-                     buttonStyles="btn-default"
-                     analyticsCategory="AggregateQueryBuilder"
-                     analyticsEvent="Change"></sb-radio-button-group>
-        </span>
-            <span class="ml-sm">
-          <label class="mr-xs">{{'common.value-display-type-input-label' | translate}}</label>
-          <sb-radio-button-group [options]="options.valueDisplayTypes"
-                     [(ngModel)]="settings.valueDisplayType"
-                     buttonGroupStyles="btn-group-xs"
-                     buttonStyles="btn-default"
-                     analyticsCategory="AggregateQueryBuilder"
-                     analyticsEvent="Change"></sb-radio-button-group>
-        </span>
+          <div>
+            <span class="pull-left flex-child">
+              <label class="mr-xs">
+                <info-button title="{{'aggregate-report.column-order' | translate}}"
+                             content="{{'aggregate-report.column-order-info' | translate}}">
+                </info-button>
+              </label>
+              <order-selector [items]="columnItems"
+                              (itemsChange)="onColumnOrderChange($event)"></order-selector>
+            </span>
+            <span class="pull-right flex-child ml-xs">
+              <label class="mr-xs">{{'common.value-display-type-input-label' | translate}}</label>
+              <sb-radio-button-group [options]="options.valueDisplayTypes"
+                                     [(ngModel)]="settings.valueDisplayType"
+                                     buttonGroupStyles="btn-group-xs"
+                                     buttonStyles="btn-default"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     analyticsEvent="Change"></sb-radio-button-group>
+            </span>
+            <span class="pull-right flex-child ml-xs">
+              <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
+              <sb-radio-button-group [options]="options.performanceLevelDisplayTypes"
+                         [(ngModel)]="settings.performanceLevelDisplayType"
+                         buttonGroupStyles="btn-group-xs"
+                         buttonStyles="btn-default"
+                         analyticsCategory="AggregateQueryBuilder"
+                         analyticsEvent="Change"></sb-radio-button-group>
+            </span>
           </div>
+          <div class="clearfix"></div>
         </div>
         <div class="mt-sm">
           <aggregate-report-table [preview]="true"
                                   [table]="previewTable"
                                   [valueDisplayType]="settings.valueDisplayType"
                                   [performanceLevelDisplayType]="settings.performanceLevelDisplayType"
-                                  [columnOrdering]="['organization', 'assessmentGrade', 'schoolYear', 'dimension']"></aggregate-report-table>
+                                  [columnOrdering]="settings.columnOrder"></aggregate-report-table>
         </div>
       </div>
     </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.ts
@@ -19,6 +19,8 @@ import { AggregateReportOptions } from "./aggregate-report-options";
 import { AggregateReportRequestMapper } from "./aggregate-report-request.mapper";
 import "rxjs/add/observable/interval";
 import "rxjs/add/operator/switchMap";
+import { AggregateReportColumnOrderItemProvider } from "./aggregate-report-column-order-item.provider";
+import { OrderableItem } from "../shared/order-selector/order-selector.component";
 
 /**
  * Form control validator that makes sure the control value is not an empty array
@@ -110,6 +112,11 @@ export class AggregateReportFormComponent {
    */
   assessmentDefinitionsByTypeCode: Map<string, AssessmentDefinition>;
 
+  /**
+   * The current column order
+   */
+  columnItems: OrderableItem[];
+
   constructor(private router: Router,
               private route: ActivatedRoute,
               private optionMapper: AggregateReportOptionsMapper,
@@ -117,7 +124,8 @@ export class AggregateReportFormComponent {
               private notificationService: NotificationService,
               private organizationService: AggregateReportOrganizationService,
               private reportService: AggregateReportService,
-              private tableDataService: AggregateReportTableDataService) {
+              private tableDataService: AggregateReportTableDataService,
+              private columnOrderableItemProvider: AggregateReportColumnOrderItemProvider) {
 
     this.assessmentDefinitionsByTypeCode = route.snapshot.data[ 'assessmentDefinitionsByAssessmentTypeCode' ];
     this.aggregateReportOptions = route.snapshot.data[ 'options' ];
@@ -129,6 +137,8 @@ export class AggregateReportFormComponent {
     if (this.organizations.length == 0 && defaultOrganization) {
       this.addOrganizationToSettings(defaultOrganization);
     }
+
+    this.columnItems = this.columnOrderableItemProvider.toOrderableItems(this.settings.columnOrder);
 
     this.previewTable = {
       assessmentDefinition: this.assessmentDefinitionsByTypeCode.get(this.settings.assessmentType),
@@ -249,6 +259,10 @@ export class AggregateReportFormComponent {
 
   onIncludeAllDistrictsChange(): void {
     this.markOrganizationsControlTouched();
+  }
+
+  onColumnOrderChange(items: OrderableItem[]): void {
+    this.settings.columnOrder = items.map(item => item.value);
   }
 
   private markOrganizationsControlTouched(): void {

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.spec.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.spec.ts
@@ -1,18 +1,8 @@
-import {
-  DefaultDistrict,
-  DefaultSchool,
-  District,
-  OrganizationType,
-  School
-} from "../shared/organization/organization";
-import { Observable } from "rxjs/Observable";
 import { AggregateReportOptions } from "./aggregate-report-options";
-import { AggregateReportQuery, AggregateReportRequest } from "../report/aggregate-report-request";
-import { AggregateReportFormSettings } from "./aggregate-report-form-settings";
-import { AggregateReportOptionsMapper } from "./aggregate-report-options.mapper";
-import Spy = jasmine.Spy;
+import { AggregateReportOptionsMapper, DefaultColumnOrder } from "./aggregate-report-options.mapper";
 import { PerformanceLevelDisplayTypes } from "../shared/display-options/performance-level-display-type";
 import { ValueDisplayTypes } from "../shared/display-options/value-display-type";
+import Spy = jasmine.Spy;
 
 describe('AggregateReportOptionsMapper', () => {
 
@@ -34,7 +24,7 @@ describe('AggregateReportOptionsMapper', () => {
       'createOptionMapper'
     ]);
     fixture = new AggregateReportOptionsMapper(translateService, schoolYearPipe, displayOptionService);
-  })
+  });
 
   it('toDefaultSettings should create default settings correctly from options', () => {
 
@@ -83,7 +73,8 @@ describe('AggregateReportOptionsMapper', () => {
       schools: [],
       schoolYears: [options.schoolYears[0]],
       subjects: options.subjects,
-      valueDisplayType: ValueDisplayTypes.Percent
+      valueDisplayType: ValueDisplayTypes.Percent,
+      columnOrder: DefaultColumnOrder
     });
 
   });

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.ts
@@ -9,6 +9,8 @@ import { ValueDisplayTypes } from "../shared/display-options/value-display-type"
 import { PerformanceLevelDisplayTypes } from "../shared/display-options/performance-level-display-type";
 
 
+export const DefaultColumnOrder: string[] = ['organization', 'assessmentGrade', 'schoolYear', 'dimension'];
+
 /**
  * Responsible for mapping server provided report options into option
  * models that can be directly consumed by the UI components
@@ -136,6 +138,7 @@ export class AggregateReportOptionsMapper {
       economicDisadvantages: options.economicDisadvantages,
       performanceLevelDisplayType: PerformanceLevelDisplayTypes.Separate,
       valueDisplayType: ValueDisplayTypes.Percent,
+      columnOrder: DefaultColumnOrder,
       dimensionTypes: [],
       includeStateResults: true,
       includeAllDistricts: false,

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.spec.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.spec.ts
@@ -12,6 +12,7 @@ import { Observable } from "rxjs/Observable";
 import { AggregateReportOptions } from "./aggregate-report-options";
 import { AggregateReportQuery, AggregateReportRequest } from "../report/aggregate-report-request";
 import { AggregateReportFormSettings } from "./aggregate-report-form-settings";
+import { DefaultColumnOrder } from "./aggregate-report-options.mapper";
 import Spy = jasmine.Spy;
 
 describe('AggregateReportRequestMapper', () => {
@@ -63,7 +64,8 @@ describe('AggregateReportRequestMapper', () => {
       schoolIds: [ 2 ],
       schoolYears: [ 2000 ],
       subjectCodes: [ 'Math' ],
-      valueDisplayType: 'Number'
+      valueDisplayType: 'Number',
+      columnOrder: ['columnA', 'columnB']
     };
 
     const request: AggregateReportRequest = {
@@ -95,7 +97,8 @@ describe('AggregateReportRequestMapper', () => {
       schoolYears: query.schoolYears,
       subjects: query.subjectCodes,
       valueDisplayType: query.valueDisplayType,
-      name: request.name
+      name: request.name,
+      columnOrder: ['columnA', 'columnB']
     };
 
     fixture.toSettings(request, mockOptions())
@@ -151,7 +154,8 @@ describe('AggregateReportRequestMapper', () => {
       schoolYears: query.schoolYears,
       subjects: query.subjectCodes,
       valueDisplayType: query.valueDisplayType,
-      name: request.name
+      name: request.name,
+      columnOrder: DefaultColumnOrder
     };
 
     fixture.toSettings(request, options)

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
@@ -9,6 +9,7 @@ import { Observable } from "rxjs/Observable";
 import { District, OrganizationType, School } from "../shared/organization/organization";
 import { Utils } from "../shared/support/support";
 import { AggregateReportOrganizationService } from "./aggregate-report-organization.service";
+import { DefaultColumnOrder } from "./aggregate-report-options.mapper";
 
 const equalSize = (a: any[], b: any[]) => a.length === b.length;
 const idsOf = values => values.map(value => value.id);
@@ -47,7 +48,8 @@ export class AggregateReportRequestMapper {
       includeState: settings.includeStateResults,
       schoolYears: settings.schoolYears,
       subjectCodes: settings.subjects,
-      valueDisplayType: settings.valueDisplayType
+      valueDisplayType: settings.valueDisplayType,
+      columnOrder: settings.columnOrder
     };
 
     if (assessmentDefinition.interim) {
@@ -174,6 +176,9 @@ export class AggregateReportRequestMapper {
           schools: schools,
           subjects: query.subjectCodes,
           valueDisplayType: query.valueDisplayType,
+          columnOrder: Utils.isNullOrEmpty(request.reportQuery.columnOrder)
+            ? DefaultColumnOrder
+            : request.reportQuery.columnOrder
         };
       });
   }

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
@@ -26,6 +26,7 @@ import { AggregateReportFormSettingsResolve } from "./aggregate-report-form-sett
 import { StickyDirective } from "../shared/nav/sticky.directive";
 import { CsvModule } from "../csv-export/csv-export.module";
 import { AggregateReportTableExportService } from "./results/aggregate-report-table-export.service";
+import { AggregateReportColumnOrderItemProvider } from "./aggregate-report-column-order-item.provider";
 
 @NgModule({
   declarations: [
@@ -65,7 +66,8 @@ import { AggregateReportTableExportService } from "./results/aggregate-report-ta
     AggregateReportOptionsMapper,
     AggregateReportOrganizationService,
     AggregateReportItemMapper,
-    AggregateReportFormSettingsResolve
+    AggregateReportFormSettingsResolve,
+    AggregateReportColumnOrderItemProvider
   ]
 })
 export class AggregateReportsModule {

--- a/webapp/src/main/webapp/src/app/report/aggregate-report-request.ts
+++ b/webapp/src/main/webapp/src/app/report/aggregate-report-request.ts
@@ -29,4 +29,5 @@ export interface AggregateReportQuery {
   readonly schoolYears: number[];
   readonly subjectCodes?: string[];
   readonly valueDisplayType: string;
+  readonly columnOrder?: string[];
 }


### PR DESCRIPTION
…he results table.

This PR adds the column ordering component to the preview table in the aggregate report query form.  The user-selected column order is round-tripped through the request and initializes the result tables with the column order specified at query time.