### PR TITLE
Change our info icon button from default type to "button" type.

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/button/information-button.component.html
+++ b/webapp/src/main/webapp/src/app/shared/button/information-button.component.html
@@ -1,5 +1,6 @@
 {{ title }}
 <button class="btn btn-borderless btn-xs icon-only"
+        type="button"
         [popover]="buttonPopover"
         popoverTitle="{{ title }}"
         [placement]="placement"


### PR DESCRIPTION
Most browsers use "submit" as their default button type.  This was causing us an issue when binding to a form's submit event *and* the form contained an un-typed info popup button.

This PR just changes the info button type from the default to "button."