### PR TITLE
cleans up results page ui

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -101,7 +101,7 @@
   </div>
 
   <div id="group-results-edit-assessments"
-       class="well gray-lighter"
+       class="well gray-lighter clearfix"
        [hidden]="!expandAssessments || hideAssessments">
     <div id="adv-filters-edit-assessments-collapse"
          class="pull-right">
@@ -113,8 +113,14 @@
         <i class="fa fa-close" aria-hidden="true"></i>
       </button>
     </div>
-    <select-assessments [assessments]="availableAssessments"
-                        (selectedAssessmentsChanged)="selectedAssessmentsChanged($event)"></select-assessments>
+    <ng-container *ngIf="availableAssessments && availableAssessments.length; else loadingAssessments">
+      <select-assessments [assessments]="availableAssessments"
+                          (selectedAssessmentsChanged)="selectedAssessmentsChanged($event)"></select-assessments>
+    </ng-container>
+    <ng-template #loadingAssessments>
+      <i class="fa fa-spinner fa-pulse fa-2x"></i>
+    </ng-template>
+
   </div>
 
 </div>

--- a/webapp/src/main/webapp/src/app/assessments/filters/select-assessments/select-assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/filters/select-assessments/select-assessments.component.html
@@ -12,8 +12,11 @@
           <a *ngFor="let assessment of byGrade.assessments"
              (click)="toggleSelectedAssessment(assessment)"
              class="tag tag-xs {{colorService.getColor(getGradeIdx(byGrade.grade))}}"
-             angulartics2On="click" angularticsEvent="AddAssessment" angularticsCategory="AssessmentResults" [angularticsProperties]="{label: assessment.label}"
-             [ngClass]="{'active': assessment.selected }">{{assessment.label}}</a>
+             angulartics2On="click"
+             angularticsEvent="AddAssessment"
+             angularticsCategory="AssessmentResults"
+             [angularticsProperties]="{label: assessment.label}"
+             [ngClass]="{'active': assessment.selected}">{{assessment.label}}</a>
         </div>
       </div>
       <div class="panel-footer"></div>

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -434,7 +434,17 @@ body .select-menu-group {
 
 .average-scale-score-display {
 
+  .table > tbody > tr:first-child {
+    > td:first-child {
+      border-top-left-radius: @border-radius-base;
+    }
+    > td:last-child {
+      border-top-right-radius: @border-radius-base;
+    }
+  }
+
   .well {
+    overflow: hidden;
     padding: 0;
     margin-bottom: 0;
 


### PR DESCRIPTION
corners of these containers are now actually round as intended

![image](https://user-images.githubusercontent.com/23462925/36613681-15a3b546-188f-11e8-8ec4-5ed667270bfd.png)


x icon no longer hangs over the edge of the well when the assessments are loading

![image](https://user-images.githubusercontent.com/23462925/36613741-51ef90ba-188f-11e8-8142-fb3bf3e23038.png)

