### PR TITLE
Add better error handling to the group upload component.

### DIFF
--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -60,6 +60,11 @@ spring:
   session:
     store-type: none
 
+  http:
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 500MB
+
   # still need this for translations api
   jackson:
     default-property-inclusion: non_null

--- a/webapp/src/main/webapp/src/app/admin/groups/import/group-import.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/groups/import/group-import.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 import { GroupImportService } from "./group-import.service";
 import { ImportResult } from "./import-result.model";
-import { FileUploader } from "ng2-file-upload";
+import { FileItem, FileUploader, ParsedResponseHeaders } from "ng2-file-upload";
 import { TranslateService } from "@ngx-translate/core";
 import { Utils } from "../../../shared/support/support";
 import { AdminServiceRoute } from "../../../shared/service-route";
@@ -29,11 +29,20 @@ export class GroupImportComponent implements OnInit {
     this.uploader = new FileUploader({ url: URL });
     this.uploader.setOptions({ autoUpload: true });
 
-    this.uploader.onCompleteItem = (item: any, response: any, status: any, headers: any) => {
-      if (!Utils.isNullOrUndefined(response)) {
+    this.uploader.onCompleteItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
+      if (status == 202 && !Utils.isNullOrUndefined(response)) {
         this.importResults.push(this.studentGroupService.mapImportResultFromApi(JSON.parse(response)));
         this.importResults = this.importResults.slice();
       }
+    };
+
+    this.uploader.onErrorItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
+      this.importResults.push(this.studentGroupService.mapImportResultFromApi({
+        message: this.translate.instant("admin-groups.import.upload-failed"),
+        filename: item.file.name,
+        status: "FAILED"
+      }));
+      this.importResults = this.importResults.slice();
     };
 
     this.uploader.onCompleteAll = () => {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -879,7 +879,8 @@
       "PROCESSED": "Processed",
       "UNAUTHORIZED": "Unauthorized",
       "UNKNOWN_ASMT": "Unknown Assessment",
-      "UNKNOWN_SCHOOL": "Unknown School"
+      "UNKNOWN_SCHOOL": "Unknown School",
+      "FAILED": "Failed"
     },
     "subject-claim-code": {
       "1": "Concepts & Procedures",
@@ -950,7 +951,8 @@
       "replacement-instruct": "To make changes to an existing group, please upload a replacement file.",
       "sending": "Uploading...",
       "title": "Upload New or Revised Groups",
-      "warning-html": "<p><strong class=\"mr-xs\">WARNING:</strong> Groups in the uploaded file will replace existing groups if they have the same school ID, school year and group name.</p><p>All other groups will not be deleted or changed.</p>"
+      "warning-html": "<p><strong class=\"mr-xs\">WARNING:</strong> Groups in the uploaded file will replace existing groups if they have the same school ID, school year and group name.</p><p>All other groups will not be deleted or changed.</p>",
+      "upload-failed": "Failed to upload groups to server."
     },
     "no-results": "No groups found matching the given filter criteria.",
     "no-schools": "Your user account does not have access to view the groups of any schools.",


### PR DESCRIPTION
While testing handling large-sized group uploads I noticed that we weren't handling communication errors/5XX responses well in the UI.  This PR both increases the file upload limit in the webapp to match the admin-service and improves error handling in the UI.

Note that I've changed the error message slightly from the image below to "Failed to upload groups to server."
![group_error_handling](https://user-images.githubusercontent.com/617828/37371121-97e65ff0-26cb-11e8-91dc-7d6b0f867cb1.png)
