### PR TITLE
Remove the html id conflict between the advanced filters transfer tog…

### DIFF
--- a/webapp/src/main/webapp/src/app/report/report-download.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.html
@@ -49,12 +49,12 @@
             </div>
 
             <div class="form-group" *ngIf="transferAccess">
-              <label>
+              <label for="report-transfer-assessment-toggle">
                 <span info-button
                       title="{{'labels.filters.test.transfer-assessment' | translate}}"
                       content="{{'labels.filters.test.transfer-assessment-info' | translate}}"></span>
               </label>
-              <sb-radio-button-group name="transfer-assessment-toggle"
+              <sb-radio-button-group name="report-transfer-assessment-toggle"
                          [(ngModel)]="options.disableTransferAccess"
                          [options]="[
                            {value: false, text: 'buttons.visibility.show' | translate},


### PR DESCRIPTION
…gle and the report dialog transfer toggle.

After toggling the control in the advanced filters the control in the report dialog was unresponsive and vice-versa.