### PR TITLE
Bugfix/inject school into school typeahead

### DIFF
--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -38,8 +38,9 @@
       <label for="school-search-name">{{'common.school-typeahead-label' | translate}}</label>
       <div *ngIf="aboveLimit">
         <school-typeahead #schoolTypeahead
+                          [school]="currentSchool"
                           [options]="schoolOptions"
-                          (selected)="schoolSelectChanged($event)"
+                          (schoolChange)="schoolSelectChanged($event)"
                           ></school-typeahead>
         <div>
           <span [hidden]="!schoolTypeahead.loading"><i class="fa fa-spinner fa-pulse"></i></span>

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.ts
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.ts
@@ -149,7 +149,6 @@ export class SchoolResultsComponent implements OnInit {
           this.schoolService.findGradesWithAssessmentsForSchool(schoolIdParam)
         ).subscribe(([ school, filterOptions, grades ]) => {
           this.schoolOptions = Observable.create(observer => {
-            console.log("typeahead", this.schoolTypeahead);
             observer.next(this.schoolTypeahead.value);
           }).pipe(
             mergeMap(

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.ts
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.ts
@@ -148,8 +148,8 @@ export class SchoolResultsComponent implements OnInit {
           this.filterOptionService.getExamFilterOptions(),
           this.schoolService.findGradesWithAssessmentsForSchool(schoolIdParam)
         ).subscribe(([ school, filterOptions, grades ]) => {
-
           this.schoolOptions = Observable.create(observer => {
+            console.log("typeahead", this.schoolTypeahead);
             observer.next(this.schoolTypeahead.value);
           }).pipe(
             mergeMap(

--- a/webapp/src/main/webapp/src/app/school-grade/school-grade.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/school-grade.component.html
@@ -14,7 +14,7 @@
           <div *ngIf="aboveLimit">
             <school-typeahead #schoolTypeahead
                               [options]="schoolOptions"
-                              (selected)="schoolChanged($event)"
+                              (schoolChange)="schoolChanged($event)"
                               (input)="deselectSchool($event)"></school-typeahead>
             <div>
               <span [hidden]="!schoolTypeahead.loading"><i class="fa fa-spinner fa-pulse"></i></span>
@@ -22,8 +22,7 @@
               <span [hidden]="!schoolTypeahead.noResults" class="small gray-darker">{{'school-typeahead.no-matches' | translate}}</span>
             </div>
           </div>
-          <sb-typeahead #schoolTypeahead
-                        *ngIf="!aboveLimit"
+          <sb-typeahead *ngIf="!aboveLimit"
                         inputId="search-school-name"
                         [options]="schoolOptions"
                         (selected)="schoolChanged($event)"

--- a/webapp/src/main/webapp/src/app/shared/school/school-typeahead.ts
+++ b/webapp/src/main/webapp/src/app/shared/school/school-typeahead.ts
@@ -35,24 +35,25 @@ export class SchoolTypeahead extends AbstractControlValueAccessor<string> {
   options: Observable<School[]> | School[];
 
   @Output()
-  selected: EventEmitter<School> = new EventEmitter<School>();
+  schoolChange: EventEmitter<School> = new EventEmitter<School>();
+
+  @Input()
+  set school(school: School) {
+    this._school = school;
+    this._value = school ? school.name : undefined;
+  }
+
+  get school(): School {
+    return this._school;
+  }
 
   loading: boolean = false;
   noResults: boolean = false;
-
-  get value(): string {
-    return this._value;
-  }
-
-  set value(value: string) {
-    if (this._value !== value && value.length) {
-      this._value = value;
-      this._onChangeCallback(value);
-    }
-  }
+  private _school: School;
 
   onTypeaheadSelectInternal(event: TypeaheadMatch): void {
-    event.item && this.selected.emit(event.item);
+    this.school = event.item;
+    this.schoolChange.emit(event.item);
   }
 
 }


### PR DESCRIPTION
Add ability to initialize the school-typeahead component with a school instance.
I also changed the API a bit to allow for `[(school)]="mySchool"` 2-way binding if we ever need it.