### PR TITLE
Fix downloads in the My Reports page

### DIFF
--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -3,12 +3,9 @@ import { ReportAction, ReportActionService } from "./report-action.service";
 import { PopupMenuAction } from "../shared/menu/popup-menu-action.model";
 import { Report } from "./report.model";
 import { TranslateService } from "@ngx-translate/core";
-import { Observable } from "rxjs/Observable";
-import { Download } from "../shared/data/download.model";
-import { saveAs } from "file-saver";
 import { SpinnerModal } from "../shared/loading/spinner.modal";
-import { NotificationService } from "../shared/notification/notification.service";
 import 'rxjs/add/operator/finally';
+import { Observable } from "rxjs/Observable";
 
 /**
  * Responsible for providing a UI displaying and performing an action
@@ -32,8 +29,7 @@ export class ReportActionComponent implements OnInit {
   public menuActions: PopupMenuAction[];
 
   constructor(private actionService: ReportActionService,
-              private translateService: TranslateService,
-              private notificationService: NotificationService) {
+              private translateService: TranslateService) {
   }
 
   ngOnInit(): void {
@@ -44,25 +40,18 @@ export class ReportActionComponent implements OnInit {
 
   performAction(reportAction: ReportAction): void {
     this.spinnerModal.loading = true;
-    const observable: Observable<Download> | void = this.actionService.performAction(reportAction);
-    if (observable) {
-      observable.finally(() => {
+    const action: Observable<any> = this.actionService.performAction(reportAction);
+    action
+      .finally(() => {
         this.spinnerModal.loading = false;
-      }).subscribe(
-        (download: Download) => {
-          saveAs(download.content, download.name);
-        },
-        () => {
-          this.notificationService.error({ id: 'labels.reports.messages.download-failed' });
-        },
-      );
-    }
+      })
+      .subscribe(() => {});
   }
 
   private toMenuAction(reportAction: ReportAction): PopupMenuAction {
     const menuAction: PopupMenuAction = new PopupMenuAction();
     menuAction.perform = () => {
-      this.actionService.performAction(reportAction);
+      this.performAction(reportAction);
     };
     menuAction.displayName = () => {
       return this.translateService.instant(reportAction.labelKey);

--- a/webapp/src/main/webapp/src/app/report/report-action.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.ts
@@ -3,7 +3,9 @@ import { Report } from "./report.model";
 import { ReportService } from "./report.service";
 import { Download } from "../shared/data/download.model";
 import { Router } from "@angular/router";
+import { saveAs } from "file-saver";
 import { Observable } from "rxjs/Observable";
+import { NotificationService } from "../shared/notification/notification.service";
 
 export const AggregateReportType: string = "AggregateReportRequest";
 
@@ -20,7 +22,8 @@ export class ReportActionService {
   ];
 
   constructor(private reportService: ReportService,
-              private router: Router) {
+              private router: Router,
+              private notificationService: NotificationService) {
   }
 
   /**
@@ -40,17 +43,33 @@ export class ReportActionService {
    *
    * @param {ReportAction} action An action
    */
-  public performAction(action: ReportAction): Observable<Download> | void {
+  public performAction(action: ReportAction): Observable<any> {
     switch (action.type) {
       case ActionType.Download:
         return this.performDownload(action);
       case ActionType.Navigate:
-        return this.performNavigate(action);
+        this.performNavigate(action);
+        return Observable.empty();
     }
   }
 
-  private performDownload(action: ReportAction): Observable<Download> {
-    return this.reportService.getReportContent(action.value);
+  /**
+   * Test
+   * @param {ReportAction} action
+   * @returns {Observable<any>}
+   */
+  private performDownload(action: ReportAction): Observable<any> {
+    const observable: Observable<any> = this.reportService.getReportContent(action.value);
+    observable
+      .subscribe(
+        (download: Download) => {
+          saveAs(download.content, download.name);
+          console.log("done saving");
+        },
+        (error) => {
+          this.notificationService.error({ id: 'labels.reports.messages.download-failed' });
+        });
+    return observable;
   }
 
   private performNavigate(action: ReportAction): void {

--- a/webapp/src/main/webapp/src/app/report/report-action.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.ts
@@ -64,7 +64,6 @@ export class ReportActionService {
       .subscribe(
         (download: Download) => {
           saveAs(download.content, download.name);
-          console.log("done saving");
         },
         (error) => {
           this.notificationService.error({ id: 'labels.reports.messages.download-failed' });


### PR DESCRIPTION
The introduction of the spinner in the My Reports download page prevented users from being able to download aggregate reports.

This PR moves the download saving out of the My Reports component and back into the action handler.  The action handler will now return an observable that the component can use to determine when an arbitrary action has been completed.