### PR TITLE
Handle the asynchronous modification of the minimumItemDataYear property

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -108,7 +108,14 @@ export class AssessmentResultsComponent implements OnInit {
    * If there are no exams that are after this school year, then disable the ability to go there and show proper message
    */
   @Input()
-  minimumItemDataYear: number;
+  set minimumItemDataYear(value: number) {
+    this._minimumItemDataYear = value;
+    this.initializeViews();
+  };
+
+  get minimumItemDataYear(): number {
+    return this._minimumItemDataYear;
+  }
 
   /**
    * Exam filters applied, if any.
@@ -214,6 +221,7 @@ export class AssessmentResultsComponent implements OnInit {
   private _filterBy: FilterBy;
   private _assessmentExam: AssessmentExam;
   private _filterBySubscription: Subscription;
+  private _minimumItemDataYear: number;
 
   constructor(private applicationSettingsService: ApplicationSettingsService,
               public colorService: ColorService,
@@ -238,16 +246,6 @@ export class AssessmentResultsComponent implements OnInit {
     this.resultsByItemView = this.createResultViewState(ResultsViewState.ByItem, this.displayItemLevelData, true, true);
     this.distractorAnalysisView = this.createResultViewState(ResultsViewState.DistractorAnalysis, this.displayItemLevelData, true, true);
     this.writingTraitScoresView = this.createResultViewState(ResultsViewState.WritingTraitScores, this.enableWritingTraitScores, true, this.displayWritingTraitScores);
-  }
-
-  createResultViewState(viewState: ResultsViewState, enabled: boolean, canExport: boolean, display: boolean): ResultsView {
-    return {
-      label: 'assessment-results.view.' + ResultsViewState[ viewState ],
-      value: viewState,
-      disabled: !enabled,
-      display: display,
-      canExport: canExport
-    }
   }
 
   setCurrentView(view: ResultsView): void {
@@ -293,6 +291,16 @@ export class AssessmentResultsComponent implements OnInit {
       };
       this.percentileService.getPercentilesGroupedByRank(request)
         .subscribe(percentileGroups => this.percentileGroups = percentileGroups);
+    }
+  }
+
+  private createResultViewState(viewState: ResultsViewState, enabled: boolean, canExport: boolean, display: boolean): ResultsView {
+    return {
+      label: 'assessment-results.view.' + ResultsViewState[ viewState ],
+      value: viewState,
+      disabled: !enabled,
+      display: display,
+      canExport: canExport
     }
   }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -75,6 +75,7 @@ export class AssessmentResultsComponent implements OnInit {
         this.toggleSession(this.sessions[ 0 ]);
       }
     }
+    this.updateViews();
   }
 
   /**
@@ -110,7 +111,7 @@ export class AssessmentResultsComponent implements OnInit {
   @Input()
   set minimumItemDataYear(value: number) {
     this._minimumItemDataYear = value;
-    this.initializeViews();
+    this.updateViews();
   };
 
   get minimumItemDataYear(): number {
@@ -237,11 +238,10 @@ export class AssessmentResultsComponent implements OnInit {
       this.percentileDisplayEnabled = settings.percentileDisplayEnabled;
     });
 
-    this.initializeViews();
     this.setCurrentView(this.resultsByStudentView);
   }
 
-  initializeViews(): void {
+  updateViews(): void {
     this.resultsByStudentView = this.createResultViewState(ResultsViewState.ByStudent, true, false, true);
     this.resultsByItemView = this.createResultViewState(ResultsViewState.ByItem, this.displayItemLevelData, true, true);
     this.distractorAnalysisView = this.createResultViewState(ResultsViewState.DistractorAnalysis, this.displayItemLevelData, true, true);


### PR DESCRIPTION
This fixes an issue where the "minimumItemDataYear" setting isn't loaded/asynchronously bound on the assessment results display, leading to disabled options like "View Distractor Analysis."
This is fairly difficult to reproduce since we cache the system settings results.  You have to hard-refresh on the home page then navigate directly to a group's assessments (with results for the current year) then try to display the distractor analysis without changing assessments.