### PR TITLE
Modify instructional resource management UX according to UAT feedback.

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/create-instructional-resource.modal.html
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/create-instructional-resource.modal.html
@@ -13,94 +13,84 @@
     <div *ngIf="duplicateResource" class="alert alert-danger">
       {{ 'labels.instructional-resource.create.duplicate' | translate }}
     </div>
-    <form class="form-horizontal">
+    <form>
       <fieldset>
-        <div class="form-group row mb-xs">
-          <label for="assessment-label" class="col-xs-4 control-label">{{'labels.instructional-resource.cols.assessment-label' | translate}}</label>
-          <div class="col-xs-8 pl-0">
-            <input class="form-control"
-                   id="assessment-label"
-                   name="assessment-label"
-                   [typeahead]="assessmentSource"
-                   (typeaheadLoading)="assessmentLoading = $event"
-                   (typeaheadNoResults)="assessmentNoResults = $event"
-                   (typeaheadOnSelect)="onAssessmentSelect($event.item)"
-                   [typeaheadMinLength]="3"
-                   [(ngModel)]="assessmentSearch"
-                   [typeaheadItemTemplate]="assessmentTemplate"
-                   typeaheadOptionField="label"
-                   placeholder="{{'labels.instructional-resource.form.field.assessment.placeholder' | translate}}">
-            <div>
-              <span [hidden]="!assessmentLoading"><i class="fa fa-spinner fa-pulse"></i></span>
-              <span [hidden]="!assessmentNoResults" class="text-info">{{'labels.instructional-resource.assessments.no-results' | translate}}</span>
-            </div>
+        <div class="form-group mb-xs">
+          <label for="assessment-label" class="control-label">{{'labels.instructional-resource.form.assessment-label' | translate}}</label>
+          <input class="form-control"
+                 id="assessment-label"
+                 name="assessment-label"
+                 [typeahead]="assessmentSource"
+                 (typeaheadLoading)="assessmentLoading = $event"
+                 (typeaheadNoResults)="assessmentNoResults = $event"
+                 (typeaheadOnSelect)="onAssessmentSelect($event.item)"
+                 [typeaheadMinLength]="3"
+                 [(ngModel)]="assessmentSearch"
+                 [typeaheadItemTemplate]="assessmentTemplate"
+                 typeaheadOptionField="label"
+                 placeholder="{{'labels.instructional-resource.form.field.assessment.placeholder' | translate}}">
+          <div>
+            <span [hidden]="!assessmentLoading"><i class="fa fa-spinner fa-pulse"></i></span>
+            <span [hidden]="!assessmentNoResults" class="text-info">{{'labels.instructional-resource.assessments.no-results' | translate}}</span>
           </div>
         </div>
-        <div class="form-group row mb-xs">
-          <label class="col-xs-4 control-label">{{'labels.instructional-resource.cols.assessment-name' | translate}}</label>
-          <span *ngIf="assessment" class="col-xs-8 text-overflow-ellipsis pl-md" title="{{assessment.name}}">{{assessment.name}}</span>
+        <div class="mb-xs" *ngIf="assessment">
+          <span class="label label-default">{{'labels.instructional-resource.cols.assessment-name' | translate}}</span>
+          <span class="text-overflow-ellipsis small" title="{{assessment.name}}">{{assessment.name}}</span>
         </div>
-        <div class="form-group row mb-xs">
-          <label for="organization-name" class="col-xs-4 control-label">{{'labels.instructional-resource.form.organization-name' | translate}}</label>
-          <div class="col-xs-8 pl-0">
-            <input class="form-control"
-                   id="organization-name"
-                   name="organization-name"
-                   [typeahead]="organizationSource"
-                   (typeaheadLoading)="organizationLoading = $event"
-                   (typeaheadNoResults)="organizationNoResults = $event"
-                   (typeaheadOnSelect)="onOrganizationSelect($event.item)"
-                   [typeaheadMinLength]="3"
-                   [(ngModel)]="organizationSearch"
-                   [typeaheadItemTemplate]="organizationTemplate"
-                   typeaheadOptionField="name"
-                   placeholder="{{'labels.instructional-resource.form.field.organization.placeholder' | translate}}">
-            <div>
-              <span [hidden]="!organizationLoading"><i class="fa fa-spinner fa-pulse"></i></span>
-              <span [hidden]="!organizationNoResults"class="text-info">{{'labels.instructional-resource.organizations.no-results' | translate}}</span>
-            </div>
+        <div class="form-group mb-xs">
+          <label for="organization-name" class="control-label">{{'labels.instructional-resource.form.organization-name' | translate}}</label>
+          <input class="form-control"
+                 id="organization-name"
+                 name="organization-name"
+                 [typeahead]="organizationSource"
+                 (typeaheadLoading)="organizationLoading = $event"
+                 (typeaheadNoResults)="organizationNoResults = $event"
+                 (typeaheadOnSelect)="onOrganizationSelect($event.item)"
+                 [typeaheadMinLength]="3"
+                 [(ngModel)]="organizationSearch"
+                 [typeaheadItemTemplate]="organizationTemplate"
+                 typeaheadOptionField="name"
+                 placeholder="{{'labels.instructional-resource.form.field.organization.placeholder' | translate}}">
+          <div>
+            <span [hidden]="!organizationLoading"><i class="fa fa-spinner fa-pulse"></i></span>
+            <span [hidden]="!organizationNoResults"class="text-info">{{'labels.instructional-resource.organizations.no-results' | translate}}</span>
           </div>
         </div>
-        <div class="form-group row mb-xs">
-          <label class="col-xs-4 control-label">{{'labels.instructional-resource.cols.organization-type' | translate}}</label>
-          <span *ngIf="organization" class="col-xs-8 text-overflow-ellipsis">{{ ('labels.instructional-resource.organizations.type.' + organization.organizationType) | translate }}</span>
+        <div class="mb-xs" *ngIf="organization">
+          <span class="label label-default">{{'labels.instructional-resource.cols.organization-type' | translate}}</span>
+          <span class="text-overflow-ellipsis small">{{ ('labels.instructional-resource.organizations.type.' + organization.organizationType) | translate }}</span>
         </div>
-        <div class="form-group row mb-xs">
-          <label for="performance-level" class="col-xs-4 control-label">{{'labels.instructional-resource.cols.performance-level' | translate}}</label>
-          <div class="col-xs-8 pl-0">
-            <select id="performance-level"
-                    name="performance-level"
-                    class="form-control"
-                    [(ngModel)]="performanceLevel"
-                    (change)="onPerformanceLevelSelect()"
-                    [disabled]="!assessment" >
-              <option disabled [ngValue]="-1">{{'prompt.select' | translate}}</option>
-              <option *ngIf="assessment" [ngValue]="0">{{'labels.instructional-resource.assessments.performance-levels.all' | translate}}</option>
-              <option *ngFor="let performanceLevel of performanceLevels" [ngValue]="performanceLevel">{{ ('labels.instructional-resource.assessments.performance-levels.' + assessment.type + '.' + performanceLevel) | translate }}</option>
-            </select>
-          </div>
+        <div class="form-group mb-xs">
+          <label for="performance-level" class="control-label">{{'labels.instructional-resource.cols.performance-level' | translate}}</label>
+          <select id="performance-level"
+                  name="performance-level"
+                  class="form-control"
+                  [(ngModel)]="performanceLevel"
+                  (change)="onPerformanceLevelSelect()"
+                  [disabled]="!assessment" >
+            <option disabled [ngValue]="-1">{{'prompt.select' | translate}}</option>
+            <option *ngIf="assessment" [ngValue]="0">{{'labels.instructional-resource.assessments.performance-levels.all' | translate}}</option>
+            <option *ngFor="let performanceLevel of performanceLevels" [ngValue]="performanceLevel">{{ ('labels.instructional-resource.assessments.performance-levels.' + assessment.type + '.' + performanceLevel) | translate }}</option>
+          </select>
         </div>
-        <div class="form-group row mb-xs"
+        <div class="form-group"
              [ngClass]="{'has-error': resource.invalid && (resource.dirty || resource.touched)}">
-          <label for="resource" class="col-xs-4 control-label">{{'labels.instructional-resource.cols.resource' | translate}}</label>
-          <div class="col-xs-8 pl-0">
-            <input id="resource"
-                   name="resource"
-                   class="form-control"
-                   #resource="ngModel"
-                   placeholder="{{'labels.instructional-resource.form.field.resource.placeholder' | translate}}"
-                   [(ngModel)]="resourceUrl"
-                   pattern="https?://.+"
-                   required>
-            <div *ngIf="resource.invalid && (resource.dirty || resource.touched)">
-              <p *ngIf="resource.errors.pattern"
-                 class="help-block small red">{{'labels.instructional-resource.form.field.resource.error.pattern' | translate}}</p>
-              <p *ngIf="!resource.errors.pattern && resource.errors.required"
-                 class="help-block small red">{{'labels.instructional-resource.form.field.resource.error.required' | translate}}</p>
-            </div>
+          <label for="resource" class="control-label">{{'labels.instructional-resource.cols.resource' | translate}}</label>
+          <input id="resource"
+                 name="resource"
+                 class="form-control"
+                 #resource="ngModel"
+                 placeholder="{{'labels.instructional-resource.form.field.resource.placeholder' | translate}}"
+                 [(ngModel)]="resourceUrl"
+                 pattern="https?://.+"
+                 required>
+          <div *ngIf="resource.invalid && (resource.dirty || resource.touched)">
+            <p *ngIf="resource.errors.pattern"
+               class="help-block small red">{{'labels.instructional-resource.form.field.resource.error.pattern' | translate}}</p>
+            <p *ngIf="!resource.errors.pattern && resource.errors.required"
+               class="help-block small red">{{'labels.instructional-resource.form.field.resource.error.required' | translate}}</p>
           </div>
-
-
         </div>
       </fieldset>
     </form>

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/create-instructional-resource.modal.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/create-instructional-resource.modal.ts
@@ -1,5 +1,5 @@
 import { BsModalRef } from "ngx-bootstrap";
-import { Component, EventEmitter } from "@angular/core";
+import { Component, EventEmitter, OnDestroy } from "@angular/core";
 import { InstructionalResource } from "./model/instructional-resource.model";
 import { InstructionalResourceService } from "./instructional-resource.service";
 import { Assessment } from "./model/assessment.model";
@@ -11,6 +11,8 @@ import { Organization } from "./model/organization.model";
 import { OrganizationService } from "./organization.service";
 import { OrganizationQuery } from "./model/organization-query.model";
 import { ValidationErrors } from "@angular/forms";
+import { Subscription } from "rxjs/Subscription";
+import { NavigationStart, Router } from "@angular/router";
 
 /**
  * This modal component displays an instructional resource creation form.
@@ -19,7 +21,7 @@ import { ValidationErrors } from "@angular/forms";
   selector: 'create-instructional-resource-modal',
   templateUrl: './create-instructional-resource.modal.html'
 })
-export class CreateInstructionalResourceModal {
+export class CreateInstructionalResourceModal implements OnDestroy {
 
   existingResources: InstructionalResource[] = [];
   unableToCreate: boolean = false;
@@ -43,10 +45,13 @@ export class CreateInstructionalResourceModal {
 
   resourceUrl: string;
 
+  private _subscription: Subscription;
+
   constructor(private modal: BsModalRef,
               private assessmentService: AssessmentService,
               private organizationService: OrganizationService,
-              private resourceService: InstructionalResourceService) {
+              private resourceService: InstructionalResourceService,
+              private router: Router) {
 
     this.assessmentSource = Observable.create((observer: any) => {
       observer.next(this.assessmentSearch);
@@ -55,6 +60,14 @@ export class CreateInstructionalResourceModal {
     this.organizationSource = Observable.create((observer: any) => {
       observer.next(this.organizationSearch);
     }).mergeMap((token: string) => this.findOrganizations(token));
+
+    this._subscription = router.events.filter(e => e instanceof NavigationStart).subscribe(() => {
+      this.cancel();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._subscription.unsubscribe();
   }
 
   cancel() {

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/instructional-resource.component.html
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/instructional-resource.component.html
@@ -1,7 +1,7 @@
 <div class="mb-md">
   <span class="h3 blue-dark">{{'labels.instructional-resource.title' | translate}}</span>
   <div class="pull-right">
-    <span class="btn btn-primary mr-xs" (click)="openCreateResourceModal()"><i class="fa fa-cloud-upload"></i> {{'prompt.create' | translate}}</span>
+    <span class="btn btn-primary mr-xs" (click)="openCreateResourceModal()"><i class="fa fa-plus"></i> {{'prompt.create' | translate}}</span>
   </div>
 </div>
 
@@ -27,7 +27,12 @@
           {{ ('labels.instructional-resource.organizations.type.' + type) | translate }}
         </ng-template>
       </p-column>
-      <p-column field="organizationName" header="{{'labels.instructional-resource.cols.organization-name' | translate}}" [sortable]="true"></p-column>
+      <p-column field="organizationName" [sortable]="true">
+        <ng-template pTemplate="header">
+          <info-button title="{{'labels.instructional-resource.cols.organization-name' | translate}}"
+                       content="{{'labels.instructional-resource.cols.organization-name-info' | translate}}"></info-button>
+        </ng-template>
+      </p-column>
       <p-column field="performanceLevel" header="{{'labels.instructional-resource.cols.performance-level' | translate}}" [sortable]="true">
         <ng-template let-assessmentType="rowData.assessmentType" let-performanceLevel="rowData.performanceLevel" pTemplate="body">
           <span *ngIf="performanceLevel == 0">{{ 'labels.instructional-resource.assessments.performance-levels.all' | translate }}</span>

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.html
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.html
@@ -21,7 +21,10 @@
           <span class="col-xs-8 text-overflow-ellipsis" title="{{resource.assessmentName}}">{{resource.assessmentName}}</span>
         </div>
         <div class="form-group row">
-          <label class="col-xs-4 control-label">{{'labels.instructional-resource.cols.organization-name' | translate}}</label>
+          <label class="col-xs-4 control-label">
+            <info-button title="{{'labels.instructional-resource.cols.organization-name' | translate}}"
+                         content="{{'labels.instructional-resource.cols.organization-name-info' | translate}}"></info-button>
+          </label>
           <span class="col-xs-8 text-overflow-ellipsis" title="{{resource.organizationName}}">{{resource.organizationName}}</span>
         </div>
         <div class="form-group row">

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.ts
@@ -1,8 +1,10 @@
-import { Component, EventEmitter } from "@angular/core";
+import { Component, EventEmitter, OnDestroy } from "@angular/core";
 import { InstructionalResource } from "./model/instructional-resource.model";
 import { BsModalRef } from "ngx-bootstrap";
 import { InstructionalResourceService } from "./instructional-resource.service";
 import * as _ from "lodash";
+import { NavigationStart, Router } from "@angular/router";
+import { Subscription } from "rxjs/Subscription";
 
 /**
  * This modal component displays an instructional resource update form.
@@ -11,7 +13,7 @@ import * as _ from "lodash";
   selector: 'update-instructional-resource-modal',
   templateUrl: './update-instructional-resource.modal.html'
 })
-export class UpdateInstructionalResourceModal {
+export class UpdateInstructionalResourceModal implements OnDestroy {
 
   get resource(): InstructionalResource {
     return this._resource;
@@ -25,9 +27,18 @@ export class UpdateInstructionalResourceModal {
   updated: EventEmitter<InstructionalResource> = new EventEmitter();
 
   private _resource: InstructionalResource = new InstructionalResource();
+  private _subscription: Subscription;
 
   constructor(private modal: BsModalRef,
-              private resourceService: InstructionalResourceService) {
+              private resourceService: InstructionalResourceService,
+              private router: Router) {
+    this._subscription = router.events.filter(e => e instanceof NavigationStart).subscribe(() => {
+      this.cancel();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._subscription.unsubscribe();
   }
 
   cancel() {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1310,9 +1310,10 @@
       },
       "cols": {
         "assessment-label": "Assessment Label(s)",
-        "assessment-name": "Assessment Name",
+        "assessment-name": "System Name",
         "organization-name": "Organization",
-        "organization-type": "Organization Type",
+        "organization-name-info": "Instructional Resources can be bound to a State, Group of Districts, District, or Group of Schools.",
+        "organization-type": "Type",
         "performance-level": "Performance Level",
         "resource": "URL"
       },
@@ -1330,14 +1331,14 @@
       },
       "filter": "Search by Assessment/Organization",
       "form": {
-        "assessment-label": "Assessment Label",
-        "organization-name": "Organization Name",
+        "assessment-label": "Search for an Assessment",
+        "organization-name": "Search for a State, Group of Districts, District, or Group of Schools",
         "field": {
           "assessment": {
-            "placeholder": "Search Assessment Label"
+            "placeholder": "Enter name"
           },
           "organization": {
-            "placeholder": "Search Organization Name"
+            "placeholder": "Enter name"
           },
           "resource": {
             "placeholder": "Enter URL",


### PR DESCRIPTION
This PR resolves some UAT feedback issues/requests:
The "Organization" title was given an info button listing the types of organizations that can be assigned instructional resources.
The create button icon was changed from a cloud upload to a plus.
The labels and layout of the create modal dialog were changed to provide a better prompt to the user that they are filling out an auto-complete dialog.
The modal dialogs now hide if any route navigations are performed.  This fixes an issue where typing into an auto-complete input after the session has expired navigates to the session-expired route, but did not close the modal dialog.