### PR TITLE
Disable embargoed aggregate report download in the UI.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-reports.module.ts
@@ -8,7 +8,7 @@ import { MultiselectDropdownModule } from "angular-2-dropdown-multiselect";
 import { AggregateReportOptionsService } from "./aggregate-report-options.service";
 import { AggregateReportOptionsMapper } from "./aggregate-report-options.mapper";
 import { AggregateReportOrganizationService } from "./aggregate-report-organization.service";
-import { ModalModule, TypeaheadModule } from "ngx-bootstrap";
+import { ModalModule, PopoverModule, TypeaheadModule } from "ngx-bootstrap";
 import { AggregateReportOrganizationList } from "./aggregate-report-organization-list.component";
 import { AggregateReportService } from "./aggregate-report.service";
 import { ReportModule } from "../report/report.module";
@@ -47,6 +47,7 @@ import { AggregateReportColumnOrderItemProvider } from "./aggregate-report-colum
     FormsModule,
     ModalModule,
     MultiselectDropdownModule,
+    PopoverModule.forRoot(),
     ReactiveFormsModule,
     ReportModule,
     TypeaheadModule

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -89,10 +89,15 @@
                   class="label">{{'common.assessment-type.' + query.assessmentTypeCode + '.short-name' | translate}}</span><span
                 class="label">{{'common.subject.' + table.subjectCode + '.short-name' | translate}}</span>
               </h3>
-              <button class="btn btn-sm btn-default ml-sm"
-                      (click)="reportTable.exportTable(getExportName(table))"><i class="fa fa-cloud-download"></i>
+              <a class="btn btn-sm btn-default ml-sm with-pointer"
+                 [ngClass]="{'disabled': isEmbargoed()}"
+                 popover="{{ (isEmbargoed() ? 'labels.reports.report-actions.embargoed' : '') | translate }}"
+                 triggers="{{ isEmbargoed() ? 'mouseenter:mouseleave': '' }}"
+                 placement="top"
+                 container="body"
+                 (click)="!isEmbargoed() && reportTable.exportTable(getExportName(table))"><i class="fa fa-cloud-download"></i>
                 {{'common.export' | translate}}
-              </button>
+              </a>
             </div>
             <div class="clearfix"></div>
             <div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -144,6 +144,10 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
     tableView.columnOrdering = items.map(item => item.value);
   }
 
+  isEmbargoed(): boolean {
+    return this.report.metadata.createdWhileDataEmbargoed == "true";
+  }
+
   private updateViewState(): void {
     let targetViewState: ViewState = this.getTargetViewState();
     this.onViewStateChange(this._viewState, targetViewState);

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -145,7 +145,7 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
   }
 
   isEmbargoed(): boolean {
-    return this.report.metadata.createdWhileDataEmbargoed == "true";
+    return this.report.metadata.createdWhileDataEmbargoed === "true";
   }
 
   private updateViewState(): void {

--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -47,8 +47,8 @@ export class ReportActionComponent implements OnInit {
     menuAction.isDisabled = () => {
       return reportAction.disabled;
     };
-    if (reportAction.tooltipKey) {
-      menuAction.tooltip = () => this.translateService.instant(reportAction.tooltipKey);
+    if (reportAction.popoverKey) {
+      menuAction.tooltip = () => this.translateService.instant(reportAction.popoverKey);
     }
 
     return menuAction;

--- a/webapp/src/main/webapp/src/app/report/report-action.component.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.component.ts
@@ -47,6 +47,10 @@ export class ReportActionComponent implements OnInit {
     menuAction.isDisabled = () => {
       return reportAction.disabled;
     };
+    if (reportAction.tooltipKey) {
+      menuAction.tooltip = () => this.translateService.instant(reportAction.tooltipKey);
+    }
+
     return menuAction;
   }
 }

--- a/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
@@ -90,7 +90,7 @@ describe('ReportActionService', () => {
     expect(router.navigateByUrl).toHaveBeenCalledWith(`/aggregate-reports?src=${report.id}`);
 
     const downloadReportAction: ReportAction = actions[2];
-    expect(downloadReportAction.tooltipKey).toBeUndefined();
+    expect(downloadReportAction.popoverKey).toBeUndefined();
     expect(downloadReportAction.disabled).toBe(false);
     service.performAction(downloadReportAction);
     expect(reportService.downloadReportContent).toHaveBeenCalledWith(report.id);
@@ -107,7 +107,7 @@ describe('ReportActionService', () => {
     expect(actions.length).toBe(3);
 
     const downloadReportAction: ReportAction = actions[2];
-    expect(downloadReportAction.tooltipKey.length).toBeGreaterThan(1);
+    expect(downloadReportAction.popoverKey.length).toBeGreaterThan(1);
     expect(downloadReportAction.disabled).toBe(true);
     service.performAction(downloadReportAction);
     expect(reportService.downloadReportContent).not.toHaveBeenCalled();

--- a/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.spec.ts
@@ -76,6 +76,7 @@ describe('ReportActionService', () => {
     const report: Report = createReport();
     report.status = "COMPLETED";
     report.reportType = AggregateReportType;
+    report.metadata = {'createdWhileDataEmbargoed' : 'false'};
 
     const actions: ReportAction[] = service.getActions(report);
     expect(actions.length).toBe(3);
@@ -89,8 +90,27 @@ describe('ReportActionService', () => {
     expect(router.navigateByUrl).toHaveBeenCalledWith(`/aggregate-reports?src=${report.id}`);
 
     const downloadReportAction: ReportAction = actions[2];
+    expect(downloadReportAction.tooltipKey).toBeUndefined();
+    expect(downloadReportAction.disabled).toBe(false);
     service.performAction(downloadReportAction);
     expect(reportService.downloadReportContent).toHaveBeenCalledWith(report.id);
+
+  });
+
+  it('should disable the download action for an embargoed AggregateReportRequest', () => {
+    const report: Report = createReport();
+    report.status = "COMPLETED";
+    report.reportType = AggregateReportType;
+    report.metadata = {'createdWhileDataEmbargoed' : 'true'};
+
+    const actions: ReportAction[] = service.getActions(report);
+    expect(actions.length).toBe(3);
+
+    const downloadReportAction: ReportAction = actions[2];
+    expect(downloadReportAction.tooltipKey.length).toBeGreaterThan(1);
+    expect(downloadReportAction.disabled).toBe(true);
+    service.performAction(downloadReportAction);
+    expect(reportService.downloadReportContent).not.toHaveBeenCalled();
   });
 
   function createReport(): Report {

--- a/webapp/src/main/webapp/src/app/report/report-action.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.ts
@@ -73,7 +73,7 @@ export interface ReportAction {
   readonly icon?: string;
   readonly labelKey?: string;
   readonly disabled?: boolean;
-  readonly tooltipKey?: string;
+  readonly popoverKey?: string;
 }
 
 /**
@@ -127,7 +127,7 @@ class AggregateReportActionProvider extends DefaultActionProvider {
 
   public getActions(report: Report): ReportAction[] {
     const disableViewAndDownload: boolean = !report.completed && !report.processing;
-    const embargoed: boolean = report.metadata.createdWhileDataEmbargoed == "true";
+    const embargoed: boolean = report.metadata.createdWhileDataEmbargoed === "true";
     return [
       {
         type: ActionType.Navigate,
@@ -145,7 +145,7 @@ class AggregateReportActionProvider extends DefaultActionProvider {
         value: report.id,
         labelKey: 'labels.reports.report-actions.download-report',
         disabled: disableViewAndDownload || embargoed,
-        tooltipKey: embargoed ? 'labels.reports.report-actions.embargoed' : undefined
+        popoverKey: embargoed ? 'labels.reports.report-actions.embargoed' : undefined
       }
     ];
   }

--- a/webapp/src/main/webapp/src/app/report/report-action.service.ts
+++ b/webapp/src/main/webapp/src/app/report/report-action.service.ts
@@ -42,6 +42,10 @@ export class ReportActionService {
    * @param {ReportAction} action An action
    */
   public performAction(action: ReportAction): void {
+    if (action.disabled) {
+      return;
+    }
+
     if (action.type == ActionType.Download) {
       this.performDownload(action);
     }
@@ -69,6 +73,7 @@ export interface ReportAction {
   readonly icon?: string;
   readonly labelKey?: string;
   readonly disabled?: boolean;
+  readonly tooltipKey?: string;
 }
 
 /**
@@ -121,7 +126,8 @@ class AggregateReportActionProvider extends DefaultActionProvider {
   }
 
   public getActions(report: Report): ReportAction[] {
-    const disableViewAndDownload = !report.completed && !report.processing;
+    const disableViewAndDownload: boolean = !report.completed && !report.processing;
+    const embargoed: boolean = report.metadata.createdWhileDataEmbargoed == "true";
     return [
       {
         type: ActionType.Navigate,
@@ -138,7 +144,8 @@ class AggregateReportActionProvider extends DefaultActionProvider {
         type: ActionType.Download,
         value: report.id,
         labelKey: 'labels.reports.report-actions.download-report',
-        disabled: disableViewAndDownload
+        disabled: disableViewAndDownload || embargoed,
+        tooltipKey: embargoed ? 'labels.reports.report-actions.embargoed' : undefined
       }
     ];
   }

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1524,7 +1524,7 @@
         "view-report": "View Report",
         "view-query": "View Report Query",
         "download-report": "Download Report Data",
-        "embargoed": "Report contains embargoed results"
+        "embargoed": "Reports with embargoed results may only be viewed online, they may not be downloaded."
       },
       "status": {
         "COMPLETED": "Completed",

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1523,7 +1523,8 @@
       "report-actions": {
         "view-report": "View Report",
         "view-query": "View Report Query",
-        "download-report": "Download Report Data"
+        "download-report": "Download Report Data",
+        "embargoed": "Report contains embargoed results"
       },
       "status": {
         "COMPLETED": "Completed",

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -911,3 +911,7 @@ body .ui-widget.ui-datatable table .ui-datatable-data > tr > td.level-down,
     margin-bottom: 0;
   }
 }
+
+a.btn.disabled.with-pointer {
+  pointer-events: auto;
+}


### PR DESCRIPTION
This PR disables the download actions for an aggregate report when it was generated containing embargoed results.

![image](https://user-images.githubusercontent.com/617828/36749323-475f4528-1baf-11e8-8028-a77894baa0ef.png)

![image](https://user-images.githubusercontent.com/617828/36749335-52cf650a-1baf-11e8-8205-e926c609a672.png)
