### PR TITLE
Hide student response when viewing item level details in assessment v…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-item/results-by-item.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-item/results-by-item.component.html
@@ -90,7 +90,6 @@
         <item-tab [item]="item"
                   [showResponse]="false"
                   [exams]="exams"
-                  [includeResponseInStudentScores]="true"
                   [showItemDetails]="assessment.isInterim">
         </item-tab>
       </td>


### PR DESCRIPTION
…iewer.

This was a copy-paste failure when converting our tables to the new implementation.  We should only display the student response in the distractor analysis view.