### PR TITLE
Fix leaking connections to S3 in the report-processor when retrieving…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/MediaTypes.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/MediaTypes.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 
 /**
  * Utility class for handling custom MediaTypes.
@@ -27,6 +28,7 @@ public class MediaTypes {
             .put(APPLICATION_ZIP, "zip")
             .put(TEXT_CSV_UTF8, "csv")
             .put(APPLICATION_JSON, "json")
+            .put(APPLICATION_OCTET_STREAM, "unknown")
             .build();
 
     public static String getExtension(final MediaType mediaType) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
@@ -95,6 +95,16 @@ public class ArchiveBackedReportContentService implements ReportContentService {
         return URI.create(BasePath + report.getId() + "." + getExtension(mediaType));
     }
 
+    /**
+     * Determine the content media type.
+     * NOTE: Old V1 PDF reports are stored with the S3-default content type of
+     * 'application/octet-stream' This assumes any resource with the S3-default
+     * content type is actually 'application/pdf'
+     * TODO: Remove APPLICATION_PDF assumption once we no longer need to support V1 PDF reports
+     *
+     * @param contentType The resource content-type
+     * @return The parsed media type
+     */
     private MediaType parseMediaType(final String contentType) {
         if (isEmpty(contentType)) {
             return APPLICATION_PDF_UTF8;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.APPLICATION_PDF_UTF8;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.getExtension;
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.util.StringUtils.isEmpty;
 
 /**
@@ -66,17 +67,16 @@ public class ArchiveBackedReportContentService implements ReportContentService {
         final Properties reportProperties = archiveService.readProperties(location);
         if (!reportProperties.containsKey(Headers.CONTENT_LENGTH)) return null;
 
-        final String contentType = reportProperties.getProperty(Headers.CONTENT_TYPE);
-        final MediaType mediaType = isEmpty(contentType) ? APPLICATION_PDF_UTF8 : MediaType.parseMediaType(contentType);
+        final MediaType mediaType = parseMediaType(reportProperties.getProperty(Headers.CONTENT_TYPE));
         final long reportLength = (Long) reportProperties.get(Headers.CONTENT_LENGTH);
-        return new ReportContentResource(archiveService.openResource(location), reportLength, mediaType, report);
+        return new ReportContentResource(() -> archiveService.openResource(location), reportLength, mediaType, report);
     }
 
     @Override
     public Set<Report> deleteContents(final Iterable<Report> reports) {
         final Set<Report> successfulDeletes = new HashSet<>();
         for (final Report report : reports) {
-            Report deletedReport = deleteContent(report);
+            final Report deletedReport = deleteContent(report);
             if (deletedReport != null) {
                 successfulDeletes.add(deletedReport);
             }
@@ -93,6 +93,17 @@ public class ArchiveBackedReportContentService implements ReportContentService {
     @Override
     public URI createUri(final Report report, final MediaType mediaType) {
         return URI.create(BasePath + report.getId() + "." + getExtension(mediaType));
+    }
+
+    private MediaType parseMediaType(final String contentType) {
+        if (isEmpty(contentType)) {
+            return APPLICATION_PDF_UTF8;
+        }
+
+        final MediaType parsedMediaType = MediaType.parseMediaType(contentType);
+        return APPLICATION_OCTET_STREAM.isCompatibleWith(parsedMediaType)
+                ? APPLICATION_PDF_UTF8
+                : parsedMediaType;
     }
 
     private Report deleteContent(final Report report) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/ReportContentResource.java
@@ -1,25 +1,28 @@
 package org.opentestsystem.rdw.reporting.processor.web;
 
 import org.opentestsystem.rdw.reporting.processor.model.Report;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.AbstractResource;
 import org.springframework.http.MediaType;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Supplier;
 
 /**
  * This resource represents a Report content response resource.
  */
-public class ReportContentResource extends InputStreamResource {
+public class ReportContentResource extends AbstractResource {
 
+    private final Supplier<InputStream> inputStreamSupplier;
     private final long contentLength;
     private final MediaType contentType;
     private final Report report;
 
-    public ReportContentResource(final InputStream inputStream,
+    public ReportContentResource(final Supplier<InputStream> inputStreamSupplier,
                                  final long contentLength,
                                  final MediaType contentType,
                                  final Report report) {
-        super(inputStream);
+        this.inputStreamSupplier = inputStreamSupplier;
         this.contentLength = contentLength;
         this.contentType = contentType;
         this.report = report;
@@ -28,6 +31,27 @@ public class ReportContentResource extends InputStreamResource {
     @Override
     public long contentLength() {
         return contentLength;
+    }
+
+    /**
+     * This implementation always returns {@code true}.
+     */
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    /**
+     * This implementation always returns {@code true}.
+     */
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public String getDescription() {
+        return "ReportContentResource Report Id: " + report.getId();
     }
 
     /**
@@ -41,4 +65,8 @@ public class ReportContentResource extends InputStreamResource {
         return report;
     }
 
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return inputStreamSupplier.get();
+    }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentServiceTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.APPLICATION_PDF_UTF8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArchiveBackedReportContentServiceTest {
@@ -90,6 +92,65 @@ public class ArchiveBackedReportContentServiceTest {
             }
             assertThat(resource.contentLength()).isGreaterThan(0);
             assertThat(resource.getMediaType()).isEqualTo(APPLICATION_PDF_UTF8);
+        }
+    }
+
+    @Test
+    public void itShouldInterpretOctetStreamContentTypeAsPDF() throws Exception {
+        when(archiveService.readProperties(anyString())).thenAnswer(invocation -> {
+            final Properties properties = new Properties();
+            final String location = invocation.getArgumentAt(0, String.class);
+            if (!archive.containsKey(location)) return properties;
+
+            properties.put(Headers.CONTENT_LENGTH, (long) archive.get(location).length);
+            properties.put(Headers.CONTENT_TYPE, APPLICATION_OCTET_STREAM.toString());
+            return properties;
+        });
+
+        final Report original = MockBuilder.report();
+        try (final InputStream contents = new ByteArrayInputStream("Contents".getBytes())) {
+            final Report updated = service.writeContent(original, contents, 123L, APPLICATION_PDF_UTF8);
+            final ReportContentResource resource = service.openContent(updated);
+            assertThat(resource.getMediaType()).isEqualTo(APPLICATION_PDF_UTF8);
+        }
+    }
+
+    @Test
+    public void itShouldInterpretMissingContentTypeAsPDF() throws Exception {
+        when(archiveService.readProperties(anyString())).thenAnswer(invocation -> {
+            final Properties properties = new Properties();
+            final String location = invocation.getArgumentAt(0, String.class);
+            if (!archive.containsKey(location)) return properties;
+
+            properties.put(Headers.CONTENT_LENGTH, (long) archive.get(location).length);
+            return properties;
+        });
+
+        final Report original = MockBuilder.report();
+        try (final InputStream contents = new ByteArrayInputStream("Contents".getBytes())) {
+            final Report updated = service.writeContent(original, contents, 123L, APPLICATION_PDF_UTF8);
+            final ReportContentResource resource = service.openContent(updated);
+            assertThat(resource.getMediaType()).isEqualTo(APPLICATION_PDF_UTF8);
+        }
+    }
+
+    @Test
+    public void itShouldPopulateContentTypeFromArchiveProperties() throws Exception {
+        when(archiveService.readProperties(anyString())).thenAnswer(invocation -> {
+            final Properties properties = new Properties();
+            final String location = invocation.getArgumentAt(0, String.class);
+            if (!archive.containsKey(location)) return properties;
+
+            properties.put(Headers.CONTENT_LENGTH, (long) archive.get(location).length);
+            properties.put(Headers.CONTENT_TYPE, APPLICATION_JSON.toString());
+            return properties;
+        });
+
+        final Report original = MockBuilder.report();
+        try (final InputStream contents = new ByteArrayInputStream("Contents".getBytes())) {
+            final Report updated = service.writeContent(original, contents, 123L, APPLICATION_PDF_UTF8);
+            final ReportContentResource resource = service.openContent(updated);
+            assertThat(resource.getMediaType()).isEqualTo(APPLICATION_JSON);
         }
     }
 

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultExamReportServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/DefaultExamReportServiceTest.java
@@ -73,7 +73,7 @@ public class DefaultExamReportServiceTest {
         final Report report = report(123L);
         final byte[] contents = "PDF CONTENTS".getBytes();
         final ReportContentResource resource = new ReportContentResource(
-                new ByteArrayInputStream(contents),
+                () -> new ByteArrayInputStream(contents),
                 (long) contents.length,
                 APPLICATION_PDF_UTF8,
                 report
@@ -91,7 +91,7 @@ public class DefaultExamReportServiceTest {
         final Report report = report(123L);
         final byte[] contents = "ZIP CONTENTS".getBytes();
         final ReportContentResource resource = new ReportContentResource(
-                new ByteArrayInputStream(contents),
+                () -> new ByteArrayInputStream(contents),
                 (long) contents.length,
                 APPLICATION_ZIP,
                 report


### PR DESCRIPTION
… a V1 PDF report with a default content-type of application/octet-stream.

The problem was that we were running out of S3 connections in the connection pool.
This was happening because we were opening an InputStream to an S3 resource, then throwing an exception without closing the InputStream.

This fix converts our ReportContentResource to hold a Supplier<InputStream> lambda so that the InputStream isn't opened until it is actually being read within an AutoCloseable try/catch.