### PR TITLE
allow assessment-types collection to be set empty

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/AggregateReportSettings.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/AggregateReportSettings.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 @Component
 @ConfigurationProperties(prefix = "app.aggregate-reports")
 public class AggregateReportSettings {
@@ -25,7 +27,7 @@ public class AggregateReportSettings {
     }
 
     public void setAssessmentTypes(final Set<String> values) {
-        this.assessmentTypes = values != null ? ImmutableSet.copyOf(values) : ImmutableSet.of();
+        this.assessmentTypes = toTypeSet(values);
     }
 
     public Set<String> getStatewideUserAssessmentTypes() {
@@ -33,7 +35,20 @@ public class AggregateReportSettings {
     }
 
     public void setStatewideUserAssessmentTypes(final Set<String> values) {
-        this.statewideUserAssessmentTypes = values != null ? ImmutableSet.copyOf(values) : ImmutableSet.of();
+        this.statewideUserAssessmentTypes = toTypeSet(values);
     }
 
+    /**
+     * This helper allows the property to be set to "null" (or "none") to create an empty set.
+     * This is necessary because the default setting for this property is not empty and there
+     * is no Spring way to create an empty property that overrides the default setting.
+     *
+     * @param values type values, may be null
+     * @return immutable set with "none"/"null" removed, may be empty but never null
+     */
+    private static ImmutableSet<String> toTypeSet(final Set<String> values) {
+        return values == null ? ImmutableSet.of() : values.stream()
+                .filter(value -> !value.equalsIgnoreCase("none") && !value.equalsIgnoreCase("null"))
+                .collect(toImmutableSet());
+    }
 }

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/AggregateReportSettingsIT.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/AggregateReportSettingsIT.java
@@ -1,0 +1,25 @@
+package org.opentestsystem.rdw.olap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles("ars")
+public class AggregateReportSettingsIT {
+
+    @Autowired
+    private AggregateReportSettings settings;
+
+    @Test
+    public void itShouldOverrideTypes() {
+        assertThat(settings.getAssessmentTypes()).containsExactlyInAnyOrder("iab", "ica", "sum");
+        assertThat(settings.getStatewideUserAssessmentTypes()).isEmpty();
+    }
+}

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/AggregateReportSettingsTest.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/AggregateReportSettingsTest.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.olap;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AggregateReportSettingsTest {
+
+    private AggregateReportSettings settings;
+
+    @Before
+    public void createSettings() {
+        settings = new AggregateReportSettings();
+    }
+
+    @Test
+    public void itShouldRetainSettings() {
+        settings.setAssessmentTypes(ImmutableSet.of("ica", "sum"));
+        settings.setStatewideUserAssessmentTypes(ImmutableSet.of("sum"));
+
+        assertThat(settings.getAssessmentTypes()).containsExactlyInAnyOrder("ica", "sum");
+        assertThat(settings.getStatewideUserAssessmentTypes()).containsExactlyInAnyOrder("sum");
+    }
+
+    @Test
+    public void itShouldFilterNullPlaceholder() {
+        settings.setAssessmentTypes(ImmutableSet.of("null", "ica", "sum"));
+        settings.setStatewideUserAssessmentTypes(ImmutableSet.of("none"));
+
+        assertThat(settings.getAssessmentTypes()).containsExactlyInAnyOrder("ica", "sum");
+        assertThat(settings.getStatewideUserAssessmentTypes()).isEmpty();
+    }
+}

--- a/aggregate-service/src/test/resources/application-ars.yml
+++ b/aggregate-service/src/test/resources/application-ars.yml
@@ -1,0 +1,4 @@
+app:
+  aggregate-reports:
+    assessment-types: iab,ica,sum
+    statewide-user-assessment-types: none


### PR DESCRIPTION
As we all know (and love), with Spring properties there is no way to set an empty value when overriding a non-empty value. This tweaks AggregateReportSettings so we can do that.

Why? Because SmarterBalanced wants to disable summative test results in production because there are no summative tests. But the state user also can't see interim results. So the state user can't see anything. And, yeah, i have no idea how the app will behave when we disable all assessment types and go to aggregate reporting.