### PR TITLE
Prevent student, group, and school-grade report download modal dialog…

### DIFF
--- a/webapp/src/main/webapp/src/app/report/report-download.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-download.component.html
@@ -6,7 +6,8 @@
      aria-hidden="true"
      (onShow)="onShowInternal($event)">
 
-  <div class="modal-dialog modal-md">
+  <div *ngIf="modal.isShown"
+       class="modal-dialog modal-md">
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title pull-left">{{title}}</h4>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1450,7 +1450,7 @@
       },
       "form": {
         "accommodations": {
-          "info": "This feature allows student reports that may be shared with colleges and universities or other external organizations to be printed without reference to accommodations.",
+          "info": "This feature allows student reports that may be shared with colleges and universities or other external organizations to be printed without reference to accommodations made available to the student.",
           "title": "Student Accommodations"
         },
         "assessment-type": "Assessment Type",


### PR DESCRIPTION
…s from interfering with each other.

The problem was that our report download dialog modals are *always* in the DOM, whether or not they're visible.  This led to interference between two modal dialog's inputs due to sharing the same HTML id attribute.

This fix is to remove the modal dialog's elements from the DOM until/unless the modal dialog is visible.