### PR TITLE
show aggregate writing trait score view for ICAs - not summative beca…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -126,7 +126,7 @@
                 <li role="menuitem"
                     *ngIf="writingTraitScoresView.display">
                   <a class="dropdown-item"
-                     popover="{{ (!assessmentExam.assessment.isIab ? 'assessment-results.no-writing-trait-scores-for-summative-ica-exams' : 'assessment-results.no-writing-trait-scores') | translate }}"
+                     popover="{{ (writingTraitScoresView.disabled ? 'assessment-results.writing-trait-scores-disabled' : 'assessment-results.no-writing-trait-scores') | translate }}"
                      triggers="{{ !writingTraitScoresView.disabled ? '' : 'mouseenter:mouseleave'}}"
                      placement="right"
                      container="body"

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -159,7 +159,7 @@ export class AssessmentResultsComponent implements OnInit {
   }
 
   get enableWritingTraitScores(): boolean {
-    return this._assessmentExam.assessment.isIab && this.displayItemLevelData;
+    return this.displayItemLevelData;
   }
 
   get showStudentResults(): boolean {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -175,7 +175,7 @@
     "no-results-by-item": "Results by item is not available for assessments administered prior to 2017-18 school year.",
     "no-results-by-item-for-summative-exams": "Results by item is not available for summative assessments.",
     "no-writing-trait-scores": "Writing trait scores are not available for assessments administered prior to 2017-18 school year.",
-    "no-writing-trait-scores-for-summative-ica-exams": "Writing trait scores are currently available for only ELA Performance Task IABs.",
+    "writing-trait-scores-disabled": "Writing trait scores are currently available for only ELA Performance Task for interim assessments..",
     "result-view-select": "Select a results view",
     "select-view": "Select View",
     "session-unknown": "[Unknown]",


### PR DESCRIPTION
…use it's item level data

![image](https://user-images.githubusercontent.com/341584/38693517-f9b7b56c-3e3b-11e8-87ed-60aa4ccc107e.png)
