### PR TITLE
Lower memory aggregate report backfilling

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcCustomAggregateReportRowRepository.java
@@ -38,10 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.function.Function;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
 import static org.opentestsystem.rdw.reporting.common.model.AggregateReport.builder;
 import static org.opentestsystem.rdw.reporting.common.model.OrganizationType.District;
@@ -126,11 +124,7 @@ class JdbcCustomAggregateReportRowRepository implements CustomAggregateReportRep
          */
         AggregateReport run() {
             final AggregateReport.Builder reportBuilder = builder();
-            final Map<ReportRowIdentity, ReportRow> templateRows = queryWithReportTemplate.getReportTemplate().stream()
-                    .collect(toMap(
-                            ReportRowIdentity::new,
-                            Function.identity()
-                    ));
+            final Map<ReportRowIdentity, ReportRow> templateRows = queryWithReportTemplate.getReportTemplate();
             reportBuilder.rows(jdbcTemplate.query(
                     queryWithReportTemplate.getSqlQuery(),
                     queryWithReportTemplate.getParameterSource(),

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/QueryWithReportTemplate.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/sqlbuilder/QueryWithReportTemplate.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.olap.sqlbuilder;
 
+import org.opentestsystem.rdw.olap.model.ReportRowIdentity;
 import org.opentestsystem.rdw.reporting.common.model.ActiveAssessment;
 import org.opentestsystem.rdw.reporting.common.model.Dimension;
 import org.opentestsystem.rdw.reporting.common.model.Measures;
@@ -10,10 +11,10 @@ import org.opentestsystem.rdw.reporting.common.sqlbuilder.QueryProvider;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
+import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * This is a helper class that is used during conversion of the {@link ReportQuery} to a sql string, its parameters and a template version of the report.
@@ -22,7 +23,7 @@ import static com.google.common.collect.Sets.newHashSet;
 public class QueryWithReportTemplate extends ReportContext {
     private String sqlQuery;
     private MapSqlParameterSource parameterSource;
-    private Set<ReportRow> reportTemplate;
+    private Map<ReportRowIdentity, ReportRow> reportTemplate;
 
     public String getSqlQuery() {
         return sqlQuery;
@@ -32,7 +33,7 @@ public class QueryWithReportTemplate extends ReportContext {
         return parameterSource;
     }
 
-    public Set<ReportRow> getReportTemplate() {
+    public Map<ReportRowIdentity, ReportRow> getReportTemplate() {
         return reportTemplate;
     }
 
@@ -49,7 +50,7 @@ public class QueryWithReportTemplate extends ReportContext {
             final QueryWithReportTemplate queryWithReportTemplate = super.build();
             queryWithReportTemplate.sqlQuery = queryProvider.newQuery(templateSql, addOns).toString();
             queryWithReportTemplate.parameterSource = parameterSource;
-            queryWithReportTemplate.reportTemplate = newHashSet();
+            queryWithReportTemplate.reportTemplate = newHashMap();
 
             for (final Organization organization : organizations) {
                 for (final ActiveAssessment assessment : assessments) {
@@ -60,7 +61,7 @@ public class QueryWithReportTemplate extends ReportContext {
                                 .dimension(dimension)
                                 .measures(emptyMeasure)
                                 .build();
-                        queryWithReportTemplate.reportTemplate.add(row);
+                        queryWithReportTemplate.reportTemplate.put(new ReportRowIdentity(row), row);
                     }
                 }
             }


### PR DESCRIPTION
If we want even lower memory usage of the aggregate report processing we can truly remove and free up the back-filled rows for GC as we process the result set.