### PR TITLE
Modify report downloads to use browser to download rather than ajax.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -13,7 +13,6 @@ import { Utils } from "../../shared/support/support";
 import { Comparator, ranking } from "@kourge/ordering/comparator";
 import { ordering } from "@kourge/ordering";
 import { AggregateReportQuery } from "../../report/aggregate-report-request";
-import { saveAs } from "file-saver";
 import { DisplayOptionService } from "../../shared/display-options/display-option.service";
 import { TranslateService } from "@ngx-translate/core";
 import { AggregateReportRequestMapper } from "../aggregate-report-request.mapper";
@@ -125,14 +124,8 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
   }
 
   onDownloadDataButtonClick(): void {
-    this.spinnerModal.loading = true;
-    this.reportService.getReportContent(this.report.id)
-      .finally(() => {
-        this.spinnerModal.loading = false;
-      })
-      .subscribe(download => {
-        saveAs(download.content, download.name);
-      });
+    this.reportService.downloadReportContent(this.report.id);
+    this.router.navigateByUrl("/reports");
   }
 
   getExportName(table: AggregateReportTableView): string {

--- a/webapp/src/main/webapp/src/app/report/report-action.component.html
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.html
@@ -8,4 +8,3 @@
             [item]="report"
             [actions]="menuActions"
             text="{{report.label}}"></popup-menu>
-<spinner-modal #spinnerModal></spinner-modal>

--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -1,9 +1,8 @@
-import { Component, Input, OnInit, ViewChild } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 import { ReportAction, ReportActionService } from "./report-action.service";
 import { PopupMenuAction } from "../shared/menu/popup-menu-action.model";
 import { Report } from "./report.model";
 import { TranslateService } from "@ngx-translate/core";
-import { SpinnerModal } from "../shared/loading/spinner.modal";
 import 'rxjs/add/operator/finally';
 
 /**
@@ -15,10 +14,6 @@ import 'rxjs/add/operator/finally';
   templateUrl: './report-action.component.html'
 })
 export class ReportActionComponent implements OnInit {
-
-
-  @ViewChild('spinnerModal')
-  spinnerModal: SpinnerModal;
 
   @Input()
   public report: Report;

--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -5,7 +5,6 @@ import { Report } from "./report.model";
 import { TranslateService } from "@ngx-translate/core";
 import { SpinnerModal } from "../shared/loading/spinner.modal";
 import 'rxjs/add/operator/finally';
-import { Observable } from "rxjs/Observable";
 
 /**
  * Responsible for providing a UI displaying and performing an action
@@ -39,13 +38,7 @@ export class ReportActionComponent implements OnInit {
   }
 
   performAction(reportAction: ReportAction): void {
-    this.spinnerModal.loading = true;
-    const action: Observable<any> = this.actionService.performAction(reportAction);
-    action
-      .finally(() => {
-        this.spinnerModal.loading = false;
-      })
-      .subscribe(() => {});
+    this.actionService.performAction(reportAction);
   }
 
   private toMenuAction(reportAction: ReportAction): PopupMenuAction {

--- a/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
@@ -20,7 +20,7 @@ describe('ReportActionService', () => {
 
     reportService = jasmine.createSpyObj(
       "ReportService",
-      ["getReportContent"]
+      ["getReportContent", "downloadReportContent"]
     );
     (reportService.getReportContent as Spy).and.callFake(() => Observable.empty());
 
@@ -69,7 +69,7 @@ describe('ReportActionService', () => {
     expect(actions[0].type).toBe(ActionType.Download);
 
     service.performAction(actions[0]);
-    expect(reportService.getReportContent).toHaveBeenCalledWith(report.id);
+    expect(reportService.downloadReportContent).toHaveBeenCalledWith(report.id);
   });
 
   it('should provide multiple actions for a completed AggregateReportRequest', () => {
@@ -90,7 +90,7 @@ describe('ReportActionService', () => {
 
     const downloadReportAction: ReportAction = actions[2];
     service.performAction(downloadReportAction);
-    expect(reportService.getReportContent).toHaveBeenCalledWith(report.id);
+    expect(reportService.downloadReportContent).toHaveBeenCalledWith(report.id);
   });
 
   function createReport(): Report {

--- a/webapp/src/main/webapp/src/app/report/report-action.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.ts
@@ -1,10 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Report } from "./report.model";
 import { ReportService } from "./report.service";
-import { Download } from "../shared/data/download.model";
 import { Router } from "@angular/router";
-import { saveAs } from "file-saver";
-import { Observable } from "rxjs/Observable";
 import { NotificationService } from "../shared/notification/notification.service";
 import "rxjs/add/observable/empty";
 
@@ -44,32 +41,17 @@ export class ReportActionService {
    *
    * @param {ReportAction} action An action
    */
-  public performAction(action: ReportAction): Observable<any> {
-    switch (action.type) {
-      case ActionType.Download:
-        return this.performDownload(action);
-      case ActionType.Navigate:
-        this.performNavigate(action);
-        return Observable.empty();
+  public performAction(action: ReportAction): void {
+    if (action.type == ActionType.Download) {
+      this.performDownload(action);
+    }
+    if (action.type == ActionType.Navigate) {
+      this.performNavigate(action);
     }
   }
 
-  /**
-   * Test
-   * @param {ReportAction} action
-   * @returns {Observable<any>}
-   */
-  private performDownload(action: ReportAction): Observable<any> {
-    const observable: Observable<any> = this.reportService.getReportContent(action.value);
-    observable
-      .subscribe(
-        (download: Download) => {
-          saveAs(download.content, download.name);
-        },
-        (error) => {
-          this.notificationService.error({ id: 'labels.reports.messages.download-failed' });
-        });
-    return observable;
+  private performDownload(action: ReportAction): void {
+    this.reportService.downloadReportContent(action.value);
   }
 
   private performNavigate(action: ReportAction): void {

--- a/webapp/src/main/webapp/src/app/report/report.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/report/report.service.spec.ts
@@ -6,7 +6,7 @@ import { Report } from "./report.model";
 import { Observable } from "rxjs/Observable";
 import { AssessmentType } from "../shared/enum/assessment-type.enum";
 import { AssessmentSubjectType } from "../shared/enum/assessment-subject-type.enum";
-import { DataService } from "../shared/data/data.service";
+import { DATA_CONTEXT_URL, DataService } from "../shared/data/data.service";
 
 describe('ReportService', () => {
   let dataService: MockDataService;
@@ -20,6 +20,9 @@ describe('ReportService', () => {
         ReportService, {
           provide: DataService,
           useValue: dataService
+        }, {
+          provide: DATA_CONTEXT_URL,
+          useValue: '/api'
         }
       ]
     });

--- a/webapp/src/main/webapp/src/app/report/report.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { Inject, Injectable } from "@angular/core";
 import { Headers, ResponseContentType } from "@angular/http";
 import { ReportOptions } from "./report-options.model";
 import { Observable } from "rxjs/Observable";
@@ -11,7 +11,7 @@ import { Student } from "../student/model/student.model";
 import { Group } from "../user/model/group.model";
 import { School } from "../user/model/school.model";
 import { Grade } from "../school-grade/grade.model";
-import { DataService } from "../shared/data/data.service";
+import { DATA_CONTEXT_URL, DataService } from "../shared/data/data.service";
 import { Download } from "../shared/data/download.model";
 import { AggregateReportRequest } from "./aggregate-report-request";
 import { AggregateReportRow } from "./aggregate-report";
@@ -22,7 +22,8 @@ const ServiceRoute = '/report-processor';
 @Injectable()
 export class ReportService {
 
-  constructor(private dataService: DataService) {
+  constructor(private dataService: DataService,
+              @Inject(DATA_CONTEXT_URL) private contextUrl: string = '/api') {
   }
 
   /**
@@ -118,6 +119,15 @@ export class ReportService {
       }),
       responseType: ResponseContentType.Blob
     }).catch(ResponseUtils.throwError);
+  }
+
+  /**
+   * Download the given report by opening a tab to the report content.
+   *
+   * @param {number} reportId The report id
+   */
+  public downloadReportContent(reportId: number): void {
+    window.open(`${this.contextUrl}${ServiceRoute}/reports/${reportId}`, '_blank');
   }
 
   /**


### PR DESCRIPTION
This PR just converts our report download actions to open a browser tab rather than download via AJAX request.
The benefit is that for large report downloads the user can watch/cancel progress using standard browser download management.