### PR TITLE
Reduce the default memory limit of the admin-service to align with ot…

### DIFF
--- a/admin-service/build.gradle
+++ b/admin-service/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'org.springframework.boot'
 
-createDockerfile {
-    environmentVariable("MAX_HEAP_SIZE", "-Xmx768m")
-}
-
 dependencies {
     compile project(':rdw-reporting-common')
     compile project(':rdw-reporting-common-web')


### PR DESCRIPTION
…her API services.

My guess is that we didn't lower the default memory limit when we converted the admin-service from a full app with front- and back-end implementations to just an API backend.
I don't believe this service does any heavy memory lifts, so I'm reducing the default memory limit to the reporting default value of -Xmx384m