### PR TITLE
corrected creation of cacheKey in caching-data service

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/data/caching-data.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/data/caching-data.service.ts
@@ -32,7 +32,7 @@ export class CachingDataService {
 
   public get(url: string, options?: RequestOptionsArgs): Observable<any> {
 
-    const cacheKey = this.createKey(url, options ? options.params || {} : {});
+    const cacheKey = this.createKey(url, options);
 
     const response = this.responsesByUrl.get(cacheKey);
     if (response) {


### PR DESCRIPTION
Issue here was we were expecting options to be passed. Another issue was that `createKey` returns url is options is null (but on line 35 we were passing `{}`, not `null`)