### PR TITLE
separated styling of indicators between dropdown menus and row expans…

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
@@ -362,7 +362,7 @@
               <div class="flex-child">
                 <button class="btn btn-default btn-sm icon-only pull-right"
                         (click)="onAdvancedFiltersExpanderButtonClick()">
-                  <i class="fa" [ngClass]="showAdvancedFilters ? 'fa-caret-square-o-down' : 'fa-caret-square-o-up'"></i>
+                  <i class="fa" [ngClass]="showAdvancedFilters ? 'fa-caret-square-o-up' : 'fa-caret-square-o-down'"></i>
                 </button>
               </div>
             </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-form.component.html
@@ -362,7 +362,7 @@
               <div class="flex-child">
                 <button class="btn btn-default btn-sm icon-only pull-right"
                         (click)="onAdvancedFiltersExpanderButtonClick()">
-                  <i class="fa" [ngClass]="showAdvancedFilters ? 'fa-angle-up' : 'fa-angle-down'"></i>
+                  <i class="fa" [ngClass]="showAdvancedFilters ? 'fa-caret-square-o-down' : 'fa-caret-square-o-up'"></i>
                 </button>
               </div>
             </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -20,7 +20,7 @@
         <li>
           <button class="btn btn-default btn-sm icon-only"
                   (click)="onToggleRequestViewButtonClick()">
-            <i class="fa {{showRequest ? 'fa-angle-up' : 'fa-angle-down'}}"></i>
+            <i class="fa {{showRequest ? 'fa-caret-square-o-down' : 'fa-caret-square-o-up'}}"></i>
           </button>
         </li>
       </ul>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -20,7 +20,7 @@
         <li>
           <button class="btn btn-default btn-sm icon-only"
                   (click)="onToggleRequestViewButtonClick()">
-            <i class="fa {{showRequest ? 'fa-caret-square-o-down' : 'fa-caret-square-o-up'}}"></i>
+            <i class="fa {{showRequest ? 'fa-caret-square-o-up' : 'fa-caret-square-o-down'}}"></i>
           </button>
         </li>
       </ul>

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -17,7 +17,7 @@
                     angularticsCategory="AssessmentResults">
               {{'buttons.visibility.' + (showAdvancedFilters ? 'hide' : 'show') | translate}}
               <i class="fa ml-xs"
-                 [ngClass]="{'fa-chevron-up': showAdvancedFilters, 'fa-chevron-down': !showAdvancedFilters}"
+                 [ngClass]="{'fa-caret-square-o-down': showAdvancedFilters, 'fa-caret-square-o-up': !showAdvancedFilters}"
                  aria-hidden="true"></i>
             </button>
           </div>
@@ -151,7 +151,7 @@
         <button class="btn btn-default btn-xs"
                 (click)="allCollapsed = !allCollapsed">
           {{('labels.groups.results.' + (allCollapsed ? 'expand-all' : 'collapse-all')) | translate }}
-          <i class="fa" [ngClass]="{'fa-angle-down': allCollapsed, 'fa-angle-up': !allCollapsed}"></i>
+          <i class="fa" [ngClass]="{'fa-caret-square-o-up': allCollapsed, 'fa-caret-square-o-down': !allCollapsed}"></i>
         </button>
       </li>
       <li>

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -17,7 +17,7 @@
                     angularticsCategory="AssessmentResults">
               {{'buttons.visibility.' + (showAdvancedFilters ? 'hide' : 'show') | translate}}
               <i class="fa ml-xs"
-                 [ngClass]="{'fa-caret-square-o-down': showAdvancedFilters, 'fa-caret-square-o-up': !showAdvancedFilters}"
+                 [ngClass]="{'fa-caret-square-o-up': showAdvancedFilters, 'fa-caret-square-o-down': !showAdvancedFilters}"
                  aria-hidden="true"></i>
             </button>
           </div>
@@ -151,7 +151,7 @@
         <button class="btn btn-default btn-xs"
                 (click)="allCollapsed = !allCollapsed">
           {{('labels.groups.results.' + (allCollapsed ? 'expand-all' : 'collapse-all')) | translate }}
-          <i class="fa" [ngClass]="{'fa-caret-square-o-up': allCollapsed, 'fa-caret-square-o-down': !allCollapsed}"></i>
+          <i class="fa" [ngClass]="{'fa-caret-square-o-down': allCollapsed, 'fa-caret-square-o-up': !allCollapsed}"></i>
         </button>
       </li>
       <li>

--- a/webapp/src/main/webapp/src/app/assessments/filters/adv-filters/adv-filters-toggle.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/filters/adv-filters/adv-filters-toggle.component.html
@@ -8,7 +8,7 @@
             (click)="displayOptions.expanded = !displayOptions.expanded"
             angulartics2On="click" angularticsEvent="ToggleExpandCollapse" angularticsCategory="AdvancedFilters">
       {{'buttons.collapsible.' + (displayOptions.expanded ? 'collapse' : 'expand') | translate }}
-      <i class="fa" [ngClass]="{'fa-chevron-up': displayOptions.expanded, 'fa-chevron-down': !displayOptions.expanded}"
+      <i class="fa" [ngClass]="{'fa-caret-square-o-down': displayOptions.expanded, 'fa-caret-square-o-up': !displayOptions.expanded}"
          aria-hidden="true"></i>
     </button>
   </div>

--- a/webapp/src/main/webapp/src/app/assessments/filters/adv-filters/adv-filters-toggle.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/filters/adv-filters/adv-filters-toggle.component.html
@@ -8,7 +8,7 @@
             (click)="displayOptions.expanded = !displayOptions.expanded"
             angulartics2On="click" angularticsEvent="ToggleExpandCollapse" angularticsCategory="AdvancedFilters">
       {{'buttons.collapsible.' + (displayOptions.expanded ? 'collapse' : 'expand') | translate }}
-      <i class="fa" [ngClass]="{'fa-caret-square-o-down': displayOptions.expanded, 'fa-caret-square-o-up': !displayOptions.expanded}"
+      <i class="fa" [ngClass]="{'fa-caret-square-o-up': displayOptions.expanded, 'fa-caret-square-o-down': !displayOptions.expanded}"
          aria-hidden="true"></i>
     </button>
   </div>

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -26,7 +26,7 @@
               angularticsEvent="ToggleCollapseResults"
               angularticsCategory="AssessmentResults">
         <i class="fa font-bold"
-           [ngClass]="{'fa-caret-square-o-down': !collapsed, 'fa-caret-square-o-up': collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
+           [ngClass]="{'fa-caret-square-o-up': !collapsed, 'fa-caret-square-o-down': collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
       </button>
     </div>
   </div>

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -26,7 +26,7 @@
               angularticsEvent="ToggleCollapseResults"
               angularticsCategory="AssessmentResults">
         <i class="fa font-bold"
-           [ngClass]="{'fa-angle-up': !collapsed, 'fa-angle-down': collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
+           [ngClass]="{'fa-caret-square-o-down': !collapsed, 'fa-caret-square-o-up': collapsed}"></i> <span class="sr-only">{{'prompt.collapse' | translate}}</span>
       </button>
     </div>
   </div>

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
@@ -8,7 +8,7 @@ import { Utils } from "../support/support";
 @Component({
   selector: 'datatable-row-expander',
   template: `
-    <button class="btn btn-info btn-xs btn-block text-left label-max-width" (click)="toggle()" title="{{text}}"><i class="fa" [ngClass]="{'fa-caret-square-o-up': !expanded, 'fa-caret-square-o-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
+    <button class="btn btn-info btn-xs btn-block text-left label-max-width" (click)="toggle()" title="{{text}}"><i class="fa" [ngClass]="{'fa-caret-square-o-down': !expanded, 'fa-caret-square-o-up': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
   `
 })
 export class DataTableRowExpander {

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-row-expander.component.ts
@@ -8,7 +8,7 @@ import { Utils } from "../support/support";
 @Component({
   selector: 'datatable-row-expander',
   template: `
-    <button class="btn btn-info btn-xs btn-block text-left label-max-width" (click)="toggle()" title="{{text}}"><i class="fa" [ngClass]="{'fa-chevron-right': !expanded, 'fa-chevron-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
+    <button class="btn btn-info btn-xs btn-block text-left label-max-width" (click)="toggle()" title="{{text}}"><i class="fa" [ngClass]="{'fa-caret-square-o-up': !expanded, 'fa-caret-square-o-down': expanded, 'mr-xs': hasText}"></i> {{text}}</button>
   `
 })
 export class DataTableRowExpander {

--- a/webapp/src/main/webapp/src/app/student/results/student-results-filter.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results-filter.component.html
@@ -40,7 +40,7 @@
             {{'buttons.visibility.' + (showAdvancedFilters ? 'hide' : 'show') | translate}}
             <i class="fa"
                aria-hidden="true"
-               [ngClass]="{'fa-caret-square-o-down': showAdvancedFilters, 'fa-caret-square-o-up': !showAdvancedFilters}"></i>
+               [ngClass]="{'fa-caret-square-o-up': showAdvancedFilters, 'fa-caret-square-o-down': !showAdvancedFilters}"></i>
           </button>
         </div>
       </div>

--- a/webapp/src/main/webapp/src/app/student/results/student-results-filter.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results-filter.component.html
@@ -40,7 +40,7 @@
             {{'buttons.visibility.' + (showAdvancedFilters ? 'hide' : 'show') | translate}}
             <i class="fa"
                aria-hidden="true"
-               [ngClass]="{'fa-chevron-up': showAdvancedFilters, 'fa-chevron-down': !showAdvancedFilters}"></i>
+               [ngClass]="{'fa-caret-square-o-down': showAdvancedFilters, 'fa-caret-square-o-up': !showAdvancedFilters}"></i>
           </button>
         </div>
       </div>

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.html
@@ -56,7 +56,7 @@
                 angularticsEvent="ToggleCollapseResults"
                 angularticsCategory="StudentHistory">
           <span class="sr-only">{{ 'buttons.collapsible.collapse' | translate }}</span>
-          <i class="fa fa-bold {{ isCollapsed(assessmentType, subject) ? 'fa-caret-square-o-up' : 'fa-caret-square-o-down' }}"></i>
+          <i class="fa fa-bold {{ isCollapsed(assessmentType, subject) ? 'fa-caret-square-o-down' : 'fa-caret-square-o-up' }}"></i>
         </button>
 
         <div class="mt-md" [hidden]="isCollapsed(assessmentType, subject)">

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.html
@@ -56,7 +56,7 @@
                 angularticsEvent="ToggleCollapseResults"
                 angularticsCategory="StudentHistory">
           <span class="sr-only">{{ 'buttons.collapsible.collapse' | translate }}</span>
-          <i class="fa fa-bold {{ isCollapsed(assessmentType, subject) ? 'fa-angle-down' : 'fa-angle-up' }}"></i>
+          <i class="fa fa-bold {{ isCollapsed(assessmentType, subject) ? 'fa-caret-square-o-up' : 'fa-caret-square-o-down' }}"></i>
         </button>
 
         <div class="mt-md" [hidden]="isCollapsed(assessmentType, subject)">


### PR DESCRIPTION
…ion. Made the styling consistent with the effect of the row expansion (up means not expanded, down means expanded)

#  unchanged
<img width="374" alt="screen shot 2018-02-23 at 12 33 33 pm" src="https://user-images.githubusercontent.com/33040425/36615773-44357df2-1896-11e8-95a0-b25482022d52.png">
<img width="133" alt="screen shot 2018-02-23 at 12 33 43 pm" src="https://user-images.githubusercontent.com/33040425/36615761-3d0dc0f2-1896-11e8-8a7e-29e0d74b3fa0.png">
<img width="253" alt="screen shot 2018-02-23 at 12 34 17 pm" src="https://user-images.githubusercontent.com/33040425/36615787-4e70128c-1896-11e8-835e-9098f9ecd0ea.png">

# changed
<img width="435" alt="screen shot 2018-02-23 at 12 33 59 pm" src="https://user-images.githubusercontent.com/33040425/36615805-5cd04338-1896-11e8-8e2a-f2ea9518a3bd.png">
<img width="353" alt="screen shot 2018-02-23 at 12 34 08 pm" src="https://user-images.githubusercontent.com/33040425/36615815-6380d6f2-1896-11e8-8210-41caba003873.png">
<img width="428" alt="screen shot 2018-02-23 at 12 34 27 pm" src="https://user-images.githubusercontent.com/33040425/36615823-6f37c5b4-1896-11e8-8b9c-fffceb28277d.png">
<img width="476" alt="screen shot 2018-02-23 at 12 34 35 pm" src="https://user-images.githubusercontent.com/33040425/36615835-76cd3f66-1896-11e8-8644-6b43f98a2ff0.png">
