### PR TITLE
Add ability to control info button popup placement.

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
@@ -90,7 +90,9 @@
   </p-column>
   <p-column field="score" [sortable]="true" [hidden]="isClaimScoreSelected">
     <ng-template pTemplate="header">
-      <span info-button title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
+      <span info-button
+            placement="left"
+            title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
             content="{{'labels.groups.results.assessment.exams.cols.score-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData" pTemplate="body">

--- a/webapp/src/main/webapp/src/app/shared/button/information-button.component.html
+++ b/webapp/src/main/webapp/src/app/shared/button/information-button.component.html
@@ -2,6 +2,7 @@
 <button class="btn btn-borderless btn-xs icon-only"
         [popover]="buttonPopover"
         popoverTitle="{{ title }}"
+        [placement]="placement"
         container="body"
         outsideClick="true">
     <span class="sr-only">{{'labels.more-info' | translate}}</span>

--- a/webapp/src/main/webapp/src/app/shared/button/information-button.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/button/information-button.component.ts
@@ -19,4 +19,7 @@ export class InformationButtonComponent {
   @Input()
   public icon: string;
 
+  @Input()
+  public placement: string = "top";
+
 }

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-iab-table.component.html
@@ -55,7 +55,9 @@
   </p-column>
   <p-column field="exam.score" sortable="true">
     <ng-template pTemplate="header">
-      <span info-button title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
+      <span info-button
+            placement="left"
+            title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
             content="{{'labels.groups.results.assessment.exams.cols.score-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData.exam" pTemplate="body">

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-ica-summitive-table.component.html
@@ -72,7 +72,9 @@
             sortable="true"
             [hidden]="displayState.table !== 'overall'">
     <ng-template pTemplate="header">
-      <span info-button title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
+      <span info-button
+            placement="left"
+            title="{{'labels.groups.results.assessment.exams.cols.score' | translate}}"
             content="{{'labels.groups.results.assessment.exams.cols.score-info' | translate}}"></span>
     </ng-template>
     <ng-template let-exam="rowData.exam" pTemplate="body">


### PR DESCRIPTION
Move popup placement from top left when info button is in the last column of a table.

Unfortunately our ngx-bootstrap library doesn't have a "keep the popover on the screen" option for popover placement.
This PR adds the ability pass the popver placement through the info-button component to the popover component.  I've updated the three tables I know of that have a final table column with a popover info-button to place the popover to the left of the button rather than centered on top.

![image](https://user-images.githubusercontent.com/617828/36397836-1453c500-1579-11e8-981a-d650637f57a3.png)
