### PR TITLE
Feature/dwr 1698 has wer

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/Assessments.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/Assessments.java
@@ -36,8 +36,7 @@ public final class Assessments {
                 .gradeCode(row.getString(prefix + "grade_code"))
                 .type(type)
                 .subject(Subject.valueOf(row.getInt(prefix + "subject_id")))
-                .schoolYear(row.getInt(prefix + "school_year"))
-                .werItem(row.getBoolean(prefix + "has_wer_item"));
+                .schoolYear(row.getInt(prefix + "school_year"));
 
         // IABs do not have claims
         if (type != AssessmentType.IAB) {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/Assessments.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/jdbc/Assessments.java
@@ -36,7 +36,8 @@ public final class Assessments {
                 .gradeCode(row.getString(prefix + "grade_code"))
                 .type(type)
                 .subject(Subject.valueOf(row.getInt(prefix + "subject_id")))
-                .schoolYear(row.getInt(prefix + "school_year"));
+                .schoolYear(row.getInt(prefix + "school_year"))
+                .werItem(row.getBoolean(prefix + "has_wer_item"));
 
         // IABs do not have claims
         if (type != AssessmentType.IAB) {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
@@ -121,7 +121,7 @@ public class Assessment {
     }
 
     /**
-     * @return <code>true</code> if the assessment has one or more WER items
+     * @return <code>true</code> if the assessment has one or more WER items. <code>null</code> if there wasn't a check done
      */
     public Boolean isWerItem() {
         return werItem;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
@@ -21,7 +21,7 @@ public class Assessment {
     private int schoolYear;
     private List<Integer> cutPoints;
     private List<String> claimCodes;
-    private boolean werItem;
+    private Boolean werItem;
 
     private Assessment() {
     }
@@ -123,7 +123,7 @@ public class Assessment {
     /**
      * @return <code>true</code> if the assessment has one or more WER items
      */
-    public boolean isWerItem() {
+    public Boolean isWerItem() {
         return werItem;
     }
 
@@ -160,7 +160,7 @@ public class Assessment {
         private int schoolYear;
         private List<Integer> cutPoints;
         private List<String> claimCodes;
-        private boolean werItem;
+        private Boolean werItem;
 
         public Builder id(final long id) {
             this.id = id;
@@ -207,7 +207,7 @@ public class Assessment {
             return this;
         }
 
-        public Builder werItem(final boolean werItem) {
+        public Builder werItem(final Boolean werItem) {
             this.werItem = werItem;
             return this;
         }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
@@ -21,6 +21,7 @@ public class Assessment {
     private int schoolYear;
     private List<Integer> cutPoints;
     private List<String> claimCodes;
+    private boolean werItem;
 
     private Assessment() {
     }
@@ -120,6 +121,13 @@ public class Assessment {
     }
 
     /**
+     * @return <code>true</code> if the assessment has one or more WER items
+     */
+    public boolean isWerItem() {
+        return werItem;
+    }
+
+    /**
      * This allows IAB and ICA/Summative exam's to not collide in {@link java.util.Set}s
      *
      * @param o the object to compare
@@ -152,6 +160,7 @@ public class Assessment {
         private int schoolYear;
         private List<Integer> cutPoints;
         private List<String> claimCodes;
+        private boolean werItem;
 
         public Builder id(final long id) {
             this.id = id;
@@ -198,6 +207,11 @@ public class Assessment {
             return this;
         }
 
+        public Builder werItem(final boolean werItem) {
+            this.werItem = werItem;
+            return this;
+        }
+
         public Assessment build() {
             final Assessment assessment = new Assessment();
             assessment.id = id;
@@ -209,6 +223,7 @@ public class Assessment {
             assessment.schoolYear = schoolYear;
             assessment.cutPoints = cutPoints != null ? ImmutableList.copyOf(cutPoints) : ImmutableList.of();
             assessment.claimCodes = claimCodes != null ? ImmutableList.copyOf(claimCodes) : null;
+            assessment.werItem = werItem;
             return assessment;
         }
 

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractAssessmentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractAssessmentRepository.java
@@ -57,6 +57,7 @@ public abstract class AbstractAssessmentRepository<T extends AbstractAssessmentS
 
     private Assessment buildAssessment(final ResultSet row, final int index) throws SQLException {
         return Assessments.map(row, Assessment.builder())
+                .werItem(row.getBoolean("has_wer_item"))
                 .cutPoints(ImmutableList.of(
                         row.getInt("min_score"),
                         row.getInt("cut_point_1"),

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -258,7 +258,9 @@ sql:
           a.max_score,
           a.cut_point_1,
           a.cut_point_2,
-          a.cut_point_3
+          a.cut_point_3,
+          EXISTS(SELECT 1 FROM item i WHERE i.asmt_id = a.id AND i.type = 'WER') as has_wer_item
+
 
       selectFromExamItem: >-
            SELECT

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
@@ -72,16 +72,16 @@ public final class TestData {
     );
 
     public static final List<Assessment> STUDENT10_GROUP10_ASSESSMENTS_WITH_CUT_POINTS = ImmutableList.of(
-            assessmentBuilder1().cutPoints(newArrayList(100, 200, 300, 400, 500)).build(),
-            assessmentBuilder2().cutPoints(newArrayList(1, 0, 2, 0, 3)).build(),
-            assessmentBuilder3().cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build()
+            assessmentBuilder1().werItem(true).cutPoints(newArrayList(100, 200, 300, 400, 500)).build(),
+            assessmentBuilder2().werItem(false).cutPoints(newArrayList(1, 0, 2, 0, 3)).build(),
+            assessmentBuilder3().werItem(false).cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build()
     );
 
     public static final List<Assessment> ALL_ASSESSMENTS_WITH_CUT_POINTS = ImmutableList.of(
-            assessmentBuilder1().cutPoints(newArrayList(100, 200, 300, 400, 500)).build(),
-            assessmentBuilder2().cutPoints(newArrayList(1, 0, 2, 0, 3)).build(),
-            assessmentBuilder3().cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build(),
-            assessmentBuilder4().cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build()
+            assessmentBuilder1().werItem(true).cutPoints(newArrayList(100, 200, 300, 400, 500)).build(),
+            assessmentBuilder2().werItem(false).cutPoints(newArrayList(1, 0, 2, 0, 3)).build(),
+            assessmentBuilder3().werItem(false).cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build(),
+            assessmentBuilder4().werItem(true).cutPoints(newArrayList(1000, 2000, 3000, 4000, 5000)).build()
     );
     public static final List<Exam> STUDENT10_EXAMS = ImmutableList.of(
             exam1().schoolYear(1997).build(),

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeAssessmentRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeAssessmentRepositoryIT.java
@@ -31,7 +31,7 @@ public class JdbcSchoolGradeAssessmentRepositoryIT extends JdbcRepositoryWithPer
     @Test
     public void findLatestShouldFindTheLatestExam() {
         final Assessment actual = repository.findLatest(userBuilder.permissionsById(individualStatewide).build(), search().build());
-        assertThat(actual).isEqualTo(TestData.ALL_ASSESSMENTS_BY_ID.get(-3L));
+        assertThat(actual).isEqualToComparingFieldByField(TestData.ALL_ASSESSMENTS_BY_ID.get(-3L));
     }
 
     @Test
@@ -63,9 +63,13 @@ public class JdbcSchoolGradeAssessmentRepositoryIT extends JdbcRepositoryWithPer
 
         //a teacher has access to more than one school, but the search limits it to one only
         final User user = userBuilder.permissionsById(individualStatewide).build();
-        assertThat(repository.findAll(user, query).stream().map(Assessment::getId)).containsOnly(-2L);
+        assertThat(repository.findAll(user, query).stream())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(TestData.ALL_ASSESSMENTS_BY_ID.get(-2L));
 
         getSystemSettings().setTransferAccessEnabled(true);
-        assertThat(repository.findAll(user, query).stream().map(Assessment::getId)).containsOnly(-1L, -2L);
+        assertThat(repository.findAll(user, query).stream())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsOnly(TestData.ALL_ASSESSMENTS_BY_ID.get(-1L), TestData.ALL_ASSESSMENTS_BY_ID.get(-2L));
     }
 }

--- a/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
@@ -54,6 +54,7 @@ export class AssessmentExamMapper {
     assessment.claimCodes = serverAssessment.claimCodes || [];
     assessment.cutPoints = serverAssessment.cutPoints || [];
     assessment.resourceUrl = serverAssessment.resourceUrl;
+    assessment.werItem = serverAssessment.werItem;
     return assessment;
   }
 

--- a/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessment-exam.mapper.ts
@@ -54,7 +54,7 @@ export class AssessmentExamMapper {
     assessment.claimCodes = serverAssessment.claimCodes || [];
     assessment.cutPoints = serverAssessment.cutPoints || [];
     assessment.resourceUrl = serverAssessment.resourceUrl;
-    assessment.werItem = serverAssessment.werItem;
+    assessment.hasWerItem = serverAssessment.werItem;
     return assessment;
   }
 

--- a/webapp/src/main/webapp/src/app/assessments/model/assessment.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/assessment.model.ts
@@ -6,7 +6,7 @@ export class Assessment {
   subject: string;
   claimCodes: string[];
   cutPoints: number[];
-  werItem: boolean;
+  hasWerItem: boolean;
 
   /** @deprecated TODO this does not belong here but in a UI wrapper */
   resourceUrl: string;
@@ -32,10 +32,6 @@ export class Assessment {
 
   get isEla(): boolean {
     return this.subject === 'ELA';
-  }
-
-  get hasWerItem(): boolean {
-    return this.werItem;
   }
 
 }

--- a/webapp/src/main/webapp/src/app/assessments/model/assessment.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/assessment.model.ts
@@ -6,6 +6,7 @@ export class Assessment {
   subject: string;
   claimCodes: string[];
   cutPoints: number[];
+  werItem: boolean;
 
   /** @deprecated TODO this does not belong here but in a UI wrapper */
   resourceUrl: string;
@@ -31,6 +32,10 @@ export class Assessment {
 
   get isEla(): boolean {
     return this.subject === 'ELA';
+  }
+
+  get hasWerItem(): boolean {
+    return this.werItem;
   }
 
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -126,7 +126,7 @@
                 <li role="menuitem"
                     *ngIf="writingTraitScoresView.display">
                   <a class="dropdown-item"
-                     popover="{{ (writingTraitScoresView.disabled ? 'assessment-results.writing-trait-scores-disabled' : 'assessment-results.no-writing-trait-scores') | translate }}"
+                     popover="{{ (assessmentExam.assessment.hasWerItem ? 'assessment-results.no-writing-trait-scores' : 'assessment-results.writing-trait-scores-disabled') | translate }}"
                      triggers="{{ !writingTraitScoresView.disabled ? '' : 'mouseenter:mouseleave'}}"
                      placement="right"
                      container="body"

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -126,7 +126,7 @@
                 <li role="menuitem"
                     *ngIf="writingTraitScoresView.display">
                   <a class="dropdown-item"
-                     popover="{{ (assessmentExam.assessment.hasWerItem ? 'assessment-results.no-writing-trait-scores' : 'assessment-results.writing-trait-scores-disabled') | translate }}"
+                     popover="{{ (!hasExamsAfterMinimumItemYear ? 'assessment-results.no-writing-trait-scores' : 'assessment-results.writing-trait-scores-disabled') | translate }}"
                      triggers="{{ !writingTraitScoresView.disabled ? '' : 'mouseenter:mouseleave'}}"
                      placement="right"
                      container="body"

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -159,7 +159,7 @@ export class AssessmentResultsComponent implements OnInit {
   }
 
   get enableWritingTraitScores(): boolean {
-    return this.hasExamsAfterMinimumItemYear;
+    return this._assessmentExam.assessment.hasWerItem && this.hasExamsAfterMinimumItemYear;
   }
 
   get showStudentResults(): boolean {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -180,7 +180,7 @@
     "no-results-by-item": "Results by item is not available for assessments administered prior to 2017-18 school year.",
     "no-results-by-item-for-summative-exams": "Results by item is not available for summative assessments.",
     "no-writing-trait-scores": "Writing trait scores are not available for assessments administered prior to 2017-18 school year.",
-    "writing-trait-scores-disabled": "Writing trait scores are currently available for only ELA Performance Task for interim assessments..",
+    "writing-trait-scores-disabled": "Writing trait scores are currently available for only ELA Performance Task assessments.",
     "result-view-select": "Select a results view",
     "select-view": "Select View",
     "session-unknown": "[Unknown]",


### PR DESCRIPTION
returning a flag for if an assessment has any WER items.  this allows the results pages to know ahead of time if it is appropriate to have an option enabled for Writing Trait Scores aggregate view.  this is needed because some states won't be using the WER section of an ICA or Summative and so we could know that ahead of time if that item isn't loaded as part of the package.  plus it makes the experience better for ELA IABs that are not the PT one.

NOTE: still need to add integration tests.  will do before merging