### PR TITLE
Export FilteredSubgroup aggregate reports as CSV.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/FilteredSubgroupRow.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/FilteredSubgroupRow.java
@@ -10,13 +10,17 @@ public class FilteredSubgroupRow extends AggregateRow {
         return subgroupKey;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static class Builder extends AggregateRow.Builder<Builder, FilteredSubgroupRow> {
 
         private String subgroupKey;
 
         @Override
         protected FilteredSubgroupRow createRow() {
-            return null;
+            return new FilteredSubgroupRow();
         }
 
         @Override

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/ReportQueries.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/test/support/ReportQueries.java
@@ -3,8 +3,12 @@ package org.opentestsystem.rdw.reporting.common.test.support;
 import com.google.common.collect.ImmutableSet;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.model.BasicAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.FilteredSubgroupReportQuery;
 import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
 
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
 import static org.opentestsystem.rdw.common.model.AssessmentType.ICA;
 import static org.opentestsystem.rdw.common.model.Subject.MATH;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Gender;
@@ -27,5 +31,28 @@ public class ReportQueries {
                 .districtIds(ImmutableSet.of(1L))
                 .schoolIds(ImmutableSet.of(1L))
                 .studentFilters(filters);
+    }
+
+    public static FilteredSubgroupReportQuery.Builder filteredSubgroupQuery() {
+        final Map<String, StudentFilters> subgroups = newHashMap();
+        subgroups.put("overall", StudentFilters.builder()
+                .build());
+        subgroups.put("subgroupA", StudentFilters.builder()
+                .genderCodes(ImmutableSet.of("Male"))
+                .build());
+        subgroups.put("subgroupB", StudentFilters.builder()
+                .genderCodes(ImmutableSet.of("Female"))
+                .build());
+
+        return FilteredSubgroupReportQuery.builder()
+                .assessmentTypeCode(ICA.code())
+                .subjectCodes(ImmutableSet.of(MATH.code().toLowerCase(), Subject.ELA.code().toUpperCase()))
+                .schoolYears(ImmutableSet.of(2017, 2018))
+                .assessmentGradeCodes(ImmutableSet.of("01", "02", "03", "04", "05"))
+                .includeState(true)
+                .includeAllDistricts(false)
+                .subgroups(subgroups)
+                .districtIds(ImmutableSet.of(1L))
+                .schoolIds(ImmutableSet.of(1L));
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandler.java
@@ -3,22 +3,16 @@ package org.opentestsystem.rdw.reporting.processor.web.converter;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.lang.mutable.MutableObject;
-import org.opentestsystem.rdw.reporting.common.model.BasicAggregateReportQuery;
-import org.opentestsystem.rdw.reporting.common.model.BasicAggregateRow;
-import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.AbstractAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.AggregateRow;
 import org.opentestsystem.rdw.reporting.common.model.Measures;
-import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
 import org.opentestsystem.rdw.reporting.common.util.Headers;
-import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
-import org.opentestsystem.rdw.reporting.processor.model.ReportType;
 import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpOutputMessage;
-import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotWritableException;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,33 +35,29 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.commons.lang.StringUtils.EMPTY;
-import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.opentestsystem.rdw.common.model.AssessmentType.IAB;
-import static org.opentestsystem.rdw.reporting.common.model.AggregateQueryType.Basic;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
 import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.getExtension;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 /**
- * This handler is responsible for transforming an {@link AggregateReportRequest} JSON
- * response into a CSV payload using codes for values and data model identifiers for headers
- * where applicable.
- * If filters have been applied to the query, they are printed in the first row, last column of the
- * response under the header of "Attributes."
- *
- * Note that this handler will only be applied if the user has not explicitly requested a JSON response payload.
+ * This base handler provides common functionality for converting reports consisting of a list of
+ * {@link AggregateRow} JSON objects into a CSV.
  */
-@Component
-public class AggregateReportCsvHandler extends DefaultReportHandler {
+abstract class AggregateReportCsvHandler<Q extends AbstractAggregateReportQuery, R extends AggregateRow> extends DefaultReportHandler {
     private static final Logger logger = LoggerFactory.getLogger(AggregateReportCsvHandler.class);
-    private static final Joiner AttributeJoiner = Joiner.on("; ");
-    private static final Joiner AttributeValueJoiner = Joiner.on("|");
     private static final String NotApplicable = "";
     private static final Object[] EmptyObjectArray = new Object[]{};
     private static final Locale ReportLocale = Locale.US;
+
+    protected static final Joiner AttributeJoiner = Joiner.on("; ");
+    protected static final Joiner AttributeValueJoiner = Joiner.on("|");
 
     private final MessageSource messageSource;
     private final ObjectMapper objectMapper;
@@ -81,14 +69,7 @@ public class AggregateReportCsvHandler extends DefaultReportHandler {
         this.objectMapper = objectMapper;
     }
 
-    @Override
-    public boolean accept(final ReportContentResource resource, final MediaType requestedMediaType) {
-        final AbstractExamReportRequest request = resource.getReport().getReportRequest();
-        return !APPLICATION_JSON.isCompatibleWith(requestedMediaType) &&
-                request.getReportType() == ReportType.AggregateReportRequest &&
-                ((AggregateReportRequest) request).getQuery().getQueryType() == Basic;
-
-    }
+    protected abstract Iterator<R> asReportRowIterator(JsonParser parser, ReportContentResource resource);
 
     @Override
     protected void setHeaders(final ReportContentResource resource, final HttpHeaders headers) {
@@ -103,65 +84,110 @@ public class AggregateReportCsvHandler extends DefaultReportHandler {
     protected void writeContent(final ReportContentResource resource, final HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
         try (final InputStream in = resource.getInputStream()) {
             final AggregateReportRequest request = (AggregateReportRequest) resource.getReport().getReportRequest();
+            final Q query = (Q) request.getQuery();
             final JsonFactory jsonFactory = objectMapper.getFactory();
             final JsonParser parser = jsonFactory.createParser(in);
             if (parser.nextToken() != JsonToken.START_ARRAY) {
                 throw new IllegalStateException("Found non-array json payload for aggregate report: " + resource.getReport().getId());
             }
             parser.nextToken();
-            final Iterator<BasicAggregateRow> rowIterator = asReportRowIterator(parser, resource);
+            final Iterator<R> rowIterator = asReportRowIterator(parser, resource);
 
-            printCsv(rowIterator, (BasicAggregateReportQuery) request.getQuery(), outputMessage.getBody());
+            printCsv(rowIterator, query, outputMessage.getBody());
 
         } catch (final IOException e) {
             throw new RuntimeException("Problem writing aggregate report content to response", e);
         }
     }
 
-    private void printCsv(final Iterator<BasicAggregateRow> results, final BasicAggregateReportQuery query, final OutputStream outputStream) {
+    protected ObjectMapper getMapper() {
+        return objectMapper;
+    }
+
+    protected List<String> getHeaders(final Q query) {
+        final List<String> headers = new ArrayList<>();
+        headers.add(getMessage("report.aggregate.export.header.organization"));
+        headers.add(getMessage("report.aggregate.export.header.natural-id"));
+        headers.add(getMessage("report.aggregate.export.header.assessment"));
+        headers.add(getMessage("report.aggregate.export.header.assessment-type"));
+        headers.add(getMessage("report.aggregate.export.header.subject"));
+        headers.add(getMessage("report.aggregate.export.header.grade"));
+        headers.add(getMessage("report.aggregate.export.header.year"));
+        headers.add(getMessage("report.aggregate.export.header.student-count"));
+        headers.add(getMessage("report.aggregate.export.header.score"));
+        headers.add(getMessage("report.aggregate.export.header.standard-deviation"));
+        headers.addAll(getPerformanceLevelHeaders(query));
+        headers.add(getMessage("report.aggregate.export.header.attributes"));
+        return headers;
+    }
+
+    protected List<String> getRowValues(final CsvContext context, final R result) {
+        final List<String> rowValues = newArrayList();
+        rowValues.add(result.getOrganization().getName());
+        rowValues.add(result.getOrganization().getNaturalId());
+        rowValues.add(result.getAssessment().getLabel());
+        rowValues.add(context.getQuery().getAssessmentTypeCode());
+        rowValues.add(result.getAssessment().getSubjectCode());
+        rowValues.add(result.getAssessment().getGradeCode());
+        rowValues.add(String.valueOf(result.getAssessment().getExamSchoolYear()));
+
+        final Measures measures = result.getMeasures();
+        final long studentCount = measures.getStudentCount();
+
+        rowValues.add(String.valueOf(studentCount));
+        rowValues.add(measures.getAvgScaleScore() == null ? NotApplicable : measures.getAvgScaleScore().toString());
+        rowValues.add(measures.getAvgStdErr() == null ? NotApplicable : measures.getAvgStdErr().toString());
+        rowValues.add(String.valueOf(measures.getLevel1Count()));
+        rowValues.add(String.valueOf(measures.getLevel2Count()));
+        rowValues.add(String.valueOf(measures.getLevel3Count()));
+        if (!IAB.code().equals(context.getQuery().getAssessmentTypeCode())) {
+            rowValues.add(String.valueOf(measures.getLevel4Count()));
+        }
+
+        if (context.getRowIdx() == 0) {
+            rowValues.add(AttributeJoiner.join(getAttributes(context.getQuery())));
+        } else {
+            rowValues.add(EMPTY);
+        }
+
+        return rowValues;
+    }
+
+    protected List<String> getAttributes(final Q query) {
+        final List<String> attributes = new ArrayList<>();
+        final LocalDateTime localDate = LocalDateTime.now();
+        appendAttribute(attributes, "ReportDate", Collections.singleton(localDate.format(DateTimeFormatter.ISO_DATE_TIME)));
+        appendAttribute(attributes, "AdministrationCondition", query.getAdministrativeConditionCodes());
+        appendAttribute(attributes, "Completeness", query.getCompletenessCodes());
+
+        return attributes;
+    }
+
+    protected void appendAttribute(final List<String> attributes, final String label, final Collection<String> values) {
+        if (values.isEmpty()) return;
+
+        attributes.add(label + ": " + AttributeValueJoiner.join(values));
+    }
+
+    protected String getMessage(final String key) {
+        return messageSource.getMessage(key, EmptyObjectArray, ReportLocale);
+    }
+
+    private void printCsv(final Iterator<R> results, final Q query, final OutputStream outputStream) {
+        final List<String> headers = getHeaders(query);
         final CSVFormat csvFormat = CSVFormat.DEFAULT
-                .withHeader(getHeaders(query));
+                .withHeader(headers.toArray(new String[headers.size()]));
 
         try {
             final CSVPrinter printer = csvFormat.print(new OutputStreamWriter(outputStream, Charsets.UTF_8));
-            final MutableObject printAttributes = new MutableObject(true);
+            final CsvContext context = new CsvContext(query);
 
             while (results.hasNext()) {
-                final BasicAggregateRow result = results.next();
-                final List<String> columnValues = new ArrayList<>();
-                columnValues.add(result.getOrganization().getName());
-                columnValues.add(result.getOrganization().getNaturalId());
-                columnValues.add(result.getAssessment().getLabel());
-                columnValues.add(query.getAssessmentTypeCode());
-                columnValues.add(result.getAssessment().getSubjectCode());
-                columnValues.add(result.getAssessment().getGradeCode());
-                columnValues.add(String.valueOf(result.getAssessment().getExamSchoolYear()));
+                final R result = results.next();
+                final List<String> rowValues = getRowValues(context, result);
+                printer.printRecord(rowValues);
 
-                final Dimension dimension = result.getDimension();
-                columnValues.add(dimension.getType().code());
-                columnValues.add(trimToEmpty(dimension.getCode()));
-
-                final Measures measures = result.getMeasures();
-                final long studentCount = measures.getStudentCount();
-
-                columnValues.add(String.valueOf(studentCount));
-                columnValues.add(measures.getAvgScaleScore() == null ? NotApplicable : measures.getAvgScaleScore().toString());
-                columnValues.add(measures.getAvgStdErr() == null ? NotApplicable : measures.getAvgStdErr().toString());
-                columnValues.add(String.valueOf(measures.getLevel1Count()));
-                columnValues.add(String.valueOf(measures.getLevel2Count()));
-                columnValues.add(String.valueOf(measures.getLevel3Count()));
-                if (!IAB.code().equals(query.getAssessmentTypeCode())) {
-                    columnValues.add(String.valueOf(measures.getLevel4Count()));
-                }
-
-                if ((Boolean) printAttributes.getValue()) {
-                    printAttributes.setValue(false);
-                    columnValues.add(getAttributes(query));
-                } else {
-                    columnValues.add(EMPTY);
-                }
-
-                printer.printRecord(columnValues);
+                context.nextRowIdx();
             }
 
             printer.flush();
@@ -171,26 +197,7 @@ public class AggregateReportCsvHandler extends DefaultReportHandler {
         }
     }
 
-    private String[] getHeaders(final BasicAggregateReportQuery query) {
-        final List<String> headers = new ArrayList<>();
-        headers.add(getMessage("report.aggregate.export.header.organization"));
-        headers.add(getMessage("report.aggregate.export.header.natural-id"));
-        headers.add(getMessage("report.aggregate.export.header.assessment"));
-        headers.add(getMessage("report.aggregate.export.header.assessment-type"));
-        headers.add(getMessage("report.aggregate.export.header.subject"));
-        headers.add(getMessage("report.aggregate.export.header.grade"));
-        headers.add(getMessage("report.aggregate.export.header.year"));
-        headers.add(getMessage("report.aggregate.export.header.dimension"));
-        headers.add(getMessage("report.aggregate.export.header.dimension-code"));
-        headers.add(getMessage("report.aggregate.export.header.student-count"));
-        headers.add(getMessage("report.aggregate.export.header.score"));
-        headers.add(getMessage("report.aggregate.export.header.standard-deviation"));
-        headers.addAll(getPerformanceLevelHeaders(query));
-        headers.add(getMessage("report.aggregate.export.header.attributes"));
-        return headers.toArray(new String[headers.size()]);
-    }
-
-    private List<String> getPerformanceLevelHeaders(final BasicAggregateReportQuery query) {
+    private List<String> getPerformanceLevelHeaders(final Q query) {
         final List<String> performanceLevelHeaders = new ArrayList<>();
         if (IAB.code().equals(query.getAssessmentTypeCode())) {
             for (int i = 1; i <= 3; i++) {
@@ -204,54 +211,33 @@ public class AggregateReportCsvHandler extends DefaultReportHandler {
         return performanceLevelHeaders;
     }
 
-    private String getAttributes(final BasicAggregateReportQuery query) {
-        final List<String> attributes = new ArrayList<>();
-        final LocalDateTime localDate = LocalDateTime.now();
-        appendAttribute(attributes, "ReportDate", Collections.singleton(localDate.format(DateTimeFormatter.ISO_DATE_TIME)));
-        appendAttribute(attributes, "AdministrationCondition", query.getAdministrativeConditionCodes());
-        appendAttribute(attributes, "Completeness", query.getCompletenessCodes());
+    protected class CsvContext {
+        private final Q query;
+        private final AtomicInteger rowIdx = new AtomicInteger(0);
+        private final Map<String, Object> store = newHashMap();
 
-        final StudentFilters filters = query.getStudentFilters();
-        if (filters != null) {
-            appendAttribute(attributes, "Sex", filters.getGenderCodes());
-            appendAttribute(attributes, "Ethnicity", filters.getEthnicityCodes());
-            appendAttribute(attributes, "LEPStatus", filters.getLepCodes());
-            appendAttribute(attributes, "MigrantStatus", filters.getMigrantStatusCodes());
-            appendAttribute(attributes, "Section504Status", filters.getSection504Codes());
-            appendAttribute(attributes, "IDEAIndicator", filters.getIepCodes());
-            appendAttribute(attributes, "EconomicDisadvantageStatus", filters.getEconomicDisadvantageCodes());
+        public CsvContext(final Q query) {
+            this.query = query;
         }
 
-        return AttributeJoiner.join(attributes);
-    }
+        public Q getQuery() {
+            return query;
+        }
 
-    private String getMessage(final String key) {
-        return messageSource.getMessage(key, EmptyObjectArray, ReportLocale);
-    }
+        public int getRowIdx() {
+            return rowIdx.get();
+        }
 
-    private Iterator<BasicAggregateRow> asReportRowIterator(final JsonParser parser, final ReportContentResource resource) {
-        return new Iterator<BasicAggregateRow>() {
-            @Override
-            public boolean hasNext() {
-                return parser.currentToken() == JsonToken.START_OBJECT;
-            }
+        private void nextRowIdx() {
+            rowIdx.incrementAndGet();
+        }
 
-            @Override
-            public BasicAggregateRow next() {
-                try {
-                    final JsonNode node = objectMapper.readTree(parser);
-                    parser.nextToken();
-                    return objectMapper.treeToValue(node, BasicAggregateRow.class);
-                } catch (final IOException e) {
-                    throw new IllegalStateException("Unable to parse json payload for aggregate report: " + resource.getReport().getId(), e);
-                }
-            }
-        };
-    }
+        public void put(final String key, final Object value) {
+            store.put(key, value);
+        }
 
-    private void appendAttribute(final List<String> attributes, final String label, final Collection<String> values) {
-        if (values.isEmpty()) return;
-
-        attributes.add(label + ": " + AttributeValueJoiner.join(values));
+        public <T> T get(final String key, final Class<T> clazz) {
+            return store.containsKey(key) ? clazz.cast(store.get(key)) : null;
+        }
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/BasicAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/BasicAggregateReportCsvHandler.java
@@ -1,0 +1,115 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentestsystem.rdw.reporting.common.model.BasicAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.BasicAggregateRow;
+import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.ReportType;
+import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+import static org.opentestsystem.rdw.reporting.common.model.AggregateQueryType.Basic;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+/**
+ * This handler is responsible for transforming the JSON response for an
+ * {@link AggregateReportRequest} containing a {@link BasicAggregateReportQuery} into a CSV.
+ *
+ * The response JSON contains an array of {@link BasicAggregateRow} instances that should each be converted
+ * into a CSV row in the response payload using codes for values and data model identifiers for headers
+ * where applicable.
+ * If filters have been applied to the query, they are printed in the first row, last column of the
+ * response under the header of "Attributes."
+ *
+ * Note that this handler will only be applied if the user has not explicitly requested a JSON response payload.
+ */
+@Component
+class BasicAggregateReportCsvHandler extends AggregateReportCsvHandler<BasicAggregateReportQuery, BasicAggregateRow> {
+
+    @Autowired
+    public BasicAggregateReportCsvHandler(final MessageSource messageSource,
+                                          final ObjectMapper objectMapper) {
+        super(messageSource, objectMapper);
+    }
+
+    @Override
+    public boolean accept(final ReportContentResource resource, final MediaType requestedMediaType) {
+        final AbstractExamReportRequest request = resource.getReport().getReportRequest();
+        return !APPLICATION_JSON.isCompatibleWith(requestedMediaType) &&
+                request.getReportType() == ReportType.AggregateReportRequest &&
+                ((AggregateReportRequest) request).getQuery().getQueryType() == Basic;
+    }
+
+    @Override
+    protected List<String> getHeaders(final BasicAggregateReportQuery query) {
+        final List<String> headers = super.getHeaders(query);
+        headers.add(7, getMessage("report.aggregate.export.header.dimension"));
+        headers.add(8, getMessage("report.aggregate.export.header.dimension-code"));
+
+        return headers;
+    }
+
+    @Override
+    protected List<String> getRowValues(final CsvContext context, final BasicAggregateRow result) {
+        final List<String> rowValues = super.getRowValues(context, result);
+
+        final Dimension dimension = result.getDimension();
+        rowValues.add(7, dimension.getType().code());
+        rowValues.add(8, trimToEmpty(dimension.getCode()));
+
+        return rowValues;
+    }
+
+    @Override
+    protected Iterator<BasicAggregateRow> asReportRowIterator(final JsonParser parser, final ReportContentResource resource) {
+        return new Iterator<BasicAggregateRow>() {
+            @Override
+            public boolean hasNext() {
+                return parser.currentToken() == JsonToken.START_OBJECT;
+            }
+
+            @Override
+            public BasicAggregateRow next() {
+                try {
+                    final JsonNode node = getMapper().readTree(parser);
+                    parser.nextToken();
+                    return getMapper().treeToValue(node, BasicAggregateRow.class);
+                } catch (final IOException e) {
+                    throw new IllegalStateException("Unable to parse json payload for aggregate report: " + resource.getReport().getId(), e);
+                }
+            }
+        };
+    }
+
+    @Override
+    protected List<String> getAttributes(final BasicAggregateReportQuery query) {
+        final List<String> attributes = super.getAttributes(query);
+
+        final StudentFilters filters = query.getStudentFilters();
+        if (filters != null) {
+            appendAttribute(attributes, "Sex", filters.getGenderCodes());
+            appendAttribute(attributes, "Ethnicity", filters.getEthnicityCodes());
+            appendAttribute(attributes, "LEPStatus", filters.getLepCodes());
+            appendAttribute(attributes, "MigrantStatus", filters.getMigrantStatusCodes());
+            appendAttribute(attributes, "Section504Status", filters.getSection504Codes());
+            appendAttribute(attributes, "IDEAIndicator", filters.getIepCodes());
+            appendAttribute(attributes, "EconomicDisadvantageStatus", filters.getEconomicDisadvantageCodes());
+        }
+        return attributes;
+    }
+
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/FilteredSubgroupReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/FilteredSubgroupReportCsvHandler.java
@@ -1,0 +1,118 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentestsystem.rdw.reporting.common.model.DimensionType;
+import org.opentestsystem.rdw.reporting.common.model.FilteredSubgroupReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.FilteredSubgroupRow;
+import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.ReportType;
+import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.opentestsystem.rdw.reporting.common.model.AggregateQueryType.FilteredSubgroup;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+/**
+ * This handler is responsible for transforming the JSON response for an
+ * {@link AggregateReportRequest} containing a {@link FilteredSubgroupReportQuery} into a CSV.
+ *
+ * The response JSON contains an array of {@link FilteredSubgroupRow} instances that should each be converted
+ * into a CSV row in the response payload using codes for values and data model identifiers for headers
+ * where applicable.
+ * If completeness/administrative condition filters have been applied to the query, they are printed in the first row,
+ * last column of the response under the header of "Attributes."
+ *
+ * Note that this handler will only be applied if the user has not explicitly requested a JSON response payload.
+ */
+@Component
+public class FilteredSubgroupReportCsvHandler extends AggregateReportCsvHandler<FilteredSubgroupReportQuery, FilteredSubgroupRow> {
+
+    @Autowired
+    public FilteredSubgroupReportCsvHandler(final MessageSource messageSource,
+                                            final ObjectMapper objectMapper) {
+        super(messageSource, objectMapper);
+    }
+
+    @Override
+    public boolean accept(final ReportContentResource resource, final MediaType requestedMediaType) {
+        final AbstractExamReportRequest request = resource.getReport().getReportRequest();
+        return !APPLICATION_JSON.isCompatibleWith(requestedMediaType) &&
+                request.getReportType() == ReportType.AggregateReportRequest &&
+                ((AggregateReportRequest) request).getQuery().getQueryType() == FilteredSubgroup;
+    }
+
+    @Override
+    protected List<String> getHeaders(final FilteredSubgroupReportQuery query) {
+        final List<String> headers = super.getHeaders(query);
+        headers.add(7, getMessage("report.aggregate.export.header.dimension"));
+
+        return headers;
+    }
+
+    @Override
+    protected List<String> getRowValues(final CsvContext context, final FilteredSubgroupRow result) {
+        final List<String> rowValues = super.getRowValues(context, result);
+
+        rowValues.add(7, getSubgroup(context, result.getSubgroupKey()));
+        return rowValues;
+    }
+
+    @Override
+    protected Iterator<FilteredSubgroupRow> asReportRowIterator(final JsonParser parser, final ReportContentResource resource) {
+        return new Iterator<FilteredSubgroupRow>() {
+            @Override
+            public boolean hasNext() {
+                return parser.currentToken() == JsonToken.START_OBJECT;
+            }
+
+            @Override
+            public FilteredSubgroupRow next() {
+                try {
+                    final JsonNode node = getMapper().readTree(parser);
+                    parser.nextToken();
+                    return getMapper().treeToValue(node, FilteredSubgroupRow.class);
+                } catch (final IOException e) {
+                    throw new IllegalStateException("Unable to parse json payload for aggregate report: " + resource.getReport().getId(), e);
+                }
+            }
+        };
+    }
+
+    private String getSubgroup(final CsvContext context, final String subgroupKey) {
+        if (isNotEmpty(context.get(subgroupKey, String.class))) {
+            return context.get(subgroupKey, String.class);
+        }
+
+        final StudentFilters rowFilters = context.getQuery().getSubgroups().get(subgroupKey);
+        if (rowFilters == null) {
+            throw new IllegalStateException("Unknown subgroup referenced by FilteredSubgroup report result: " + subgroupKey);
+        }
+
+        final List<String> filterAttributes = newArrayList();
+        appendAttribute(filterAttributes, "Sex", rowFilters.getGenderCodes());
+        appendAttribute(filterAttributes, "Ethnicity", rowFilters.getEthnicityCodes());
+        appendAttribute(filterAttributes, "LEPStatus", rowFilters.getLepCodes());
+        appendAttribute(filterAttributes, "MigrantStatus", rowFilters.getMigrantStatusCodes());
+        appendAttribute(filterAttributes, "Section504Status", rowFilters.getSection504Codes());
+        appendAttribute(filterAttributes, "IDEAIndicator", rowFilters.getIepCodes());
+        appendAttribute(filterAttributes, "EconomicDisadvantageStatus", rowFilters.getEconomicDisadvantageCodes());
+
+        final String subgroupAttributes = filterAttributes.isEmpty() ? DimensionType.Overall.code() : AttributeJoiner.join(filterAttributes);
+        context.put(subgroupKey, subgroupAttributes);
+        return subgroupAttributes;
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/AggregateReportCsvHandlerTest.java
@@ -1,178 +1,26 @@
 package org.opentestsystem.rdw.reporting.processor.web.converter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.opentestsystem.rdw.reporting.common.model.ActiveAssessment;
-import org.opentestsystem.rdw.reporting.common.model.BasicAggregateReportQuery;
-import org.opentestsystem.rdw.reporting.common.model.BasicAggregateRow;
-import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.AggregateRow;
 import org.opentestsystem.rdw.reporting.common.model.District;
 import org.opentestsystem.rdw.reporting.common.model.Measures;
 import org.opentestsystem.rdw.reporting.common.model.Organization;
 import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
-import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.common.model.School;
 import org.opentestsystem.rdw.reporting.common.model.State;
-import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
-import org.opentestsystem.rdw.reporting.common.test.support.ReportQueries;
-import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
-import org.opentestsystem.rdw.reporting.processor.model.Report;
-import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
-import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
-import org.springframework.context.MessageSource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.mock.http.MockHttpOutputMessage;
 
-import java.io.ByteArrayInputStream;
-import java.io.StringReader;
-import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
-import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-
-@RunWith(MockitoJUnitRunner.class)
-public class AggregateReportCsvHandlerTest {
+public abstract class AggregateReportCsvHandlerTest {
     private static final AtomicInteger idGenerator = new AtomicInteger(1);
 
-    @Mock
-    private MessageSource messageSource;
-
-    @Mock
-    private ReportContentResource resource;
-
-    private MockHttpOutputMessage outputMessage;
-    private byte[] reportPayload;
-    private Report report;
-    private AggregateReportCsvHandler handler;
-
-    @Before
-    public void setup() throws Exception {
-        final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
-        outputMessage = new MockHttpOutputMessage();
-
-        when(messageSource.getMessage(anyString(), any(Object[].class), any(Locale.class)))
-                .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-
-        // 1 state, 3 districts, 3 schools per district => 13 rows
-        final List<BasicAggregateRow> data = newArrayList(reportRow(state()));
-        final List<District> districts = newArrayList(district(), district(), district());
-        districts.forEach(district -> {
-            data.add(reportRow(district));
-            data.add(reportRow(school(district.getId())));
-            data.add(reportRow(school(district.getId())));
-            data.add(reportRow(school(district.getId())));
-        });
-        reportPayload = objectMapper.writeValueAsBytes(data);
-
-        final BasicAggregateReportQuery query = ReportQueries.basicAggregateQuery().build();
-        final AggregateReportRequest request = AggregateReportRequest.builder()
-                .query(query)
-                .build();
-        report = spy(Report.builder()
-                .status(ReportStatus.COMPLETED)
-                .reportRequest(request)
-                .label("my report")
-                .build());
-        when(resource.getReport()).thenAnswer(invocation -> report);
-        when(resource.getInputStream()).thenAnswer(invocation -> new ByteArrayInputStream(reportPayload));
-
-        handler = new AggregateReportCsvHandler(messageSource, objectMapper);
-    }
-
-    @Test
-    public void itShouldHandleAggregateReportPayloads() {
-        assertThat(handler.accept(resource, null)).isTrue();
-    }
-
-    @Test
-    public void itShouldNotHandleAggregateReportPayloadsIfJsonIsRequested() {
-        assertThat(handler.accept(resource, APPLICATION_JSON)).isFalse();
-    }
-
-    @Test
-    public void itShouldOnlyHandleAggregateReportPayloads() {
-        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder().build();
-        when(report.getReportRequest()).thenReturn(request);
-        assertThat(handler.accept(resource, null)).isFalse();
-    }
-
-    @Test
-    public void itShouldWriteHeaders() throws Exception {
-        handler.writeResource(resource, outputMessage);
-
-        final HttpHeaders headers = outputMessage.getHeaders();
-        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV_UTF8);
-        assertThat(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("my_report");
-    }
-
-    @Test
-    public void itShouldWriteJsonAsCsv() throws Exception {
-        handler.writeResource(resource, outputMessage);
-
-        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
-            final CSVParser parser = CSVFormat.DEFAULT
-                    .withFirstRecordAsHeader()
-                    .parse(reader);
-
-            assertThat(parser.getHeaderMap()).hasSize(17);
-            final List<CSVRecord> rows = parser.getRecords();
-            assertThat(rows).hasSize(13);
-        }
-    }
-
-    @Test
-    public void itShouldWriteFiltersAsAttributes() throws Exception {
-        final StudentFilters filters = StudentFilters.builder()
-                .genderCodes(ImmutableSet.of("Male"))
-                .build();
-        final BasicAggregateReportQuery query = ReportQueries.basicAggregateQuery()
-                .studentFilters(filters)
-                .build();
-        final AggregateReportRequest request = AggregateReportRequest.builder()
-                .query(query)
-                .build();
-        when(report.getReportRequest()).thenReturn(request);
-
-        handler.writeResource(resource, outputMessage);
-
-        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
-            final CSVParser parser = CSVFormat.DEFAULT
-                    .withFirstRecordAsHeader()
-                    .parse(reader);
-            final List<CSVRecord> rows = parser.getRecords();
-            final String attributes = Iterators.getLast(rows.get(0).iterator());
-            assertThat(attributes).contains("ReportDate");
-            assertThat(attributes).contains("Sex: Male");
-        }
-    }
-
-    private State state() {
+    protected State state() {
         return State.builder()
                 .name("State")
                 .build();
     }
 
-    private District district() {
+    protected District district() {
         final int districtId = idGenerator.getAndIncrement();
         return District.builder()
                 .name("District " + districtId)
@@ -180,7 +28,7 @@ public class AggregateReportCsvHandlerTest {
                 .build();
     }
 
-    private School school(final long districtId) {
+    protected School school(final long districtId) {
         final int schoolId = idGenerator.getAndIncrement();
         return School.builder()
                 .organizationType(OrganizationType.School)
@@ -190,8 +38,8 @@ public class AggregateReportCsvHandlerTest {
                 .build();
     }
 
-    private BasicAggregateRow reportRow(final Organization organization) {
-        return BasicAggregateRow.builder()
+    protected <B extends AggregateRow.Builder<B, ?>> B reportRowBuilder(final B builder, final Organization organization) {
+        return builder
                 .assessment(ActiveAssessment.builder()
                         .id(123)
                         .examSchoolYear(1999)
@@ -199,7 +47,6 @@ public class AggregateReportCsvHandlerTest {
                         .label("An Assessment")
                         .gradeCode("03")
                         .build())
-                .dimension(Dimension.builder().type(Overall).build())
                 .measures(Measures.builder()
                         .avgScaleScore(2500)
                         .avgStdErr(50)
@@ -208,7 +55,6 @@ public class AggregateReportCsvHandlerTest {
                         .level3Count(3)
                         .level4Count(4)
                         .build())
-                .organization(organization)
-                .build();
+                .organization(organization);
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/BasicAggregateReportCsvHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/BasicAggregateReportCsvHandlerTest.java
@@ -1,0 +1,168 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.model.BasicAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.BasicAggregateRow;
+import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.District;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.opentestsystem.rdw.reporting.common.test.support.ReportQueries;
+import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
+import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.MockHttpOutputMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Locale;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
+import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BasicAggregateReportCsvHandlerTest extends AggregateReportCsvHandlerTest {
+
+    @Mock
+    private MessageSource messageSource;
+
+    @Mock
+    private ReportContentResource resource;
+
+    private MockHttpOutputMessage outputMessage;
+    private byte[] reportPayload;
+    private Report report;
+    private BasicAggregateReportCsvHandler handler;
+
+    @Before
+    public void setup() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+        outputMessage = new MockHttpOutputMessage();
+
+        when(messageSource.getMessage(anyString(), any(Object[].class), any(Locale.class)))
+                .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        // 1 state, 3 districts, 3 schools per district => 13 rows
+        final List<BasicAggregateRow> data = newArrayList(reportRow(state()));
+        final List<District> districts = newArrayList(district(), district(), district());
+        districts.forEach(district -> {
+            data.add(reportRow(district));
+            data.add(reportRow(school(district.getId())));
+            data.add(reportRow(school(district.getId())));
+            data.add(reportRow(school(district.getId())));
+        });
+        reportPayload = objectMapper.writeValueAsBytes(data);
+
+        final BasicAggregateReportQuery query = ReportQueries.basicAggregateQuery().build();
+        final AggregateReportRequest request = AggregateReportRequest.builder()
+                .query(query)
+                .build();
+        report = spy(Report.builder()
+                .status(ReportStatus.COMPLETED)
+                .reportRequest(request)
+                .label("my report")
+                .build());
+        when(resource.getReport()).thenAnswer(invocation -> report);
+        when(resource.getInputStream()).thenAnswer(invocation -> new ByteArrayInputStream(reportPayload));
+
+        handler = new BasicAggregateReportCsvHandler(messageSource, objectMapper);
+    }
+
+    @Test
+    public void itShouldHandleAggregateReportPayloads() {
+        assertThat(handler.accept(resource, null)).isTrue();
+    }
+
+    @Test
+    public void itShouldNotHandleAggregateReportPayloadsIfJsonIsRequested() {
+        assertThat(handler.accept(resource, APPLICATION_JSON)).isFalse();
+    }
+
+    @Test
+    public void itShouldOnlyHandleAggregateReportPayloads() {
+        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder().build();
+        when(report.getReportRequest()).thenReturn(request);
+        assertThat(handler.accept(resource, null)).isFalse();
+    }
+
+    @Test
+    public void itShouldWriteHtmlHeaders() throws Exception {
+        handler.writeResource(resource, outputMessage);
+
+        final HttpHeaders headers = outputMessage.getHeaders();
+        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV_UTF8);
+        assertThat(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("my_report");
+    }
+
+    @Test
+    public void itShouldWriteJsonAsCsv() throws Exception {
+        handler.writeResource(resource, outputMessage);
+
+        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
+            final CSVParser parser = CSVFormat.DEFAULT
+                    .withFirstRecordAsHeader()
+                    .parse(reader);
+
+            assertThat(parser.getHeaderMap()).hasSize(17);
+            final List<CSVRecord> rows = parser.getRecords();
+            assertThat(rows).hasSize(13);
+        }
+    }
+
+    @Test
+    public void itShouldWriteFiltersAsAttributes() throws Exception {
+        final StudentFilters filters = StudentFilters.builder()
+                .genderCodes(ImmutableSet.of("Male"))
+                .build();
+        final BasicAggregateReportQuery query = ReportQueries.basicAggregateQuery()
+                .studentFilters(filters)
+                .build();
+        final AggregateReportRequest request = AggregateReportRequest.builder()
+                .query(query)
+                .build();
+        when(report.getReportRequest()).thenReturn(request);
+
+        handler.writeResource(resource, outputMessage);
+
+        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
+            final CSVParser parser = CSVFormat.DEFAULT
+                    .withFirstRecordAsHeader()
+                    .parse(reader);
+            final List<CSVRecord> rows = parser.getRecords();
+            final String attributes = Iterators.getLast(rows.get(0).iterator());
+            assertThat(attributes).contains("ReportDate");
+            assertThat(attributes).contains("Sex: Male");
+        }
+    }
+
+    private BasicAggregateRow reportRow(final Organization organization) {
+        return super.reportRowBuilder(BasicAggregateRow.builder(), organization)
+                .dimension(Dimension.builder().type(Overall).build())
+                .build();
+    }
+
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/FilteredSubgroupReportCsvHandlerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/FilteredSubgroupReportCsvHandlerTest.java
@@ -1,0 +1,180 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.model.District;
+import org.opentestsystem.rdw.reporting.common.model.FilteredSubgroupReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.FilteredSubgroupRow;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.opentestsystem.rdw.reporting.common.test.support.ReportQueries;
+import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
+import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.MockHttpOutputMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.reporting.common.util.MediaTypes.TEXT_CSV_UTF8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilteredSubgroupReportCsvHandlerTest extends AggregateReportCsvHandlerTest {
+
+    @Mock
+    private MessageSource messageSource;
+
+    @Mock
+    private ReportContentResource resource;
+
+    private MockHttpOutputMessage outputMessage;
+    private byte[] reportPayload;
+    private Report report;
+    private FilteredSubgroupReportCsvHandler handler;
+
+    @Before
+    public void setup() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+        outputMessage = new MockHttpOutputMessage();
+
+        when(messageSource.getMessage(anyString(), any(Object[].class), any(Locale.class)))
+                .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        final Map<String, StudentFilters> subgroups = newHashMap();
+        subgroups.put("overall", StudentFilters.builder()
+                .build());
+        subgroups.put("subgroupA", StudentFilters.builder()
+                .genderCodes(ImmutableSet.of("Male"))
+                .build());
+        subgroups.put("subgroupB", StudentFilters.builder()
+                .genderCodes(ImmutableSet.of("Female"))
+                .build());
+
+        final FilteredSubgroupReportQuery query = ReportQueries.filteredSubgroupQuery()
+                .subgroups(subgroups)
+                .build();
+
+        final List<FilteredSubgroupRow> data = newArrayList();
+        final List<District> districts = newArrayList(district(), district());
+
+        // 3 subgroups, 1 state, 2 districts, 2 schools per district => 3 * (1 + 2 + 2*2) = 21 rows
+        for (final String subgroupKey : query.getSubgroups().keySet()) {
+            data.add(reportRow(subgroupKey, state()));
+            districts.forEach(district -> {
+                data.add(reportRow(subgroupKey, district));
+                data.add(reportRow(subgroupKey, school(district.getId())));
+                data.add(reportRow(subgroupKey, school(district.getId())));
+            });
+        }
+        reportPayload = objectMapper.writeValueAsBytes(data);
+
+        final AggregateReportRequest request = AggregateReportRequest.builder()
+                .query(query)
+                .build();
+        report = spy(Report.builder()
+                .status(ReportStatus.COMPLETED)
+                .reportRequest(request)
+                .label("my report")
+                .build());
+        when(resource.getReport()).thenAnswer(invocation -> report);
+        when(resource.getInputStream()).thenAnswer(invocation -> new ByteArrayInputStream(reportPayload));
+
+        handler = new FilteredSubgroupReportCsvHandler(messageSource, objectMapper);
+    }
+
+    @Test
+    public void itShouldHandleAggregateReportPayloads() {
+        assertThat(handler.accept(resource, null)).isTrue();
+    }
+
+    @Test
+    public void itShouldNotHandleAggregateReportPayloadsIfJsonIsRequested() {
+        assertThat(handler.accept(resource, APPLICATION_JSON)).isFalse();
+    }
+
+    @Test
+    public void itShouldOnlyHandleAggregateReportPayloads() {
+        final SchoolGradeExamReportRequest request = SchoolGradeExamReportRequest.builder().build();
+        when(report.getReportRequest()).thenReturn(request);
+        assertThat(handler.accept(resource, null)).isFalse();
+    }
+
+    @Test
+    public void itShouldWriteHtmlHeaders() throws Exception {
+        handler.writeResource(resource, outputMessage);
+
+        final HttpHeaders headers = outputMessage.getHeaders();
+        assertThat(headers.getContentType()).isEqualTo(TEXT_CSV_UTF8);
+        assertThat(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains("my_report");
+    }
+
+    @Test
+    public void itShouldWriteJsonAsCsv() throws Exception {
+        handler.writeResource(resource, outputMessage);
+
+        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
+            final CSVParser parser = CSVFormat.DEFAULT
+                    .withFirstRecordAsHeader()
+                    .parse(reader);
+
+            assertThat(parser.getHeaderMap()).hasSize(16);
+            final List<CSVRecord> rows = parser.getRecords();
+            assertThat(rows).hasSize(21);
+        }
+    }
+
+    @Test
+    public void itShouldWriteFiltersAsAttributes() throws Exception {
+        final FilteredSubgroupReportQuery query = ReportQueries.filteredSubgroupQuery()
+                .completenessCodes(ImmutableSet.of("Complete"))
+                .build();
+        final AggregateReportRequest request = AggregateReportRequest.builder()
+                .query(query)
+                .build();
+        when(report.getReportRequest()).thenReturn(request);
+
+        handler.writeResource(resource, outputMessage);
+
+        try (final StringReader reader = new StringReader(outputMessage.getBodyAsString())) {
+            final CSVParser parser = CSVFormat.DEFAULT
+                    .withFirstRecordAsHeader()
+                    .parse(reader);
+            final List<CSVRecord> rows = parser.getRecords();
+            final String attributes = Iterators.getLast(rows.get(0).iterator());
+            assertThat(attributes).contains("ReportDate");
+            assertThat(attributes).contains("Completeness: Complete");
+        }
+    }
+
+    private FilteredSubgroupRow reportRow(final String subgroupKey, final Organization organization) {
+        return super.reportRowBuilder(FilteredSubgroupRow.builder(), organization)
+                .subgroupKey(subgroupKey)
+                .build();
+    }
+}

--- a/webapp/src/main/webapp/src/app/report/basic-aggregate-report-request.ts
+++ b/webapp/src/main/webapp/src/app/report/basic-aggregate-report-request.ts
@@ -19,7 +19,7 @@ export interface BasicAggregateReportQuery {
   readonly includeAllDistrictsOfSchools: boolean;
   readonly includeAllSchoolsOfDistricts: boolean;
   readonly includeState: boolean;
-  readonly queryType: string;
+  readonly queryType: 'Basic' | 'FilteredSubgroup'; // See AggregateQueryType for possible values
   readonly schoolIds?: number[];
   readonly schoolYears: number[];
   readonly studentFilters: StudentFilters;


### PR DESCRIPTION
This PR assumes that filtered subgroup aggregate report payloads will be nearly identical to basic aggregate report payloads in that they will be serialized to JSON as an Array of serialized FilteredSubgroupRow instances.