### PR TITLE
enforces correct display type value is requested

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-request.mapper.ts
@@ -42,8 +42,12 @@ export class AggregateReportRequestMapper {
       settings: AggregateReportFormSettings,
       assessmentDefinition: AssessmentDefinition): AggregateReportRequest {
 
+    const performanceLevelDisplayType = assessmentDefinition.performanceLevelDisplayTypes.includes(settings.performanceLevelDisplayType)
+      ? settings.performanceLevelDisplayType
+      : assessmentDefinition.performanceLevelDisplayTypes[0];
+
     const query: any = <AggregateReportQuery>{
-      achievementLevelDisplayType: settings.performanceLevelDisplayType,
+      achievementLevelDisplayType: performanceLevelDisplayType,
       assessmentTypeCode: settings.assessmentType,
       assessmentGradeCodes: settings.assessmentGrades,
       includeAllDistricts: settings.includeAllDistricts,


### PR DESCRIPTION
recent changes make it so that the user selected performance level setting isn't changed when switching from iab to ica/sum so we have to make sure that we send the right value here. this is all to support selection memory when switching to and from report types