### PR TITLE
An attempt to fix an out of memory error.

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
@@ -26,6 +26,7 @@ import org.opentestsystem.rdw.reporting.common.sqlbuilder.QueryProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -58,9 +59,12 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
     @Value("${app.aggregate-reports.custom-aggregate-report-repository.organization-partition-size}")
     private int organizationPartitionSize;
 
+    @Value("${app.aggregate-reports.custom-aggregate-report-repository.jdbc-fetch-size}")
+    private int jdbcFetchSize;
+
     @Autowired
     public JdbcCustomAggregateReportRowRepository(final ReportingSystemSettings systemSettings,
-                                                  final NamedParameterJdbcTemplate jdbcTemplate,
+                                                  final JdbcTemplate jdbcTemplate,
                                                   final QueryProviderRepositoryHelper reportQueryRepositoryHelper,
                                                   final ActiveAssessmentRepository activeAssessmentRepository,
                                                   final OrganizationRepository organizationRepository,
@@ -68,7 +72,8 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
                                                   final EmbargoRepository embargoRepository,
                                                   final TaskExecutor threadPoolTaskExecutor) {
         this.systemSettings = systemSettings;
-        this.jdbcTemplate = jdbcTemplate;
+        jdbcTemplate.setFetchSize(jdbcFetchSize);
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
         this.reportQueryRepositoryHelper = reportQueryRepositoryHelper;
         this.activeAssessmentRepository = activeAssessmentRepository;
         this.organizationRepository = organizationRepository;

--- a/aggregate-service/src/main/resources/application.yml
+++ b/aggregate-service/src/main/resources/application.yml
@@ -31,6 +31,7 @@ app:
     state-aggregate-assessment-types: sum
     custom-aggregate-report-repository:
       organization-partition-size: 10
+      jdbc-fetch-size: 200
     query-pool-size: 6
     api-enabled: false
 


### PR DESCRIPTION
Running load test with IAB creates this: 
```
java.util.concurrent.CompletionException: java.lang.OutOfMemoryError: GC overhead limit exceeded
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1592) ~[na:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded
	at java.util.Arrays.copyOf(Arrays.java:3181) ~[na:1.8.0_131]
	at java.util.ArrayList.grow(ArrayList.java:261) ~[na:1.8.0_131]
	at java.util.ArrayList.ensureExplicitCapacity(ArrayList.java:235) ~[na:1.8.0_131]
	at java.util.ArrayList.ensureCapacityInternal(ArrayList.java:227) ~[na:1.8.0_131]
	at java.util.ArrayList.addAll(ArrayList.java:579) ~[na:1.8.0_131]
	at org.opentestsystem.rdw.reporting.common.model.AggregateReport$Builder.rows(AggregateReport.java:42) ~[rdw-reporting-common-1.2.0-1419.jar!/:na]
	at org.opentestsystem.rdw.olap.repository.impl.JdbcCustomAggregateReportRowRepository$RunQueryTask.run(JdbcCustomAggregateReportRowRepository.java:135) ~[classes!/:na]
	at org.opentestsystem.rdw.olap.repository.impl.JdbcCustomAggregateReportRowRepository$$Lambda$103/411627578.get(Unknown Source) ~[na:na]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590) ~[na:1.8.0_131]
	... 3 common frames omitted
```

According to AWS documentation (https://docs.aws.amazon.com/redshift/latest/dg/queries-troubleshooting.html#set-the-JDBC-fetch-size-parameter)  this should be a fix. I am just trying to test it.