### PR TITLE
Bugfix/handle empty aggregate report

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/stream/AggregateReports.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/stream/AggregateReports.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import static org.opentestsystem.rdw.olap.stream.AggregateRequestProcessor.AggregateRequest;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.COMPLETED;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.FAILED;
+import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.NO_RESULTS;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 /**
@@ -69,6 +70,14 @@ public class AggregateReports {
         try {
             final User user = messageSecurityService.getUser(message);
             final AggregateReport report = service.findByQuery(user, payload.getQuery());
+
+            final boolean hasResults = report.getRows().stream()
+                    .anyMatch(reportRow -> reportRow.getMeasures().getAvgScaleScore() != null);
+            if (!hasResults) {
+                sendNoResults(payload.getId());
+                return;
+            }
+
             jsonFile = Files.createTempFile(String.valueOf(payload.getId()), "json");
 
             objectMapper.writeValue(jsonFile.toFile(), report.getRows());
@@ -121,5 +130,15 @@ public class AggregateReports {
         final Message<AggregateResponseMessage> responseMessage = MessageBuilder.createMessage(responsePayload, new MessageHeaders(new HashMap<>()));
         processor.aggregateResponse().send(responseMessage);
         logger.debug("Sent aggregate report success response: {}", requestId);
+    }
+
+    private void sendNoResults(final long requestId) {
+        final AggregateResponseMessage responsePayload = AggregateResponseMessage.builder()
+                .id(requestId)
+                .status(NO_RESULTS)
+                .build();
+        final Message<AggregateResponseMessage> responseMessage = MessageBuilder.createMessage(responsePayload, new MessageHeaders(new HashMap<>()));
+        processor.aggregateResponse().send(responseMessage);
+        logger.debug("Sent aggregate report no results response: {}", requestId);
     }
 }

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/stream/AggregateReportsTest.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/stream/AggregateReportsTest.java
@@ -32,6 +32,7 @@ import org.springframework.messaging.support.MessageBuilder;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.UUID;
@@ -42,10 +43,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.COMPLETED;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.FAILED;
+import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.NO_RESULTS;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -96,7 +99,7 @@ public class AggregateReportsTest {
                 .build();
 
         final AggregateReport report = AggregateReport.builder()
-                .rows(newArrayList(reportRow(), reportRow(), reportRow()))
+                .rows(newArrayList(reportRow().build(), reportRow().build(), reportRow().build()))
                 .createdWhileDataEmbargoed(true)
                 .build();
         when(service.findByQuery(eq(user), eq(query))).thenReturn(report);
@@ -131,6 +134,44 @@ public class AggregateReportsTest {
     }
 
     @Test
+    public void itShouldSendANoResultsResponseIfReportContainsNoRows() {
+        final AggregateReport report = AggregateReport.builder()
+                .createdWhileDataEmbargoed(true)
+                .build();
+        when(service.findByQuery(eq(user), any(ReportQuery.class))).thenReturn(report);
+
+        handler.handleAggregateRequest(message);
+        verify(responseChannel).send(responseMessageCaptor.capture());
+        final AggregateResponseMessage payload = responseMessageCaptor.getValue().getPayload();
+        assertThat(payload.getStatus()).isEqualTo(NO_RESULTS);
+
+        verifyZeroInteractions(archiveService);
+    }
+
+    @Test
+    public void itShouldSendANoResultsResponseIfReportContainsOnlyRowsWithNoResults() {
+        final Measures emptyMeasures = Measures.builder().build();
+        final Collection<ReportRow> rows = newArrayList();
+        rows.add(reportRow().measures(emptyMeasures).build());
+        rows.add(reportRow().measures(emptyMeasures).build());
+        rows.add(reportRow().measures(emptyMeasures).build());
+        rows.add(reportRow().measures(emptyMeasures).build());
+
+        final AggregateReport report = AggregateReport.builder()
+                .rows(rows)
+                .createdWhileDataEmbargoed(true)
+                .build();
+        when(service.findByQuery(eq(user), any(ReportQuery.class))).thenReturn(report);
+
+        handler.handleAggregateRequest(message);
+        verify(responseChannel).send(responseMessageCaptor.capture());
+        final AggregateResponseMessage payload = responseMessageCaptor.getValue().getPayload();
+        assertThat(payload.getStatus()).isEqualTo(NO_RESULTS);
+
+        verifyZeroInteractions(archiveService);
+    }
+
+    @Test
     public void itShouldWriteResultJsonToTheArchiveService() {
         handler.handleAggregateRequest(message);
 
@@ -141,7 +182,7 @@ public class AggregateReportsTest {
         assertThat(properties.get(Headers.CONTENT_TYPE)).isEqualTo(APPLICATION_JSON.toString());
     }
 
-    private ReportRow reportRow() {
+    private ReportRow.Builder reportRow() {
         final ActiveAssessment assessment = ActiveAssessment.builder()
                 .id(1)
                 .subjectCode("Math")
@@ -171,7 +212,6 @@ public class AggregateReportsTest {
                 .dimension(Dimension.builder().type(Overall).build())
                 .assessment(assessment)
                 .measures(measures)
-                .organization(organization)
-                .build();
+                .organization(organization);
     }
 }

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -46,6 +46,12 @@
       <spinner text="{{'aggregate-report.processing' | translate}}"></spinner>
     </ng-container>
 
+    <ng-container *ngIf="reportEmpty">
+      <div class="well">
+        <p>{{'aggregate-report.empty' | translate}}</p>
+      </div>
+    </ng-container>
+
     <ng-container *ngIf="reportNotLoadable">
       <div class="well">
         <p>{{'aggregate-report.error.unloadable' | translate}}</p>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -90,6 +90,10 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
     return this._viewState === ViewState.ReportProcessing;
   }
 
+  get reportEmpty(): boolean {
+    return this._viewState === ViewState.ReportEmpty;
+  }
+
   get reportNotLoadable(): boolean {
     return this._viewState === ViewState.ReportNotLoadable;
   }
@@ -150,7 +154,10 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
     if (this.report.processing) {
       return ViewState.ReportProcessing;
     }
-    if (!this.report.loadable) {
+    if (this.report.empty) {
+      return ViewState.ReportEmpty;
+    }
+    if (!this.report.completed) {
       return ViewState.ReportNotLoadable;
     }
     if (!this.isSupportedSize(this.report) && !this._displayLargeReport) {
@@ -255,6 +262,7 @@ interface AggregateReportTableView {
 
 enum ViewState {
   ReportProcessing,
+  ReportEmpty,
   ReportNotLoadable,
   ReportSizeNotSupported,
   ReportView

--- a/webapp/src/main/webapp/src/app/report/report.model.ts
+++ b/webapp/src/main/webapp/src/app/report/report.model.ts
@@ -24,12 +24,12 @@ export class Report {
     return this.status === 'COMPLETED';
   }
 
-  get processing(): boolean {
-    return this.status === 'PENDING' || this.status === 'RUNNING';
+  get empty(): boolean {
+    return this.status === 'NO_RESULTS';
   }
 
-  get loadable(): boolean {
-    return this.status !== 'FAILED' && this.status !== 'EXPIRED';
+  get processing(): boolean {
+    return this.status === 'PENDING' || this.status === 'RUNNING';
   }
 
   get regenerable(): boolean {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -16,6 +16,7 @@
   "aggregate-report": {
     "column-order": "Column Order",
     "column-order-info": "Change your result column order to easily compare your results broken down in different ways.",
+    "empty": "Your report does not contain any results. Please modify your query and generate a new report.",
     "heading": "Aggregate Report",
     "form-link": "View Query",
     "processing": "Your report is being generated. This may take several minutes. ",


### PR DESCRIPTION
This handles both the case where the aggregate report contains no rows and when the report contains only rows with no results.

Results page when report contains no results:
![image](https://user-images.githubusercontent.com/617828/36705001-d2ecfaec-1b17-11e8-811c-2ad28baa5a67.png)
