### PR TITLE
address uat feedback + misc cleanup

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
@@ -320,11 +320,8 @@
           <div class="well">
             <div class="row">
               <div class="col-md-6">
-                <!--<label info-button-->
-                       <!--title="{{'aggregate-reports.form.field.comparative-subgroup.label' | translate}}"-->
-                       <!--content="{{'aggregate-reports.form.field.comparative-subgroup.info' | translate}}"></label>-->
               </div>
-              <div class="col-md-3">
+              <div class="col-md-6">
                 <sb-checkbox-group [options]="options.dimensionTypes"
                                    [(ngModel)]="settings.dimensionTypes"
                                    [ngModelOptions]="{standalone: true}"

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
@@ -18,12 +18,12 @@
         text: 'aggregate-reports.form.section.assessment.heading' | translate
       },
       {
-        scrollTo: subgroupFiltersSection,
-        text: 'aggregate-reports.form.section.subgroup-filters.heading' | translate
+        scrollTo: subgroupSection,
+        text: 'aggregate-reports.form.section.comparative-subgroups.heading' | translate
       },
       {
-        scrollTo: comparativeSubgroupSection,
-        text: 'aggregate-reports.form.section.comparative-subgroups.heading' | translate
+        scrollTo: advancedFiltersSection,
+        text: 'aggregate-reports.form.section.subgroup-filters.heading' | translate
       },
       {
         scrollTo: reportNameSection,
@@ -39,11 +39,12 @@
       }
       ]">
       <button class="btn btn-success btn-sm green ml-sm mt-xs"
+              [disabled]="submissionSubscription"
               (click)="onGenerateButtonClick()">{{'aggregate-reports.form.submit' | translate}}</button>
     </scroll-nav>
   </div>
 
-  <div class="row mt-sm">
+  <div class="row mt-sm mb-sm">
     <div class="col-md-8 col-md-offset-2">
       <h2 class="h3 gray-darkest">
         {{'aggregate-reports.form.heading' | translate}}
@@ -55,115 +56,109 @@
   <form #form [formGroup]="formGroup">
 
     <!-- Organization -->
-    <div class="row mt-sm" #organizationSection id="organizationSection">
+    <div class="row" #organizationSection id="organizationSection">
       <div class="col-md-8 col-md-offset-2">
-        <h3 class="h3 gray-darkest">
-          {{'aggregate-reports.form.section.organization.heading' | translate}}
-        </h3>
-        <p class="small gray-darkest">{{'aggregate-reports.form.section.organization.subtext' | translate}}</p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-8 col-md-offset-2">
-        <div class="well pb-0">
+        <div class="well-group">
+          <div class="well">
+            <h3>{{'aggregate-reports.form.section.organization.heading' | translate}}</h3>
+            <div class="subtext">{{'aggregate-reports.form.section.organization.subtext' | translate}}</div>
+          </div>
+          <div class="well pb-0">
 
-          <!-- Typeahead -->
-          <div>
-            <label>{{'aggregate-reports.form.field.organization.label' | translate}}</label>
-            <organization-typeahead #organizationTypeahead
-                                    [options]="organizationTypeaheadOptions"
-                                    (selected)="onOrganizationTypeaheadSelect($event)"></organization-typeahead>
-            <div class="form-group">
-              <input type="hidden"
-                     [(ngModel)]="organizations"
-                     formControlName="organizations"
-                     (ngModelChange)="onSettingsChange()">
-              <div *ngIf="showErrors(organizationsControl)">
-                <p *ngIf="organizationsControl.errors.invalid" class="help-block small red">{{organizationsControl.errors.invalid.messageId | translate}}</p>
+            <!-- Typeahead -->
+            <div>
+              <label>{{'aggregate-reports.form.field.organization.label' | translate}}</label>
+              <organization-typeahead #organizationTypeahead
+                                      [options]="organizationTypeaheadOptions"
+                                      (selected)="onOrganizationTypeaheadSelect($event)"></organization-typeahead>
+              <div class="form-group">
+                <input type="hidden"
+                       [(ngModel)]="organizations"
+                       formControlName="organizations"
+                       (ngModelChange)="onSettingsChange()">
+                <div *ngIf="showErrors(organizationsControl)">
+                  <p *ngIf="organizationsControl.errors.invalid" class="help-block small red">{{organizationsControl.errors.invalid.messageId | translate}}</p>
+                </div>
               </div>
             </div>
-          </div>
 
-          <!-- Settings -->
-          <div>
-            <label>{{'aggregate-reports.form.section.organization.include.heading' | translate}}</label>
-            <ul class="list-group list-group-sm small">
-              <li class="list-group-item">
-                <div class="row">
-                  <div class="col-sm-6">
-                    <label class="inline-label">
-                      <input type="checkbox"
-                             [(ngModel)]="settings.includeStateResults"
-                             [ngModelOptions]="{standalone: true}"
-                             (change)="onIncludeStateResultsChange()">
-                      <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.state-results' | translate}}</span>
-                    </label>
+            <!-- Settings -->
+            <div>
+              <label>{{'aggregate-reports.form.section.organization.include.heading' | translate}}</label>
+              <ul class="list-group list-group-sm small mb-0">
+                <li class="list-group-item">
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <label class="inline-label">
+                        <input type="checkbox"
+                               [(ngModel)]="settings.includeStateResults"
+                               [ngModelOptions]="{standalone: true}"
+                               (change)="onIncludeStateResultsChange()">
+                        <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.state-results' | translate}}</span>
+                      </label>
+                    </div>
+                    <div class="col-sm-6" *ngIf="options.statewideReporter">
+                      <label class="inline-label">
+                        <input type="checkbox"
+                               [(ngModel)]="settings.includeAllDistricts"
+                               [ngModelOptions]="{standalone: true}"
+                               (change)="onIncludeAllDistrictsChange()">
+                        <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-districts' | translate}}</span>
+                      </label>
+                    </div>
                   </div>
-                  <div class="col-sm-6" *ngIf="options.statewideReporter">
-                    <label class="inline-label">
-                      <input type="checkbox"
-                             [(ngModel)]="settings.includeAllDistricts"
-                             [ngModelOptions]="{standalone: true}"
-                             (change)="onIncludeAllDistrictsChange()">
-                      <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-districts' | translate}}</span>
-                    </label>
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <label class="inline-label">
+                        <input type="checkbox"
+                               [(ngModel)]="settings.includeAllSchoolsOfSelectedDistricts"
+                               [ngModelOptions]="{standalone: true}">
+                        <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-schools-of-districts' | translate}}</span>
+                      </label>
+                    </div>
+                    <div class="col-sm-6">
+                      <label class="inline-label">
+                        <input type="checkbox"
+                               [(ngModel)]="settings.includeAllDistrictsOfSelectedSchools"
+                               [ngModelOptions]="{standalone: true}">
+                        <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-districts-of-schools' | translate}}</span>
+                      </label>
+                    </div>
                   </div>
-                </div>
-                <div class="row">
-                  <div class="col-sm-6">
-                    <label class="inline-label">
-                      <input type="checkbox"
-                             [(ngModel)]="settings.includeAllSchoolsOfSelectedDistricts"
-                             [ngModelOptions]="{standalone: true}">
-                      <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-schools-of-districts' | translate}}</span>
-                    </label>
-                  </div>
-                  <div class="col-sm-6">
-                    <label class="inline-label">
-                      <input type="checkbox"
-                             [(ngModel)]="settings.includeAllDistrictsOfSelectedSchools"
-                             [ngModelOptions]="{standalone: true}">
-                      <span class="ml-xs">{{'aggregate-reports.form.section.organization.include.all-districts-of-schools' | translate}}</span>
-                    </label>
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </div>
+                </li>
+              </ul>
+            </div>
 
-          <!-- Selections -->
-          <div [hidden]="!settings.districts.length">
-            <label>{{'aggregate-reports.form.section.organization.district-list-heading' | translate}}</label>
-            <aggregate-report-organization-list [organizations]="settings.districts"
-                                                (organizationClick)="onOrganizationListItemClose($event)"></aggregate-report-organization-list>
-          </div>
-          <div [hidden]="!settings.schools.length">
-            <label>{{'aggregate-reports.form.section.organization.school-list-heading' | translate}}</label>
-            <aggregate-report-organization-list [organizations]="settings.schools"
-                                                (organizationClick)="onOrganizationListItemClose($event)"></aggregate-report-organization-list>
+            <!-- Selections -->
+            <div [hidden]="!settings.districts.length">
+              <label>{{'aggregate-reports.form.section.organization.district-list-heading' | translate}}</label>
+              <aggregate-report-organization-list [organizations]="settings.districts"
+                                                  (organizationClick)="onOrganizationListItemClose($event)"></aggregate-report-organization-list>
+            </div>
+            <div [hidden]="!settings.schools.length">
+              <label>{{'aggregate-reports.form.section.organization.school-list-heading' | translate}}</label>
+              <aggregate-report-organization-list [organizations]="settings.schools"
+                                                  (organizationClick)="onOrganizationListItemClose($event)"></aggregate-report-organization-list>
+            </div>
           </div>
         </div>
       </div>
     </div>
 
     <!-- Assessment Attributes -->
-    <div class="row mt-sm" #assessmentSection id="assessmentSection">
-      <div class="col-md-8 col-md-offset-2">
-        <h3 class="h3 gray-darkest">
-          {{'aggregate-reports.form.section.assessment.heading' | translate}}
-        </h3>
-      </div>
-    </div>
-    <div class="row">
+    <div class="row" #assessmentSection id="assessmentSection">
       <div class="col-md-8 col-md-offset-2">
         <div class="well-group">
+          <div class="well">
+            <h3>{{'aggregate-reports.form.section.assessment.heading' | translate}}</h3>
+          </div>
           <div class="well">
             <div class="row">
               <div class="col-md-6">
                 <label>{{'aggregate-reports.form.field.assessment-type.label' | translate}}</label>
               </div>
               <div class="col-md-6">
-                <span *ngIf="options.assessmentTypes.length == 1">{{options.assessmentTypes[0].text}}</span>
+                <span class="gray-darker" *ngIf="options.assessmentTypes.length == 1">{{options.assessmentTypes[0].text}}</span>
                 <sb-radio-button-group *ngIf="options.assessmentTypes.length > 1"
                            name="assessmentType"
                            [options]="options.assessmentTypes"
@@ -314,177 +309,20 @@
       </div>
     </div>
 
-    <!-- Subgroup Filters -->
-    <div class="row mt-sm" #subgroupFiltersSection id="subgroupFiltersSection">
-      <div class="col-md-8 col-md-offset-2">
-        <h3 class="h3 gray-darkest">
-          {{'aggregate-reports.form.section.subgroup-filters.heading' | translate}}
-        </h3>
-      </div>
-    </div>
-    <div class="row">
+    <!-- Subgroups -->
+    <div class="row" #subgroupSection id="subgroupSection">
       <div class="col-md-8 col-md-offset-2">
         <div class="well-group">
           <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.gender.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.gender.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.genders"
-                                   [(ngModel)]="settings.genders"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="genders"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'Gender: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
+            <h3>{{'aggregate-reports.form.section.comparative-subgroups.heading' | translate}}</h3>
+            <div class="subtext">{{'aggregate-reports.form.section.comparative-subgroups.subtext' | translate}}</div>
           </div>
           <div class="well">
             <div class="row">
               <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.ethnicity.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.ethnicity.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [options]="options.ethnicities"
-                                   [(ngModel)]="settings.ethnicities"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="ethnicities"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'Ethnicity: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.migrant-status.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.migrant-status.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.migrantStatuses"
-                                   [(ngModel)]="settings.migrantStatuses"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="migrantStatuses"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'Migrant Status: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.iep.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.iep.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.individualEducationPlans"
-                                   [(ngModel)]="settings.individualEducationPlans"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="individualEducationPlans"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'IEP: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.504.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.504.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.section504s"
-                                   [(ngModel)]="settings.section504s"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="section504s"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: '504 Plan: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.limited-english-proficiency.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.limited-english-proficiency.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.limitedEnglishProficiencies"
-                                   [(ngModel)]="settings.limitedEnglishProficiencies"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="limitedEnglishProficiencies"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'Limited English Proficiency: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.economic-disadvantage.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.economic-disadvantage.info' | translate}}"></label>
-              </div>
-              <div class="col-md-6">
-                <sb-checkbox-group [horizontal]="true"
-                                   [options]="options.economicDisadvantages"
-                                   [(ngModel)]="settings.economicDisadvantages"
-                                   [ngModelOptions]="{standalone: true}"
-                                   name="economicDisadvantages"
-                                   analyticsEvent="FilterClick"
-                                   analyticsCategory="AggregateQueryBuilder"
-                                   [allOptionAnalyticsProperties]="{label: 'Economic Disadvantage: All'}"
-                                   (change)="onSettingsChange()"></sb-checkbox-group>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Comparative Subgroups -->
-    <div class="row mt-sm" #comparativeSubgroupSection id="comparativeSubgroupSection">
-      <div class="col-md-8 col-md-offset-2">
-        <h3 class="h3 gray-darkest">
-          {{'aggregate-reports.form.section.comparative-subgroups.heading' | translate}}
-        </h3>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-8 col-md-offset-2">
-        <div class="well-group">
-          <div class="well">
-            <div class="row">
-              <div class="col-md-6">
-                <label info-button
-                       title="{{'aggregate-reports.form.field.comparative-subgroup.label' | translate}}"
-                       content="{{'aggregate-reports.form.field.comparative-subgroup.info' | translate}}"></label>
+                <!--<label info-button-->
+                       <!--title="{{'aggregate-reports.form.field.comparative-subgroup.label' | translate}}"-->
+                       <!--content="{{'aggregate-reports.form.field.comparative-subgroup.info' | translate}}"></label>-->
               </div>
               <div class="col-md-3">
                 <sb-checkbox-group [options]="options.dimensionTypes"
@@ -503,28 +341,189 @@
       </div>
     </div>
 
-    <!-- Report Name -->
-    <div class="row mt-sm" #reportNameSection id="reportNameSection">
+    <!-- Filters -->
+    <div class="row" #advancedFiltersSection id="advancedFiltersSection">
       <div class="col-md-8 col-md-offset-2">
-        <h3 class="h3 gray-darkest">
-          {{'aggregate-reports.form.section.report-name.heading' | translate}}
-        </h3>
+        <div class="well-group">
+          <div class="well">
+            <div class="row">
+              <div class="col-sm-6">
+                <h3>{{'aggregate-reports.form.section.subgroup-filters.heading' | translate}}</h3>
+                <div class="subtext">{{'aggregate-reports.form.section.subgroup-filters.subtext' | translate}}</div>
+              </div>
+              <div class="col-sm-6">
+                <button class="btn btn-default btn-sm icon-only pull-right"
+                        (click)="onAdvancedFiltersExpanderButtonClick()">
+                  <i class="fa" [ngClass]="showAdvancedFilters ? 'fa-angle-up' : 'fa-angle-down'"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+          <ng-container *ngIf="showAdvancedFilters">
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.gender.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.gender.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.genders"
+                                     [(ngModel)]="settings.genders"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="genders"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'Gender: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.ethnicity.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.ethnicity.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [options]="options.ethnicities"
+                                     [(ngModel)]="settings.ethnicities"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="ethnicities"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'Ethnicity: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.migrant-status.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.migrant-status.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.migrantStatuses"
+                                     [(ngModel)]="settings.migrantStatuses"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="migrantStatuses"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'Migrant Status: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.iep.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.iep.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.individualEducationPlans"
+                                     [(ngModel)]="settings.individualEducationPlans"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="individualEducationPlans"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'IEP: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.504.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.504.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.section504s"
+                                     [(ngModel)]="settings.section504s"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="section504s"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: '504 Plan: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.limited-english-proficiency.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.limited-english-proficiency.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.limitedEnglishProficiencies"
+                                     [(ngModel)]="settings.limitedEnglishProficiencies"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="limitedEnglishProficiencies"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'Limited English Proficiency: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+            <div class="well">
+              <div class="row">
+                <div class="col-md-6">
+                  <label info-button
+                         title="{{'aggregate-reports.form.field.economic-disadvantage.label' | translate}}"
+                         content="{{'aggregate-reports.form.field.economic-disadvantage.info' | translate}}"></label>
+                </div>
+                <div class="col-md-6">
+                  <sb-checkbox-group [horizontal]="true"
+                                     [options]="options.economicDisadvantages"
+                                     [(ngModel)]="settings.economicDisadvantages"
+                                     [ngModelOptions]="{standalone: true}"
+                                     name="economicDisadvantages"
+                                     analyticsEvent="FilterClick"
+                                     analyticsCategory="AggregateQueryBuilder"
+                                     [allOptionAnalyticsProperties]="{label: 'Economic Disadvantage: All'}"
+                                     (change)="onSettingsChange()"></sb-checkbox-group>
+                </div>
+              </div>
+            </div>
+          </ng-container>
+        </div>
       </div>
     </div>
-    <div class="row">
+
+    <!-- Report Name -->
+    <div class="row" #reportNameSection id="reportNameSection">
       <div class="col-md-8 col-md-offset-2">
-        <div class="well">
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group mt-sm">
-                <input type="text"
-                       class="form-control"
-                       formControlName="reportName"
-                       [(ngModel)]="settings.name"
-                       [required]="false"
-                       placeholder="{{'aggregate-reports.default-report-name' | translate}}">
-                <div *ngIf="showErrors(reportNameControl)">
-                  <p *ngIf="reportNameControl.errors.fileName" class="help-block small red">{{reportNameControl.errors.fileName.messageId | translate}}</p>
+        <div class="well-group">
+          <div class="well">
+            <h3>{{'aggregate-reports.form.section.report-name.heading' | translate}}</h3>
+          </div>
+          <div class="well">
+            <div class="row">
+              <div class="col-md-12">
+                <div class="form-group mt-sm">
+                  <input type="text"
+                         class="form-control"
+                         formControlName="reportName"
+                         [(ngModel)]="settings.name"
+                         [required]="false"
+                         placeholder="{{'aggregate-reports.default-report-name' | translate}}">
+                  <div *ngIf="showErrors(reportNameControl)">
+                    <p *ngIf="reportNameControl.errors.fileName" class="help-block small red">{{reportNameControl.errors.fileName.messageId | translate}}</p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -536,74 +535,71 @@
   </form>
 
   <!-- Summary -->
-  <div class="row mt-sm" #reviewSection id="reviewSection">
+  <div class="row" #reviewSection id="reviewSection">
     <div class="col-md-8 col-md-offset-2">
-      <h3 class="h3 gray-darkest">
-        {{'aggregate-reports.form.section.review.heading' | translate}}
-      </h3>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-8 col-md-offset-2">
-      <div class="well">
-
-        <!-- TODO add estimated row count section here -->
-
-        <aggregate-report-summary narrow="true"
-                                  [summary]="summary"></aggregate-report-summary>
-      </div>
-    </div>
-  </div>
-
-  <div class="row mt-sm" #previewSection id="previewSection">
-    <div class="col-md-8 col-md-offset-2">
-      <h3 class="h3 gray-darkest">
-        {{'aggregate-reports.form.section.preview.heading' | translate}}
-      </h3>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12 col-md-offset-2">
-      <div class="well wide-content-container">
-        <div>
-          <span class="red label">{{ 'aggregate-reports.preview' | translate }}</span>
-          <div class="mt-sm">
-            <span class="pull-left flex-child">
-              <label class="mr-xs">
-                <info-button title="{{'aggregate-report.column-order' | translate}}"
-                             content="{{'aggregate-report.column-order-info' | translate}}">
-                </info-button>
-              </label>
-              <order-selector [items]="columnItems"
-                              (itemsChange)="onColumnOrderChange($event)"></order-selector>
-            </span>
-            <span class="pull-right flex-child ml-xs">
-              <label class="mr-xs">{{'common.value-display-type-input-label' | translate}}</label>
-              <sb-radio-button-group [options]="options.valueDisplayTypes"
-                                     [(ngModel)]="settings.valueDisplayType"
-                                     buttonGroupStyles="btn-group-xs"
-                                     buttonStyles="btn-default"
-                                     analyticsCategory="AggregateQueryBuilder"
-                                     analyticsEvent="Change"></sb-radio-button-group>
-            </span>
-            <span class="pull-right flex-child ml-xs">
-              <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
-              <sb-radio-button-group [options]="options.performanceLevelDisplayTypes"
-                         [(ngModel)]="settings.performanceLevelDisplayType"
-                         buttonGroupStyles="btn-group-xs"
-                         buttonStyles="btn-default"
-                         analyticsCategory="AggregateQueryBuilder"
-                         analyticsEvent="Change"></sb-radio-button-group>
-            </span>
-          </div>
-          <div class="clearfix"></div>
+      <div class="well-group">
+        <div class="well">
+          <h3>{{'aggregate-reports.form.section.review.heading' | translate}}</h3>
         </div>
-        <div class="mt-sm">
-          <aggregate-report-table [preview]="true"
-                                  [table]="previewTable"
-                                  [valueDisplayType]="settings.valueDisplayType"
-                                  [performanceLevelDisplayType]="settings.performanceLevelDisplayType"
-                                  [columnOrdering]="settings.columnOrder"></aggregate-report-table>
+        <div class="well">
+
+          <!-- TODO add estimated row count section here -->
+
+          <aggregate-report-summary narrow="true"
+                                    [summary]="summary"></aggregate-report-summary>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="row" #previewSection id="previewSection">
+    <div class="col-md-12 col-md-offset-2">
+      <div class="well-group wide-content-container">
+        <div class="well">
+          <h3>{{'aggregate-reports.form.section.preview.heading' | translate}} </h3>
+        </div>
+        <div class="well">
+          <div>
+            <div>
+              <span class="pull-left flex-child">
+                <label class="mr-xs">
+                  <info-button title="{{'aggregate-report.column-order' | translate}}"
+                               content="{{'aggregate-report.column-order-info' | translate}}">
+                  </info-button>
+                </label>
+                <order-selector [items]="columnItems"
+                                (itemsChange)="onColumnOrderChange($event)"></order-selector>
+              </span>
+              <span class="pull-right flex-child ml-xs">
+                <label class="mr-xs">{{'common.value-display-type-input-label' | translate}}</label>
+                <sb-radio-button-group [options]="options.valueDisplayTypes"
+                                       [(ngModel)]="settings.valueDisplayType"
+                                       buttonGroupStyles="btn-group-xs"
+                                       buttonStyles="btn-default"
+                                       analyticsCategory="AggregateQueryBuilder"
+                                       analyticsEvent="Change"></sb-radio-button-group>
+              </span>
+              <span class="pull-right flex-child ml-xs">
+                <label class="mr-xs">{{'common.performance-level-display-type-input-label' | translate}}</label>
+                <sb-radio-button-group [options]="options.performanceLevelDisplayTypes"
+                                       [(ngModel)]="settings.performanceLevelDisplayType"
+                                       buttonGroupStyles="btn-group-xs"
+                                       buttonStyles="btn-default"
+                                       analyticsCategory="AggregateQueryBuilder"
+                                       analyticsEvent="Change"></sb-radio-button-group>
+              </span>
+            </div>
+            <div class="clearfix"></div>
+          </div>
+          <div class="mt-sm">
+            <div class="red label">{{ 'aggregate-reports.preview' | translate }}</div>
+            <aggregate-report-table [preview]="true"
+                                    [table]="previewTable"
+                                    [valueDisplayType]="settings.valueDisplayType"
+                                    [performanceLevelDisplayType]="settings.performanceLevelDisplayType"
+                                    [columnOrdering]="settings.columnOrder"></aggregate-report-table>
+          </div>
         </div>
       </div>
     </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
@@ -10,6 +10,8 @@ import { District, OrganizationType, School } from "../shared/organization/organ
 import { Utils } from "../shared/support/support";
 import { AggregateReportOrganizationService } from "./aggregate-report-organization.service";
 import { DefaultColumnOrder } from "./aggregate-report-options.mapper";
+import { ranking } from "@kourge/ordering/comparator";
+import { ordering } from "@kourge/ordering";
 
 const equalSize = (a: any[], b: any[]) => a.length === b.length;
 const idsOf = values => values.map(value => value.id);
@@ -124,60 +126,78 @@ export class AggregateReportRequestMapper {
       ? this.organizationService.getOrganizationsByIdAndType(OrganizationType.District, districtIds)
       : Observable.of([]);
 
+    // Returns the first argument that is not null or undefined
+    const or = (a: any, b: any) => Utils.isNullOrEmpty(a) ? b : a;
+
+    // Safely sorts the provided values ranked by the provided options
+    const sort = (values: any[], options: any[]) => (values || []).sort(ordering(ranking(options)).compare);
+
     return Observable.forkJoin(schools, districts)
       .map((results) => {
         const [ schools, districts ] = results;
-        return <AggregateReportFormSettings>{
+        const unsorted = <AggregateReportFormSettings>{
           assessmentType: query.assessmentTypeCode,
-          assessmentGrades: query.assessmentGradeCodes,
-          completenesses: Utils.isNullOrEmpty(query.completenessCodes)
-            ? options.completenesses
-            : query.completenessCodes,
-          dimensionTypes: Utils.isNullOrEmpty(query.dimensionTypes)
-            ? []
-            : query.dimensionTypes,
+          assessmentGrades: sort(query.assessmentGradeCodes, options.assessmentGrades),
+          completenesses: or(
+            sort(query.completenessCodes, options.completenesses),
+            options.completenesses
+          ),
+          dimensionTypes: or(
+            sort(query.dimensionTypes, options.dimensionTypes),
+            []
+          ),
           districts: districts,
-          economicDisadvantages: Utils.isNullOrEmpty(query.economicDisadvantageCodes)
-            ? options.economicDisadvantages
-            : query.economicDisadvantageCodes,
-          ethnicities: Utils.isNullOrEmpty(query.ethnicityCodes)
-            ? options.ethnicities
-            : query.ethnicityCodes,
-          genders: Utils.isNullOrEmpty(query.genderCodes)
-            ? options.genders
-            : query.genderCodes,
+          economicDisadvantages: or(
+            sort(query.economicDisadvantageCodes, options.economicDisadvantages),
+            options.economicDisadvantages
+          ),
+          ethnicities: or(
+            sort(query.ethnicityCodes, options.ethnicities),
+            options.ethnicities
+          ),
+          genders: or(
+            sort(query.genderCodes, options.genders),
+            options.genders
+          ),
           includeAllDistricts: query.includeAllDistricts,
           includeAllDistrictsOfSelectedSchools: query.includeAllDistrictsOfSchools,
           includeAllSchoolsOfSelectedDistricts: query.includeAllSchoolsOfDistricts,
           includeStateResults: query.includeState,
-          individualEducationPlans: Utils.isNullOrEmpty(query.iepCodes)
-            ? options.individualEducationPlans
-            : query.iepCodes,
+          individualEducationPlans: or(
+            sort(query.iepCodes, options.individualEducationPlans),
+            options.individualEducationPlans
+          ),
           interimAdministrationConditions: !queryInterimAdministrationConditions.length
             ? options.interimAdministrationConditions
             : queryInterimAdministrationConditions,
-          limitedEnglishProficiencies: Utils.isNullOrEmpty(query.lepCodes)
-            ? options.individualEducationPlans
-            : query.lepCodes,
-          migrantStatuses: Utils.isNullOrEmpty(query.migrantStatusCodes)
-            ? options.migrantStatuses
-            : query.migrantStatusCodes,
+          limitedEnglishProficiencies: or(
+            sort(query.lepCodes, options.individualEducationPlans),
+            options.individualEducationPlans
+          ),
+          migrantStatuses: or(
+            sort(query.migrantStatusCodes, options.migrantStatuses),
+            options.migrantStatuses
+          ),
           name: request.name,
           performanceLevelDisplayType: query.achievementLevelDisplayType,
-          section504s: Utils.isNullOrEmpty(query.section504Codes)
-            ? options.section504s
-            : query.section504Codes,
+          section504s: or(
+            sort(query.section504Codes, options.section504s),
+            options.section504s
+          ),
           summativeAdministrationConditions: !querySummativeAdministrationConditions.length
             ? options.summativeAdministrationConditions
             : querySummativeAdministrationConditions,
-          schoolYears: query.schoolYears,
+          schoolYears: query.schoolYears.sort((a, b) => b - a),
           schools: schools,
-          subjects: query.subjectCodes,
+          subjects: sort(query.subjectCodes, options.subjects),
           valueDisplayType: query.valueDisplayType,
-          columnOrder: Utils.isNullOrEmpty(request.reportQuery.columnOrder)
-            ? DefaultColumnOrder
-            : request.reportQuery.columnOrder
+          columnOrder: or(
+            request.reportQuery.columnOrder,
+            DefaultColumnOrder
+          )
         };
+
+        return unsorted;
       });
   }
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
@@ -135,7 +135,7 @@ export class AggregateReportRequestMapper {
     return Observable.forkJoin(schools, districts)
       .map((results) => {
         const [ schools, districts ] = results;
-        const unsorted = <AggregateReportFormSettings>{
+        return <AggregateReportFormSettings>{
           assessmentType: query.assessmentTypeCode,
           assessmentGrades: sort(query.assessmentGradeCodes, options.assessmentGrades),
           completenesses: or(
@@ -196,8 +196,6 @@ export class AggregateReportRequestMapper {
             DefaultColumnOrder
           )
         };
-
-        return unsorted;
       });
   }
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.html
@@ -1,31 +1,3 @@
-<!--<ng-template #rowTemplate let-row>-->
-  <!--<td><strong>{{row.label}}</strong></td>-->
-  <!--<td>-->
-    <!--<ul class="list-unstyled">-->
-      <!--<li *ngFor="let value of row.values">-->
-        <!--{{value}}-->
-      <!--</li>-->
-    <!--</ul>-->
-  <!--</td>-->
-<!--</ng-template>-->
-
-<!--<div class="row">-->
-  <!--<div *ngFor="let sections of columns" [ngClass]="narrow ? 'col-md-6' : 'col-md-3'">-->
-    <!--<div *ngFor="let section of sections">-->
-      <!--<div class="h5 column-heading">-->
-        <!--{{section.label}}-->
-      <!--</div>-->
-      <!--<table>-->
-        <!--<tbody>-->
-        <!--<tr *ngFor="let row of section.rows">-->
-          <!--<ng-container *ngTemplateOutlet="rowTemplate; context: {$implicit: row}"></ng-container>-->
-        <!--</tr>-->
-        <!--</tbody>-->
-      <!--</table>-->
-    <!--</div>-->
-  <!--</div>-->
-<!--</div>-->
-
 <div class="row">
   <div *ngFor="let sections of columns" [ngClass]="narrow ? 'col-md-6' : 'col-md-3'">
     <div *ngFor="let section of sections">

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.html
@@ -1,27 +1,53 @@
+<!--<ng-template #rowTemplate let-row>-->
+  <!--<td><strong>{{row.label}}</strong></td>-->
+  <!--<td>-->
+    <!--<ul class="list-unstyled">-->
+      <!--<li *ngFor="let value of row.values">-->
+        <!--{{value}}-->
+      <!--</li>-->
+    <!--</ul>-->
+  <!--</td>-->
+<!--</ng-template>-->
+
+<!--<div class="row">-->
+  <!--<div *ngFor="let sections of columns" [ngClass]="narrow ? 'col-md-6' : 'col-md-3'">-->
+    <!--<div *ngFor="let section of sections">-->
+      <!--<div class="h5 column-heading">-->
+        <!--{{section.label}}-->
+      <!--</div>-->
+      <!--<table>-->
+        <!--<tbody>-->
+        <!--<tr *ngFor="let row of section.rows">-->
+          <!--<ng-container *ngTemplateOutlet="rowTemplate; context: {$implicit: row}"></ng-container>-->
+        <!--</tr>-->
+        <!--</tbody>-->
+      <!--</table>-->
+    <!--</div>-->
+  <!--</div>-->
+<!--</div>-->
+
+<div class="row">
+  <div *ngFor="let sections of columns" [ngClass]="narrow ? 'col-md-6' : 'col-md-3'">
+    <div *ngFor="let section of sections">
+      <div class="h5 column-heading" *ngIf="section.rows.length">
+        {{section.label}}
+      </div>
+      <div class="row" *ngFor="let row of section.rows">
+        <ng-container *ngTemplateOutlet="rowTemplate; context: {$implicit: row}"></ng-container>
+      </div>
+    </div>
+  </div>
+</div>
+
 <ng-template #rowTemplate let-row>
-  <td><strong>{{row.label}}</strong></td>
-  <td>
+  <div class="col-xs-6">
+    <strong>{{row.label}}</strong>
+  </div>
+  <div class="col-xs-6">
     <ul class="list-unstyled">
       <li *ngFor="let value of row.values">
         {{value}}
       </li>
     </ul>
-  </td>
-</ng-template>
-
-<div class="row">
-  <div *ngFor="let sections of columns" [ngClass]="narrow ? 'col-md-6' : 'col-md-3'">
-    <div *ngFor="let section of sections">
-      <div class="h5 column-heading">
-        {{section.label}}
-      </div>
-      <table>
-        <tbody>
-        <tr *ngFor="let row of section.rows">
-          <ng-container *ngTemplateOutlet="rowTemplate; context: {$implicit: row}"></ng-container>
-        </tr>
-        </tbody>
-      </table>
-    </div>
   </div>
-</div>
+</ng-template>

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
@@ -6,11 +6,11 @@ import { AggregateReportFormSettings } from "./aggregate-report-form-settings";
 import { AssessmentDefinition } from "./assessment/assessment-definition";
 import { Utils } from "../shared/support/support";
 
-const NarrowColumnProvider: ColumnProvider = (organizationRows, assessmentRows, filterRows, subgroupRows) =>
-  [[organizationRows, assessmentRows], [filterRows, subgroupRows]];
+const NarrowColumnProvider: ColumnProvider = (organization, assessment, subgroup, filter) =>
+  [[organization, assessment], [filter, subgroup]];
 
-const WideColumnProvider: ColumnProvider = (organizationRows, assessmentRows, filterRows, subgroupRows) =>
-  [[organizationRows], [assessmentRows], [filterRows], [subgroupRows]];
+const WideColumnProvider: ColumnProvider = (organization, assessment, subgroup, filter) =>
+  [[organization], [assessment], [filter], [subgroup]];
 
 @Component({
   selector: 'aggregate-report-summary',
@@ -63,7 +63,7 @@ export class AggregateReportSummary {
 
     const {assessmentDefinition, options, settings} = this.summary;
 
-    const equalSize = (a, b) => a.length === b.length;
+    const equalSize = Utils.hasEqualLength;
     const translate = code => this.translate.instant(code);
 
     const All = translate('common.collection-selection.all');
@@ -142,28 +142,49 @@ export class AggregateReportSummary {
       }
     ];
 
-    const filterRows = [
-      {
+    const filterRows = [];
+    if (!equalSize(options.genders, settings.genders)) {
+      filterRows.push({
         label: translate('aggregate-reports.form.field.gender.label'),
         values: inline(orAll(options.genders, settings.genders, code => translate(`common.gender.${code}`)))
-      },
-      {
+      });
+    }
+    if (!equalSize(options.ethnicities, settings.ethnicities)) {
+      filterRows.push({
         label: translate('aggregate-reports.form.field.ethnicity.label'),
-        values: orAll(options.ethnicities, settings.ethnicities, code => translate(`common.ethnicity.${code}`))
-      },
-      {
+          values: orAll(options.ethnicities, settings.ethnicities, code => translate(`common.ethnicity.${code}`))
+      });
+    }
+    if (!equalSize(options.migrantStatuses, settings.migrantStatuses)) {
+      filterRows.push({
         label: translate('aggregate-reports.form.field.migrant-status.label'),
         values: inline(orAll(options.migrantStatuses, settings.migrantStatuses, code => translate(`common.boolean.${code}`)))
-      },
-      {
+      });
+    }
+    if (!equalSize(options.individualEducationPlans, settings.individualEducationPlans)) {
+      filterRows.push({
         label: translate('aggregate-reports.form.field.iep.label'),
         values: inline(orAll(options.individualEducationPlans, settings.individualEducationPlans, code => translate(`common.strict-boolean.${code}`)))
-      },
-      {
+      });
+    }
+    if (!equalSize(options.section504s, settings.section504s)) {
+      filterRows.push({
         label: translate('aggregate-reports.form.field.504.label'),
         values: inline(orAll(options.section504s, settings.section504s, code => translate(`common.boolean.${code}`)))
-      }
-    ];
+      });
+    }
+    if (!equalSize(options.limitedEnglishProficiencies, settings.limitedEnglishProficiencies)) {
+      filterRows.push({
+        label: translate('aggregate-reports.form.field.limited-english-proficiency.label'),
+        values: inline(orAll(options.limitedEnglishProficiencies, settings.limitedEnglishProficiencies, code => translate(`common.boolean.${code}`)))
+      });
+    }
+    if (!equalSize(options.economicDisadvantages, settings.economicDisadvantages)) {
+      filterRows.push({
+        label: translate('aggregate-reports.form.field.economic-disadvantage.label'),
+        values: inline(orAll(options.economicDisadvantages, settings.economicDisadvantages, code => translate(`common.boolean.${code}`)))
+      });
+    }
 
     const subgroupRows = [
       {
@@ -182,12 +203,12 @@ export class AggregateReportSummary {
         rows: assessmentRows
       },
       {
-        label: translate('aggregate-reports.form.section.subgroup-filters.heading'),
-        rows: filterRows
-      },
-      {
         label: translate('aggregate-reports.form.section.comparative-subgroups.heading'),
         rows: subgroupRows
+      },
+      {
+        label: translate('aggregate-reports.form.section.subgroup-filters.heading'),
+        rows: filterRows
       }
     );
   }
@@ -204,7 +225,7 @@ interface Row {
 }
 
 interface ColumnProvider {
-  (organization: Section, assessment: Section, filter: Section, subgroup: Section): Section[][];
+  (organization: Section, assessment: Section, subgroup: Section, filter: Section): Section[][];
 }
 
 export interface AggregateReportRequestSummary {

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-table-data.service.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-table-data.service.ts
@@ -6,6 +6,7 @@ import { AggregateReportItem, Dimension } from "./results/aggregate-report-item"
 import { Utils } from "../shared/support/support";
 import { TranslateService } from "@ngx-translate/core";
 import { DimensionConfigurationByType } from "./dimension-configuration";
+import { DefaultRowsPerPageOptions } from "./results/aggregate-report-table.component";
 
 const MaximumOrganizations = 2;
 const OverallDimension: Dimension = { id: 'Overall', type: 'Overall' };

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
@@ -8,7 +8,7 @@
              [rows]="100"
              [paginator]="paginationEnabled"
              [pageLinks]="3"
-             [rowsPerPageOptions]="[100, 500, 1000]"
+             [rowsPerPageOptions]="rowsPerPageOptions"
              emptyMessage="{{'aggregate-reports.results.empty-message' | translate}}"
              tableStyleClass="table table-striped table-hover overflow table-row-size-fixed">
   <p-column colId="organization"

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -15,6 +15,8 @@ import { AggregateReportTableExportService, ExportOptions } from "./aggregate-re
 
 export const SupportedRowCount = 10000;
 
+export const DefaultRowsPerPageOptions = [100, 500, 1000];
+
 const OverallDimensionType: string = 'Overall';
 
 const StateOrdering: Ordering<AggregateReportItem> = ordering(ranking([ OrganizationType.State ]))
@@ -69,6 +71,9 @@ export class AggregateReportTableComponent implements OnInit {
   public treeColumns: number[] = [];
   public performanceLevelTranslationPrefix: string;
   public loading: boolean = true;
+
+  @Input()
+  public rowsPerPageOptions: number[] = DefaultRowsPerPageOptions;
 
   private _previousSortEvent: any;
   private _table: AggregateReportTable;
@@ -413,8 +418,7 @@ export class AggregateReportTableComponent implements OnInit {
   }
 
   private updatePagination() {
-    this._paginationEnabled = !this.preview
-        && this.table
+    this._paginationEnabled = this.table
         && this.table.rows
         && this.resultsTable
         && this.resultsTable.rowsPerPageOptions

--- a/webapp/src/main/webapp/src/app/shared/nav/scroll-nav.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/nav/scroll-nav.component.ts
@@ -49,9 +49,7 @@ export class ScrollNavComponent {
   }
 
   onItemClickInternal(item: ScrollNavItem): void {
-    if (item.scrollTo) {
-      item.scrollTo.scrollIntoView();
-    }
+    this.activeItem = item;
     if (item.click) {
       item.click();
     }
@@ -63,6 +61,11 @@ export class ScrollNavComponent {
   }
 
   private updateActiveLink(): void {
+
+    // Sets the first item to active if the window scroll is zero
+    if (this._window.scrollY <= 0) {
+      this._activeItem = this.items[ 0 ];
+    }
 
     // Sets the last item to active if the user scrolls to the very bottom of the page
     if ((this._window.innerHeight + this._window.scrollY) >= this._document.body.offsetHeight) {
@@ -78,7 +81,7 @@ export class ScrollNavComponent {
     this.items
       .filter(item => item.scrollTo && document.getElementById(item.scrollTo.id))
       .forEach(item => {
-        const itemOffsetTop = Utils.getAbsoluteOffsetTop(item.scrollTo) - Utils.getHeight(item.scrollTo);
+        const itemOffsetTop = Utils.getAbsoluteOffsetTop(item.scrollTo);
         if (itemOffsetTop <= scrollTop) {
           this._activeItem = item;
         } else {

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -181,4 +181,17 @@ export class Utils {
     return false;
   }
 
+  /**
+   * Returns true if the provided arrays are both defined and of equal length
+   *
+   * @param {any[]} a the first array
+   * @param {any[]} b the second array
+   * @returns {boolean} true if the provided arrays are both defined and of equal length
+   */
+  static hasEqualLength(a: any[], b: any[]) {
+    return a != null
+      && b != null
+      && a.length === b.length;
+  }
+
 }

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -133,16 +133,8 @@
           "label": "Economic Disadvantage",
           "info": "Indicates that a student qualifies for free or reduced lunch or meets other state criteria for economic disadvantage."
         },
-        "performance-level-display-type": {
-          "label": "Achievement Level Display",
-          "info": "Two options are available:  1) each of the four achievement levels are displayed or 2) Levels 1 and 2 are combined and levels 3 and 4 are combined to show two groups:  Below Standard and At/Above Standard."
-        },
-        "value-display-type": {
-          "label": "Show Value as"
-        },
         "comparative-subgroup": {
-          "label": "Subgroups",
-          "info": "Select the student sub-groups to display separately in results."
+          "label": "Subgroups"
         },
         "report-name": {
           "label": "Enter a name",

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -52,7 +52,7 @@
       "empty-message": "No Results Found",
       "performance-group-prompt": "Show performance as",
       "performance-grouped": "Grouped",
-      "performance-separated": "Separate",
+      "performance-separated": "All",
       "cols": {
         "achievement-comparison": "Achievement Comparison",
         "assessment-grade": "Assessment Grade",
@@ -171,10 +171,12 @@
           "heading": "Assessment Attributes"
         },
         "subgroup-filters": {
-          "heading": "Subgroup Filters"
+          "heading": "Advanced Filters",
+          "subtext": "Refine results by selecting student attributes to filter by."
         },
         "comparative-subgroups": {
-          "heading": "Comparative Subgroups"
+          "heading": "Subgroups",
+          "subtext": "The results will be broken down by the subgroups you select."
         },
         "report-name": {
           "heading": "Report Name"
@@ -243,7 +245,7 @@
     },
     "performance-level-display-type-input-label": "Show achievement levels",
     "performance-level-display-type": {
-      "Separate": "Separate",
+      "Separate": "All",
       "Grouped": "Grouped"
     },
     "organization": {

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -660,6 +660,7 @@ aggregate-report-results {
 
 aggregate-report-form {
   .well-group > .well {
+    box-shadow: none;
     padding-bottom: 20px;
     &:not(:first-child) {
       box-shadow: none;

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -659,11 +659,27 @@ aggregate-report-results {
 }
 
 aggregate-report-form {
-  .well-group .well {
+  .well-group > .well {
     padding-bottom: 20px;
-  }
-  .well-group > .well:not(:first-child) {
-    box-shadow: none;
+    &:not(:first-child) {
+      box-shadow: none;
+    }
+    &:first-child {
+      padding: 15px 20px;
+      h3 {
+        .h4;
+        color: @gray-darkest;
+        margin: 0;
+        + .subtext {
+          font-size: @font-size-small;
+          color: @gray-darker;
+          margin-top: @padding-small-horizontal;
+        }
+        + .label {
+          margin-top: @padding-small-horizontal;
+        }
+      }
+    }
   }
   .nested-btn-group {
     margin-bottom: 0;
@@ -730,19 +746,12 @@ aggregate-report-organization-list {
     color: @gray-darker;
     padding-bottom: @padding-base-vertical;
   }
-  table {
-    width: 100%;
-    > tbody > tr {
-      > td {
-        vertical-align: top;
-        &:first-child {
-          color: @gray-darkest;
-        }
-        &:last-child {
-          color: @gray-darker;
-          padding-left: @padding-small-horizontal;
-        }
-      }
+  .row > div {
+    &:first-child {
+      color: @gray-darkest;
+    }
+    &:last-child {
+      color: @gray-darker;
     }
   }
 }
@@ -750,7 +759,7 @@ aggregate-report-organization-list {
 // Fixes well group border radius - should be in kit
 .well-group {
   border-radius: @border-radius-base;
-  > .well {
+  .well {
     &:first-child {
       border-top: none;
       border-top-left-radius: @border-radius-base;

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -776,3 +776,9 @@ aggregate-report-organization-list {
   padding: @padding-small-horizontal @padding-base-horizontal;
 }
 
+@media (max-width: @screen-sm-max) {
+  scroll-nav {
+    display: none;
+  }
+}
+


### PR DESCRIPTION
Visual changes:

1. Advanced filters will now come after subgroups
2. Well headers moved into wells to make way for advanced filters expander button.
3. Advanced filters summary section and rows are hidden when they are not different from the defaults

![image](https://user-images.githubusercontent.com/23462925/36460717-86363de2-166e-11e8-9ff4-91eccc735330.png)

![image](https://user-images.githubusercontent.com/23462925/36460732-9f5b51b8-166e-11e8-9e70-e7f42fd4b32f.png)

![image](https://user-images.githubusercontent.com/23462925/36460758-c6378d92-166e-11e8-8997-a82b55f9b97c.png)

![image](https://user-images.githubusercontent.com/23462925/36460777-d8eb6c9c-166e-11e8-9df8-7d6cfb1373ac.png)

