### PR TITLE
Set whether the most recent assessment is shown before executing logi…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
@@ -110,12 +110,12 @@ export class AssessmentsComponent implements OnInit {
 
   set showOnlyMostRecent(value: boolean) {
     this.expandAssessments = !value;
+    this._showOnlyMostRecent = value;
+
     if (value) {
       this.availableAssessments = [];
       this.updateAssessment(this.route.snapshot.data[ "assessment" ]);
     }
-
-    this._showOnlyMostRecent = value;
   }
 
   get selectedAssessments() {


### PR DESCRIPTION
…c that depends upon the value.

The call path is:
```
set showOnlyMostRecent(value: boolean) =>
updateAssessment(latestAssessment) =>
private updateFilterOptions() => {
  this.filterOptions.hasInterim = this.selectedAssessments.some(a => a.isInterim);
}
get selectedAssessments() => {
  if (this.showOnlyMostRecent && this._assessmentExams)
}
get showOnlyMostRecent(): boolean => {
  return this._showOnlyMostRecent;
}
```
Which basically means that `this._showOnlyMostRecent` must be set before `updateAssessment(latestAssessment)` is called. ...and digging through all that makes me wonder if it's almost time for a refactoring...