### PR TITLE
Do not store a resource URI for aggregate reports with no content.

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandler.java
@@ -59,19 +59,17 @@ public class AggregateReportResponseHandler {
             return;
         }
 
-        if (report.getStatus() != COMPLETED) {
-            reportService.update(report.copy()
-                    .status(payload.getStatus())
-                    .build());
-            return;
+        final Report.Builder updatedReport = report.copy()
+                .status(payload.getStatus());
+
+        if (payload.getStatus() == COMPLETED) {
+            updatedReport
+                    .metadata("totalCount", String.valueOf(payload.getResultCount()))
+                    .metadata("createdWhileDataEmbargoed", String.valueOf(payload.isCreatedWhileDataEmbargoed()))
+                    .reportResourceUri(contentService.createUri(report, APPLICATION_JSON));
         }
 
-        reportService.update(report.copy()
-                .status(payload.getStatus())
-                .metadata("totalCount", String.valueOf(payload.getResultCount()))
-                .metadata("createdWhileDataEmbargoed", String.valueOf(payload.isCreatedWhileDataEmbargoed()))
-                .reportResourceUri(contentService.createUri(report, APPLICATION_JSON))
-                .build());
+        reportService.update(updatedReport.build());
     }
 
     private boolean validatePayload(final AggregateResponseMessage payload, final Report report) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandler.java
@@ -59,6 +59,13 @@ public class AggregateReportResponseHandler {
             return;
         }
 
+        if (report.getStatus() != COMPLETED) {
+            reportService.update(report.copy()
+                    .status(payload.getStatus())
+                    .build());
+            return;
+        }
+
         reportService.update(report.copy()
                 .status(payload.getStatus())
                 .metadata("totalCount", String.valueOf(payload.getResultCount()))

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/AggregateReportResponseHandlerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.COMPLETED;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.FAILED;
+import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.NO_RESULTS;
 import static org.opentestsystem.rdw.reporting.common.model.ReportStatus.PENDING;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -88,6 +89,23 @@ public class AggregateReportResponseHandlerTest {
         assertThat(reportCaptor.getValue().getReportResourceUri()).isEqualTo(ReportUri);
         assertThat(parseLong(reportCaptor.getValue().getMetadata().get("totalCount"))).isEqualTo(message.getPayload().getResultCount());
         assertThat(Boolean.parseBoolean(reportCaptor.getValue().getMetadata().get("createdWhileDataEmbargoed"))).isEqualTo(message.getPayload().isCreatedWhileDataEmbargoed());
+    }
+
+    @Test
+    public void itShouldHandleAReportWithNoContent() {
+        final AggregateResponseMessage payload = AggregateResponseMessage.builder()
+                .id(ReportId)
+                .status(NO_RESULTS)
+                .build();
+        message = MessageBuilder.createMessage(payload, new MessageHeaders(new HashMap<>()));
+
+        handler.handleAggregateReportResponse(message);
+
+        verifyZeroInteractions(contentService);
+        verify(reportService).update(reportCaptor.capture());
+        assertThat(reportCaptor.getValue().getStatus()).isEqualTo(NO_RESULTS);
+        assertThat(reportCaptor.getValue().getReportResourceUri()).isNull();
+        assertThat(reportCaptor.getValue().getMetadata()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
This PR prevents storing a report URI for an aggregate report with no results.  Storing a non-existent URI may cause issues during report expiration cleanup processing where the attempt to delete the resource from the archive will fail.