### PR TITLE
removes now invalid tests

### DIFF
--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/group/JdbcGroupRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/group/JdbcGroupRepositoryIT.java
@@ -44,14 +44,4 @@ public class JdbcGroupRepositoryIT {
                 );
     }
 
-    @Test
-    public void itShouldFilterOutUnassignedGroupGrants() throws Exception {
-        assertThat(repository.findAllForUsername("user-login")).isEmpty();
-    }
-
-    @Test
-    public void itShouldFilterOutUnmatchedGroupGrants() throws Exception {
-        assertThat(repository.findAllForUsername("user-login")).isEmpty();
-    }
-
 }


### PR DESCRIPTION
these tests now don't make sense because we don't pass in a group ID whitelist to filter on