### PR TITLE
Add test for whether user has access to embargoed exam results to rep…

### DIFF
--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/DefaultEmbargoService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/DefaultEmbargoService.java
@@ -1,0 +1,24 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default implementation of an EmbargoService.
+ */
+@Service
+public class DefaultEmbargoService implements EmbargoService {
+
+    private final EmbargoRepository repository;
+
+    @Autowired
+    public DefaultEmbargoService(final EmbargoRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean hasEmbargoedOrganizations(final User user) {
+        return repository.hasEmbargoAccess(user);
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoController.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoController.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This controller is responsible for providing embargo API endpoints.
+ */
+@RestController
+public class EmbargoController {
+
+    private final EmbargoService service;
+
+    @Autowired
+    public EmbargoController(final EmbargoService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/organizations/embargoed")
+    public boolean hasEmbargoedOrganizations(@AuthenticationPrincipal final User user) {
+        return service.hasEmbargoedOrganizations(user);
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoRepository.java
@@ -1,0 +1,17 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
+
+/**
+ * Repository responsible for the embargo data
+ */
+public interface EmbargoRepository {
+
+    /**
+     * Test if the given permissions have read access to any embargoed exams.
+     *
+     * @param permissionSource The permission source
+     * @return True if the given permissions have access to embargoed exams
+     */
+    boolean hasEmbargoAccess(PermissionSource permissionSource);
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoService.java
@@ -5,7 +5,7 @@ import org.opentestsystem.rdw.reporting.common.web.security.User;
 import javax.validation.constraints.NotNull;
 
 /**
- *
+ * Implementations of this interface are responsible for providing embargo information.
  */
 public interface EmbargoService {
 

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/EmbargoService.java
@@ -1,0 +1,19 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ *
+ */
+public interface EmbargoService {
+
+    /**
+     * Determines if the user has access to embargoed student exams.
+     *
+     * @param user the user
+     * @return true if the user has access to embargoed student exams
+     */
+    boolean hasEmbargoedOrganizations(@NotNull User user);
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/JdbcEmbargoRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/embargo/JdbcEmbargoRepository.java
@@ -1,0 +1,44 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
+import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
+import org.opentestsystem.rdw.security.Permission;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.EmbargoRead;
+
+/**
+ * Default JDBC implementation of an EmbargoRepository.
+ */
+@Repository
+public class JdbcEmbargoRepository implements EmbargoRepository {
+    private final NamedParameterJdbcTemplate template;
+    private final SecurityParameterProvider securityParameterProvider;
+
+    @Value("${sql.embargo.existsForSchool}")
+    private String existsForSchoolQuery;
+
+    @Autowired
+    public JdbcEmbargoRepository(final NamedParameterJdbcTemplate template,
+                                 final SecurityParameterProvider securityParameterProvider) {
+        this.template = template;
+        this.securityParameterProvider = securityParameterProvider;
+    }
+
+    @Override
+    public boolean hasEmbargoAccess(final PermissionSource permissionSource) {
+        final Permission permission = permissionSource.getPermissionsById().get(EmbargoRead);
+        if (permission == null) {
+            return false;
+        }
+
+        return template.queryForObject(
+                existsForSchoolQuery,
+                new MapSqlParameterSource().addValues(securityParameterProvider.getSecurityParameters(permission.getScope())),
+                Boolean.class);
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/organization/OrganizationController.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/organization/OrganizationController.java
@@ -8,12 +8,14 @@ import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
 @RestController
+@RequestMapping("/organizations")
 public class OrganizationController {
 
     private final OrganizationService service;
@@ -23,22 +25,22 @@ public class OrganizationController {
         this.service = service;
     }
 
-    @GetMapping("/organizations/schools")
+    @GetMapping("/schools")
     public Set<School> getSchools(@AuthenticationPrincipal final User user) {
         return service.getSchools(user);
     }
 
-    @GetMapping("/organizations/schoolGroups")
+    @GetMapping("/schoolGroups")
     public Set<SchoolGroup> getSchoolGroups(@AuthenticationPrincipal final User user) {
         return service.getSchoolGroups(user);
     }
 
-    @GetMapping("/organizations/districts")
+    @GetMapping("/districts")
     public Set<District> getDistricts(@AuthenticationPrincipal final User user) {
         return service.getDistricts(user);
     }
 
-    @GetMapping("/organizations/districtGroups")
+    @GetMapping("/districtGroups")
     public Set<DistrictGroup> getDistrictGroups(@AuthenticationPrincipal final User user) {
         return service.getDistrictGroups(user);
     }

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -1,4 +1,13 @@
 sql:
+  embargo:
+    existsForSchool: >-
+      SELECT EXISTS(
+        SELECT 1
+        FROM school sc
+        WHERE sc.embargo_enabled = 1
+          AND ${sql.snippet.basicPermission}
+        LIMIT 1) AS embargo_enabled
+
   exam:
     findAllByStudentId: >-
       SELECT

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/DefaultEmbargoServiceTest.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/DefaultEmbargoServiceTest.java
@@ -1,0 +1,46 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultEmbargoServiceTest {
+
+    @Mock
+    private EmbargoRepository repository;
+
+    private User user;
+    private DefaultEmbargoService service;
+
+    @Before
+    public void setup() {
+        user = User.builder()
+                .id(UUID.randomUUID().toString())
+                .username("someone-10@somewhere.com")
+                .password("redacted")
+                .build();
+
+        service = new DefaultEmbargoService(repository);
+    }
+
+    @Test
+    public void itShouldDelegateHasEmbargoedOrganizationsToRepository() {
+        when(repository.hasEmbargoAccess(any(PermissionSource.class))).thenReturn(true);
+
+        assertThat(service.hasEmbargoedOrganizations(user)).isTrue();
+        verify(repository).hasEmbargoAccess(eq(user));
+    }
+}

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/EmbargoControllerIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/EmbargoControllerIT.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(EmbargoController.class)
+@WithMockUser(username = "test")
+public class EmbargoControllerIT {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private EmbargoService service;
+
+    @Test
+    public void schoolsShouldReturnWhatServiceReturns() throws Exception {
+
+        when(service.hasEmbargoedOrganizations(any(User.class))).thenReturn(true);
+
+        mvc.perform(get("/organizations/embargoed"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(true))
+        ;
+    }
+
+}

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/JdbcEmbargoRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/embargo/JdbcEmbargoRepositoryIT.java
@@ -1,0 +1,90 @@
+package org.opentestsystem.rdw.reporting.embargo;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
+import org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes;
+import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.reporting.common.security.ReportingPermission.EmbargoRead;
+
+@Import(JdbcEmbargoRepository.class)
+@Sql(scripts = {
+        "classpath:integration-test-data.sql",
+        "classpath:embargo-test-data.sql"
+})
+public class JdbcEmbargoRepositoryIT extends JdbcRepositoryWithPermissionIT {
+
+    @Autowired
+    private JdbcEmbargoRepository repository;
+
+    private Permission embargoedPermission;
+    private Permission nonEmbargoedPermission;
+
+    @Before
+    public void setup() {
+        final PermissionScope embargoedScope = PermissionScopes.districts(-10L);
+        embargoedPermission = new Permission(EmbargoRead, embargoedScope);
+
+        final PermissionScope nonEmbargoedScope = PermissionScopes.districts(-100L);
+        nonEmbargoedPermission = new Permission(EmbargoRead, nonEmbargoedScope);
+    }
+
+    @Test
+    public void aUserWithoutEmbargoReadShouldNeverBeEmbargoed() {
+        final User user = userBuilder.build();
+        assertThat(repository.hasEmbargoAccess(user)).isFalse();
+    }
+
+    @Test
+    public void aUserWithEmbargoReadForAnEmbargoedDistrictShouldBeEmbargoed() {
+        final User user = userBuilder
+                .permissionsById(ImmutableMap.<String, Permission>builder()
+                        .put(EmbargoRead, embargoedPermission)
+                        .build())
+                .build();
+
+        assertThat(repository.hasEmbargoAccess(user)).isTrue();
+    }
+
+    @Test
+    public void aUserWithEmbargoReadForANonEmbargoedDistrictShouldNotBeEmbargoed() {
+        final User user = userBuilder
+                .permissionsById(ImmutableMap.<String, Permission>builder()
+                        .put(EmbargoRead, nonEmbargoedPermission)
+                        .build())
+                .build();
+
+        assertThat(repository.hasEmbargoAccess(user)).isFalse();
+    }
+
+    @Test
+    public void aUserWithEmbargoReadForBothNonEmbargoedAndEmbargoedDistrictsShouldBeEmbargoed() {
+        final PermissionScope multiEmbargoedScope = PermissionScopes.districts(-10L, -100L);
+        final User user = userBuilder
+                .permissionsById(ImmutableMap.<String, Permission>builder()
+                        .put(EmbargoRead, new Permission(EmbargoRead, multiEmbargoedScope))
+                        .build())
+                .build();
+
+        assertThat(repository.hasEmbargoAccess(user)).isTrue();
+    }
+
+    @Test
+    public void aStateEmbargoReadUserWithAnyEmbargoedDistrictsShouldBeEmbargoed() {
+        final User user = userBuilder
+                .permissionsById(ImmutableMap.<String, Permission>builder()
+                        .put(EmbargoRead, new Permission(EmbargoRead, PermissionScopes.statewide()))
+                        .build())
+                .build();
+
+        assertThat(repository.hasEmbargoAccess(user)).isTrue();
+    }
+}

--- a/reporting-service/src/test/resources/embargo-test-data.sql
+++ b/reporting-service/src/test/resources/embargo-test-data.sql
@@ -1,0 +1,7 @@
+-- Create non-embargoed district
+insert into district (id, natural_id, name) values
+  (-100, 'districtNat100', 'district100');
+
+-- Create non-embargoed school within district
+insert into school (id, district_id, natural_id, name, embargo_enabled, update_import_id, updated, migrate_id, school_group_id, district_group_id, external_id) VALUES
+  (-100, -10, 'schoolNat100', 'school100', 0, -1, '1997-07-18 20:14:34.000000', -1, null, null, 'externalId100');

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -162,8 +162,11 @@
       </li>
       <li>
         <button class="btn btn-default btn-xs"
-                [disabled]="exportDisabled"
-                (click)="callExport()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
+                [ngClass]="{disabled: exportDisabled}"
+                popover="{{'embargo-admin-alert.export.disabled' | translate}}"
+                [triggers]="exportDisabled ? 'mouseenter:mouseleave' : ''"
+                placement="left"
+                (click)="!exportDisabled && callExport()"><i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}</button>
       </li>
     </ul>
   </ng-template>

--- a/webapp/src/main/webapp/src/app/shared/embargo/reporting-embargo.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/embargo/reporting-embargo.service.ts
@@ -28,7 +28,7 @@ export class ReportingEmbargoService {
             return of(false);
           }
 
-          return this.dataService.get(`${ReportingServiceRoute}/user-organizations/embargoed`)
+          return this.dataService.get(`${ReportingServiceRoute}/organizations/embargoed`)
             .pipe(catchError(response => of(false)))
         }));
   }

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.html
@@ -17,8 +17,11 @@
       <ul class="list-unstyled list-inline">
         <li>
           <button class="btn btn-default btn-sm"
-                  [disabled]="exportDisabled"
-                  (click)="exportCsv()">
+                  [ngClass]="{disabled: exportDisabled}"
+                  popover="{{'embargo-admin-alert.export.disabled' | translate}}"
+                  [triggers]="exportDisabled ? 'mouseenter:mouseleave' : ''"
+                  placement="left"
+                  (click)="!exportDisabled && exportCsv()">
             <i class="fa fa-bold fa-table"></i> {{'labels.export.csv' | translate}}
           </button>
         </li>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -6,7 +6,10 @@
     "aggregate-reports-link": "Create Aggregate Report"
   },
   "embargo-admin-alert": {
-    "message": "Summative test results in your region of administration are not yet released. These results may be viewed online but not downloaded."
+    "message": "Summative test results in your region of administration are not yet released. These results may be viewed online but not downloaded.",
+    "export": {
+      "disabled": "Embargoed results can be viewed online, but may not be exported."
+    }
   },
   "assessment-percentile-table": {
     "column": {


### PR DESCRIPTION
…orting UI

This PR adds a back-end "/organizations/embargoed" API that returns TRUE if the user has EMBARGO_READ access to any embargoed Schools, and FALSE otherwise.

I also added a popover tooltip to the disabled "Export CSV" buttons when they are disabled due to user's potential access to embargoed exam results.
![image](https://user-images.githubusercontent.com/617828/36810848-c8f375ec-1c80-11e8-9b51-c37eeac70416.png)
