### PR TITLE
Allow a user to include all aggregate report dimensions

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -25,109 +25,109 @@ services:
       - 5672:5672
       - 15672:15672
 
-#  config-server:
-#    image: smarterbalanced/configuration-service:3.1.0.RELEASE
-#    container_name: config-server
+  config-server:
+    image: smarterbalanced/configuration-service:3.1.0.RELEASE
+    container_name: config-server
+    ports:
+      - 8888:8888
+    links:
+      - rabbitmq
+    environment:
+      - CONFIG_SERVICE_REPO
+      - ENCRYPT_KEY
+      - GIT_USER
+      - GIT_PASSWORD
+      - SPRING_RABBITMQ_ADDRESSES=rabbitmq:5672
+      - SPRING_RABBITMQ_USERNAME=guest
+      - SPRING_RABBITMQ_PASSWORD=guest
+
+  webapp:
+    image: smarterbalanced/rdw-reporting-webapp
+    ports:
+      - 8080:8080
+      - 8081:8008
+    links:
+      - config-server
+      - admin-service
+# uncomment to enable aggregate service
+#      - aggregate-service
+      - report-processor-service
+      - reporting-service
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+  admin-service:
+    image: smarterbalanced/rdw-reporting-admin-service
+    ports:
+      - 8280:8080
+      - 8208:8008
+    volumes:
+      - /tmp:/tmp
+    links:
+      - config-server
+      - rabbitmq
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+# uncomment to enable aggregate service
+#  aggregate-service:
+#    image: smarterbalanced/rdw-reporting-aggregate-service
 #    ports:
-#      - 8888:8888
-#    links:
-#      - rabbitmq
-#    environment:
-#      - CONFIG_SERVICE_REPO
-#      - ENCRYPT_KEY
-#      - GIT_USER
-#      - GIT_PASSWORD
-#      - SPRING_RABBITMQ_ADDRESSES=rabbitmq:5672
-#      - SPRING_RABBITMQ_USERNAME=guest
-#      - SPRING_RABBITMQ_PASSWORD=guest
-#
-#  webapp:
-#    image: smarterbalanced/rdw-reporting-webapp
-#    ports:
-#      - 8080:8080
-#      - 8081:8008
-#    links:
-#      - config-server
-#      - admin-service
-## uncomment to enable aggregate service
-##      - aggregate-service
-#      - report-processor-service
-#      - reporting-service
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  admin-service:
-#    image: smarterbalanced/rdw-reporting-admin-service
-#    ports:
-#      - 8280:8080
-#      - 8208:8008
+#      - 8380:8080
+#      - 8308:8008
 #    volumes:
 #      - /tmp:/tmp
 #    links:
 #      - config-server
-#      - rabbitmq
 #    environment:
 #      - spring.profiles.active=local-docker
 #      - CONFIG_SERVICE_ENABLED=true
 #      - CONFIG_SERVICE_URL=http://config-server:8888
 #    extra_hosts:
 #      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-## uncomment to enable aggregate service
-##  aggregate-service:
-##    image: smarterbalanced/rdw-reporting-aggregate-service
-##    ports:
-##      - 8380:8080
-##      - 8308:8008
-##    volumes:
-##      - /tmp:/tmp
-##    links:
-##      - config-server
-##    environment:
-##      - spring.profiles.active=local-docker
-##      - CONFIG_SERVICE_ENABLED=true
-##      - CONFIG_SERVICE_URL=http://config-server:8888
-##    extra_hosts:
-##      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  reporting-service:
-#    image: smarterbalanced/rdw-reporting-service
-#    ports:
-#      - 8180:8080
-#      - 8108:8008
-#    links:
-#      - config-server
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  report-processor-service:
-#    image: smarterbalanced/rdw-reporting-report-processor
-#    ports:
-#      - 8085:8080
-#      - 8086:8008
-#    volumes:
-#      - /tmp:/tmp
-#    links:
-#      - config-server
-#      - rabbitmq
-#      - wkhtmltopdf
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  wkhtmltopdf:
-#    image: smarterbalanced/wkhtmltopdf-image:latest
-#    ports:
-#      - 8082:80
+
+  reporting-service:
+    image: smarterbalanced/rdw-reporting-service
+    ports:
+      - 8180:8080
+      - 8108:8008
+    links:
+      - config-server
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+  report-processor-service:
+    image: smarterbalanced/rdw-reporting-report-processor
+    ports:
+      - 8085:8080
+      - 8086:8008
+    volumes:
+      - /tmp:/tmp
+    links:
+      - config-server
+      - rabbitmq
+      - wkhtmltopdf
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+  wkhtmltopdf:
+    image: smarterbalanced/wkhtmltopdf-image:latest
+    ports:
+      - 8082:80

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.spec.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.spec.ts
@@ -139,7 +139,7 @@ describe('AggregateReportRequestMapper', () => {
       completenesses: options.completenesses,
       economicDisadvantages: options.economicDisadvantages,
       ethnicities: options.ethnicities,
-      dimensionTypes: options.dimensionTypes,
+      dimensionTypes: [],
       districts: [],
       genders: options.genders,
       individualEducationPlans: options.individualEducationPlans,

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
@@ -48,6 +48,7 @@ export class AggregateReportRequestMapper {
       includeState: settings.includeStateResults,
       schoolYears: settings.schoolYears,
       subjectCodes: settings.subjects,
+      dimensionTypes: settings.dimensionTypes,
       valueDisplayType: settings.valueDisplayType,
       columnOrder: settings.columnOrder
     };
@@ -64,9 +65,6 @@ export class AggregateReportRequestMapper {
 
     if (!equalSize(settings.completenesses, options.completenesses)) {
       query.completenessCodes = settings.completenesses;
-    }
-    if (!equalSize(settings.dimensionTypes, options.dimensionTypes)) {
-      query.dimensionTypes = settings.dimensionTypes;
     }
     if (!equalSize(settings.economicDisadvantages, options.economicDisadvantages)) {
       query.economicDisadvantageCodes = settings.economicDisadvantages;
@@ -136,7 +134,7 @@ export class AggregateReportRequestMapper {
             ? options.completenesses
             : query.completenessCodes,
           dimensionTypes: Utils.isNullOrEmpty(query.dimensionTypes)
-            ? options.dimensionTypes
+            ? []
             : query.dimensionTypes,
           districts: districts,
           economicDisadvantages: Utils.isNullOrEmpty(query.economicDisadvantageCodes)


### PR DESCRIPTION
We were previously treating dimensions similarly to filters, where if all were selected the front-end was stripping the parameters from the request payload.