### PR TITLE
Changed the agg. report SQL to see if it helps with getting a better execution plan.

### DIFF
--- a/aggregate-service/src/main/resources/custom-aggregate-report-template.sql.yml
+++ b/aggregate-service/src/main/resources/custom-aggregate-report-template.sql.yml
@@ -67,7 +67,7 @@ sqlbuilder:
               clauses:
                 select: >-
                      'School' AS organization_type,
-                     sch.id AS organization_id
+                     fe.school_id AS organization_id
                 join: >-
                      JOIN school sch ON sch.id = fe.school_id
 
@@ -75,21 +75,21 @@ sqlbuilder:
                      sch.district_id in (:school_district_ids)
 
                 groupBy: >-
-                     sch.id
+                     fe.school_id
 
             schools:
               clauses:
                 select: >-
                      'School' AS organization_type,
-                     sch.id AS organization_id
+                     fe.school_id AS organization_id
                 join: >-
                      JOIN school sch ON sch.id = fe.school_id
 
                 where: >-
-                    sch.id in (:school_ids)
+                    fe.school_id in (:school_ids)
 
                 groupBy: >-
-                     sch.id
+                     fe.school_id
 
             embargo:
               clauses:

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProviderRST.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/sqlbuilder/CustomAggregateQueryProviderRST.java
@@ -108,7 +108,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "fe.school_year, " +
             "fe.asmt_id, " +
             "'School' AS organization_type, " +
-            "sch.id AS organization_id, " +
+            "fe.school_id AS organization_id, " +
             "'Section504' AS dimension, " +
             "fe.section504 AS dimension_id, C" +
             "ASE WHEN fe.section504 = 1 THEN 'yes' WHEN fe.section504 = 0 THEN 'no' ELSE 'undefined' END AS dimension_code " +
@@ -116,10 +116,10 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "JOIN asmt a ON a.id = fe.asmt_id " +
             "JOIN school sch ON sch.id = fe.school_id " +
             "WHERE (( fe.school_year IN (:school_years) AND a.grade_id IN (:asmt_grade_ids) AND a.subject_id in (:subject_ids) AND a.type_id = :asmt_type_id) " +
-            "AND ( sch.id in (:school_ids)) " +
+            "AND ( fe.school_id in (:school_ids)) " +
             "AND ( fe.school_year < 2018 OR 3 <> :asmt_type_id OR sch.embargo_enabled = 0 OR 1 = :state_embargo_admin OR sch.district_id IN (:district_embargo_admin_ids)) " +
             "AND ( ( true = :all_section504s OR fe.section504 in (:section504_ids) ))) " +
-            "GROUP BY  fe.school_year, fe.asmt_id, sch.id, fe.section504";
+            "GROUP BY  fe.school_year, fe.asmt_id, fe.school_id, fe.section504";
 
     private static final String district504 = "SELECT  round(avg(scale_score)) AS score, " +
             "round(stddev_samp(scale_score)/sqrt(count(*))) as std_err, " +
@@ -153,7 +153,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "fe.school_year, " +
             "fe.asmt_id, " +
             "'School' AS organization_type, " +
-            "sch.id AS organization_id, " +
+            "fe.school_id AS organization_id, " +
             "'Section504' AS dimension, " +
             "fe.section504 AS dimension_id, " +
             "CASE WHEN fe.section504 = 1 THEN 'yes' WHEN fe.section504 = 0 THEN 'no' ELSE 'undefined' END AS dimension_code " +
@@ -163,7 +163,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "AND ( sch.district_id in (:school_district_ids)) " +
             "AND ( fe.school_year < 2018 OR 3 <> :asmt_type_id OR sch.embargo_enabled = 0 OR 1 = :state_embargo_admin OR sch.district_id IN (:district_embargo_admin_ids)) " +
             "AND ( ( true = :all_section504s OR fe.section504 in (:section504_ids) ))) " +
-            "GROUP BY  fe.school_year, fe.asmt_id, sch.id, fe.section504";
+            "GROUP BY  fe.school_year, fe.asmt_id, fe.school_id, fe.section504";
 
     private static final String stateOverall = "SELECT  round(avg(scale_score)) AS score, " +
             "round(stddev_samp(scale_score)/sqrt(count(*))) as std_err, " +
@@ -236,7 +236,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "fe.school_year, " +
             "fe.asmt_id, " +
             "'School' AS organization_type, " +
-            "sch.id AS organization_id, " +
+            "fe.school_id AS organization_id, " +
             "'Overall' AS dimension, " +
             "null  AS dimension_id, " +
             "null AS dimension_code " +
@@ -244,9 +244,9 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "JOIN asmt a ON a.id = fe.asmt_id " +
             "JOIN school sch ON sch.id = fe.school_id " +
             "WHERE (( fe.school_year IN (:school_years) AND a.grade_id IN (:asmt_grade_ids) AND a.subject_id in (:subject_ids) AND a.type_id = :asmt_type_id) " +
-            "AND ( sch.id in (:school_ids)) " +
+            "AND ( fe.school_id in (:school_ids)) " +
             "AND ( fe.school_year < 2018 OR 3 <> :asmt_type_id OR sch.embargo_enabled = 0 OR 1 = :state_embargo_admin OR sch.district_id IN (:district_embargo_admin_ids))) " +
-            "GROUP BY  fe.school_year, fe.asmt_id, sch.id";
+            "GROUP BY  fe.school_year, fe.asmt_id, fe.school_id";
 
     private static final String allSchoolsInDistrictOverall = "SELECT  round(avg(scale_score)) AS score, " +
             "round(stddev_samp(scale_score)/sqrt(count(*))) as std_err, " +
@@ -257,7 +257,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "fe.school_year, " +
             "fe.asmt_id, " +
             "'School' AS organization_type, " +
-            "sch.id AS organization_id, " +
+            "fe.school_id AS organization_id, " +
             "'Overall' AS dimension, " +
             "null  AS dimension_id, " +
             "null AS dimension_code " +
@@ -267,7 +267,7 @@ public class CustomAggregateQueryProviderRST extends RepositoryBackedIT {
             "WHERE (( fe.school_year IN (:school_years) AND a.grade_id IN (:asmt_grade_ids) AND a.subject_id in (:subject_ids) AND a.type_id = :asmt_type_id) " +
             "AND ( sch.district_id in (:school_district_ids)) " +
             "AND ( fe.school_year < 2018 OR 3 <> :asmt_type_id OR sch.embargo_enabled = 0 OR 1 = :state_embargo_admin OR sch.district_id IN (:district_embargo_admin_ids))) " +
-            "GROUP BY  fe.school_year, fe.asmt_id, sch.id";
+            "GROUP BY  fe.school_year, fe.asmt_id, fe.school_id";
 
     @Test
     public void testSQL() {


### PR DESCRIPTION
I just want to test and see if this helps Redshift with choosing  `XN GroupAggregate` for school reports.

 https://docs.aws.amazon.com/redshift/latest/dg/c_designing-queries-best-practices.html
_"Use sort keys in the GROUP BY clause so the query planner can use more efficient aggregation.A query might qualify for one-phase aggregation when its GROUP BY list contains only sort key columns, one of which is also the distribution key. The sort key columns in the GROUP BY list must include the first sort key, then other sort keys that you want to use in sort key order. For example, it is valid to use the first sort key, the first and second sort keys, the first, second and third sort keys, and so on.It is not valid to use the first and third sort keys.You can confirm the use of one-phase aggregation by running the EXPLAIN command and looking for XN GroupAggregate in the aggregation step of the query."_

