### PR TITLE
Append a ";charset=UTF-8" encoding specification to the CSV report do…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/MediaTypes.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/MediaTypes.java
@@ -13,17 +13,19 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
  */
 public class MediaTypes {
 
+    private static final Map<String, String> UTF8_CHARSET = ImmutableMap.of("charset", "UTF-8");
+
     public static final MediaType APPLICATION_PDF_UTF8 = new MediaType(
             MediaType.APPLICATION_PDF,
-            ImmutableMap.of("charset", "UTF-8"));
+            UTF8_CHARSET);
 
     public static final MediaType APPLICATION_ZIP = new MediaType("application", "zip");
-    public static final MediaType TEXT_CSV = new MediaType("text", "csv");
+    public static final MediaType TEXT_CSV_UTF8 = new MediaType("text", "csv", UTF8_CHARSET);
 
     public static final Map<MediaType, String> MediaTypeToExtension = ImmutableMap.<MediaType, String>builder()
             .put(APPLICATION_PDF_UTF8, "pdf")
             .put(APPLICATION_ZIP, "zip")
-            .put(TEXT_CSV, "csv")
+            .put(TEXT_CSV_UTF8, "csv")
             .put(APPLICATION_JSON, "json")
             .build();
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportService.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.processor.service;
 
 import com.amazonaws.services.s3.Headers;
 import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.reporting.common.util.MediaTypes;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.processor.model.ExportExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.repository.ExamRepository;
@@ -37,7 +38,7 @@ public class ArchiveExamExportService implements ExamExportService {
         final URI location = getRelativeUri(repository.export(user, request, uri.toASCIIString()));
 
         final Properties properties = new Properties();
-        properties.setProperty(Headers.CONTENT_TYPE, "text/csv");
+        properties.setProperty(Headers.CONTENT_TYPE, MediaTypes.TEXT_CSV_UTF8.toString());
         archiveService.writeProperties(location.toASCIIString(), properties);
 
         return location;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandler.java
@@ -45,7 +45,7 @@ import java.util.Locale;
 import static org.apache.commons.lang.StringUtils.EMPTY;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.opentestsystem.rdw.common.model.AssessmentType.IAB;
-import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV;
+import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.getExtension;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -86,10 +86,10 @@ public class AggregateReportCsvHandler extends DefaultReportHandler {
 
     @Override
     protected void setHeaders(final ReportContentResource resource, final HttpHeaders headers) {
-        final String filename = resource.getReport().getLabel().replaceAll("\\s", "_") + "." + getExtension(TEXT_CSV);
+        final String filename = resource.getReport().getLabel().replaceAll("\\s", "_") + "." + getExtension(TEXT_CSV_UTF8);
         final String contentDisposition = Headers.formatContentDispositionAttachment(filename, Charset.forName("UTF-8"));
 
-        headers.setContentType(TEXT_CSV);
+        headers.setContentType(TEXT_CSV_UTF8);
         headers.set(CONTENT_DISPOSITION, contentDisposition);
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandlerTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
-import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV;
+import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -122,7 +122,7 @@ public class AggregateReportCsvHandlerTest {
         handler.writeResource(resource, outputMessage);
 
         final HttpHeaders headers = outputMessage.getHeaders();
-        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV);
+        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV_UTF8);
         assertThat(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("my_report");
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/DefaultReportHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/DefaultReportHandlerTest.java
@@ -16,7 +16,7 @@ import java.io.ByteArrayInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV;
+import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultReportHandlerTest {
@@ -40,7 +40,7 @@ public class DefaultReportHandlerTest {
         when(resource.getInputStream())
                 .thenAnswer(invocationOnMock -> new ByteArrayInputStream(ResourceContent));
         when(resource.contentLength()).thenReturn((long) ResourceContent.length);
-        when(resource.getMediaType()).thenReturn(TEXT_CSV);
+        when(resource.getMediaType()).thenReturn(TEXT_CSV_UTF8);
         when(resource.getReport()).thenReturn(report);
 
         handler = new DefaultReportHandler();
@@ -56,7 +56,7 @@ public class DefaultReportHandlerTest {
         handler.writeResource(resource, outputMessage);
 
         final HttpHeaders headers = outputMessage.getHeaders();
-        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV);
+        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV_UTF8);
         assertThat(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("my_report");
         assertThat(headers.getContentLength()).isEqualTo(ResourceContent.length);
     }


### PR DESCRIPTION
…wnload content-type response header.

The bits being sent to the browser are correct, we just need to tell the browser that they represent UTF-8 text rather than browser-default text.