### PR TITLE
Add Percentile information to IAB PDF reports.

### DIFF
--- a/common/src/main/resources/messages.properties
+++ b/common/src/main/resources/messages.properties
@@ -503,3 +503,7 @@ report.writing.trait.Unknown.Evidence.4=Unknown.Evidence/Elaboration.4
 report.writing.trait.Unknown.Conventions.0=Unknown.Conventions.0
 report.writing.trait.Unknown.Conventions.1=Unknown.Conventions.1
 report.writing.trait.Unknown.Conventions.2=Unknown.Conventions.2
+
+#Norms
+report.percentile.rank=Score is higher than {0}% of students.
+report.percentile.mean=The average student score was {0}.

--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -29,8 +29,25 @@
     .accommodations {
         page-break-after: always;
     }
+    .row, .well-group {
+        page-break-inside: avoid;
+    }
     .bordered.gray-light .label {
         border: 1px solid #64666A;
+    }
+    .well-group--horizontal>.well {
+        min-height: 180px;
+    }
+    .relative-container {
+        position: relative;
+    }
+    .bottom-right-aligned {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+    }
+    .well.pad-small {
+        padding: 10px 20px;
     }
 </style>
 </div>
@@ -85,13 +102,10 @@
             <p th:utext="#{report.faq.p3.html}"></p>
         </div>
         <div class="col-xs-4">
-            <div class="well">
-                <div class="well-body">
-                    <p><strong th:text="#{report.important-information.header}"></strong></p>
-                    <p th:text="#{report.important-information.item1}"></p>
-                    <p th:text="#{report.important-information.item2}"></p>
-                    </ol>
-                </div>
+            <div class="well pad-small">
+                <p><strong th:text="#{report.important-information.header}"></strong></p>
+                <p th:text="#{report.important-information.item1}"></p>
+                <p th:text="#{report.important-information.item2}"></p>
             </div>
         </div>
     </div>

--- a/report-processor/src/main/resources/templates/iab-body.html
+++ b/report-processor/src/main/resources/templates/iab-body.html
@@ -54,7 +54,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="row">
+                        <div class="row relative-container">
                             <div class="col-xs-9">
                                 <div th:if="${exam.scaleScore != null}" class="scale-score-graph individual"
                                      th:with="scaleScoreView=${support.getScaleScoreView(exam, assessment)}">
@@ -82,12 +82,18 @@
                                     <span class="gray-darker h2" th:text="#{report.not-scored}"></span>
                                 </div>
                             </div>
+                            <div class="col-xs-3 bottom-right-aligned text-right">
+                                <div class="date" th:text="${#dates.format(exam.dateTime, 'MM-dd-yyyy')}"></div>
+                                <div class="performance-level"
+                                     th:if="${exam.scaleScore != null}"
+                                     th:text="#{'report.iab.level.' + ${exam.scaleScore.level} + '.label'}"></div>
+                            </div>
                         </div>
-                        <div class="details">
-                            <div class="date text-right" th:text="${#dates.format(exam.dateTime, 'MM-dd-yyyy')}"></div>
-                            <div class="performance-level text-right"
-                                 th:if="${exam.scaleScore != null}"
-                                 th:text="#{'report.iab.level.' + ${exam.scaleScore.level} + '.label'}"></div>
+
+                        <div th:if="${exam.percentileRank != null && exam.percentileMean != null}"
+                             class="mt-xs">
+                            <span th:text="#{('report.percentile.rank')(${exam.percentileRank})}"></span>
+                            <span th:text="#{('report.percentile.mean')(${exam.percentileMean.toString()})}"></span>
                         </div>
                     </div>
                 </div>

--- a/report-processor/src/main/resources/templates/ica-body.html
+++ b/report-processor/src/main/resources/templates/ica-body.html
@@ -21,10 +21,8 @@
                     </div>
                 </div>
                 <div class="col-xs-6">
-                    <div class="well" th:if="${scored}">
-                        <div class="well-body">
-                            <p th:text="#{('report.overall-achievement.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject} + '.level.' + ${report.exam.scaleScore.level})(${report.student.firstName})}"></p>
-                        </div>
+                    <div class="well pad-small" th:if="${scored}">
+                            <span th:text="#{('report.overall-achievement.grade.' + ${report.assessment.gradeCode} + '.subject.' + ${report.assessment.subject} + '.level.' + ${report.exam.scaleScore.level})(${report.student.firstName})}"></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR adds percentile information (if available) to IAB results in a PDF report.

I also added styling to prevent page-breaking in the middle of a grouped display item (like the FAQ, an individual IAB result, etc)

I also reduced some well padding on ICAs to fix a few reports where the copyright "footer" section was being printed on a second page.