### PR TITLE
updates phantomjs (has transitive hoek dep)

### DIFF
--- a/webapp/src/main/webapp/karma.conf.js
+++ b/webapp/src/main/webapp/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular/cli'],
     plugins: [
       require('karma-jasmine'),
-      require('karma-phantomjs2-launcher'),
+      require('karma-phantomjs-launcher'),
       require('karma-remap-istanbul'),
       require('karma-teamcity-reporter'),
       require('@angular/cli/plugins/karma')
@@ -29,7 +29,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['PhantomJS2'],
+    browsers: ['PhantomJS'],
     singleRun: false,
     //Quick fix for PhantomJS OOM issues
     browserNoActivityTimeout: 60000,

--- a/webapp/src/main/webapp/package-lock.json
+++ b/webapp/src/main/webapp/package-lock.json
@@ -884,41 +884,6 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
@@ -1009,6 +974,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "bootstrap": {
@@ -1601,16 +1574,6 @@
         "typedarray": "0.0.6"
       }
     },
-    "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
-      }
-    },
     "connect": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
@@ -2007,12 +1970,6 @@
         "clap": "1.2.3",
         "source-map": "0.5.7"
       }
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "dev": true
     },
     "cuint": {
       "version": "0.2.2",
@@ -2933,9 +2890,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "es6-set": {
@@ -4579,13 +4536,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-property": "1.0.2"
       }
@@ -5023,6 +4982,14 @@
         "cryptiles": "2.0.5",
         "hoek": "2.16.3",
         "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "he": {
@@ -5041,12 +5008,6 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -5561,6 +5522,7 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -5632,7 +5594,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -6118,7 +6081,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6217,278 +6181,13 @@
         "karma-jasmine": "1.1.1"
       }
     },
-    "karma-phantomjs2-launcher": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs2-launcher/-/karma-phantomjs2-launcher-0.5.0.tgz",
-      "integrity": "sha1-X/jI8i0N+OZygoyoeQhiq8Amk0U=",
+    "karma-phantomjs-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.0.tgz",
+      "integrity": "sha1-0Z/FEqbSsKvUy3KJGNqJ7UAyzd8=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1",
-        "phantomjs2-ext": "0.2.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-          "dev": true
-        },
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
-          "dev": true,
-          "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime-types": "2.0.14"
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
-        },
-        "har-validator": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
-          "dev": true,
-          "requires": {
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "commander": "2.12.1",
-            "is-my-json-valid": "2.16.1"
-          }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
-            "ctype": "0.5.3"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.12.0"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
-          "dev": true
-        },
-        "phantomjs2-ext": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/phantomjs2-ext/-/phantomjs2-ext-0.2.2.tgz",
-          "integrity": "sha1-v8oHkeYPniZVVctr76Pw3PVaviw=",
-          "dev": true,
-          "requires": {
-            "adm-zip": "0.4.7",
-            "kew": "0.5.0",
-            "mkdirp": "0.5.0",
-            "ncp": "2.0.0",
-            "npmconf": "2.1.1",
-            "progress": "1.1.8",
-            "request": "2.55.0",
-            "request-progress": "0.3.1",
-            "rimraf": "2.3.4",
-            "which": "1.0.9"
-          }
-        },
-        "qs": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.55.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.5.0",
-            "bl": "0.9.5",
-            "caseless": "0.9.0",
-            "combined-stream": "0.0.7",
-            "forever-agent": "0.6.1",
-            "form-data": "0.2.0",
-            "har-validator": "1.8.0",
-            "hawk": "2.3.1",
-            "http-signature": "0.10.1",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.0.14",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.6.0",
-            "qs": "2.4.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3"
-          }
-        },
-        "rimraf": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
-          "integrity": "sha1-gtm8Gy/PMeIFrHsoE4oCXQjpFZo=",
-          "dev": true,
-          "requires": {
-            "glob": "4.5.3"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-          "dev": true
-        }
+        "lodash": "4.17.5"
       }
     },
     "karma-remap-istanbul": {
@@ -6517,9 +6216,9 @@
       "dev": true
     },
     "kew": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.5.0.tgz",
-      "integrity": "sha1-7OEctdjQGoH4zoBMjQu6BuayXKI=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "killable": {
@@ -7289,12 +6988,6 @@
         "xml-char-classes": "1.0.0"
       }
     },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -7578,49 +7271,6 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
-      }
-    },
-    "npmconf": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-      "integrity": "sha1-ombH5cVmlet/VcrzpacyjyRRDa4=",
-      "dev": true,
-      "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.3.3",
-        "osenv": "0.1.4",
-        "semver": "4.3.6",
-        "uid-number": "0.0.5"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
       }
     },
     "npmlog": {
@@ -8074,7 +7724,7 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.1.1",
+        "es6-promise": "4.2.4",
         "extract-zip": "1.6.6",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
@@ -8104,27 +7754,6 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
-        },
-        "kew": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-          "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-          "dev": true
-        },
-        "request-progress": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-          "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-          "dev": true,
-          "requires": {
-            "throttleit": "1.0.0"
-          }
-        },
-        "throttleit": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-          "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-          "dev": true
         }
       }
     },
@@ -8911,12 +8540,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
     "protractor": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.1.2.tgz",
@@ -9604,12 +9227,12 @@
       }
     },
     "request-progress": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "0.0.2"
+        "throttleit": "1.0.0"
       }
     },
     "require-directory": {
@@ -10005,6 +9628,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "socket.io": {
@@ -10587,9 +10218,9 @@
       }
     },
     "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
@@ -10939,12 +10570,6 @@
           }
         }
       }
-    },
-    "uid-number": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
-      "dev": true
     },
     "ultron": {
       "version": "1.0.2",

--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -62,7 +62,7 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "karma-phantomjs2-launcher": "^0.5.0",
+    "karma-phantomjs-launcher": "^1.0.0",
     "karma-remap-istanbul": "^0.2.1",
     "karma-teamcity-reporter": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.16",


### PR DESCRIPTION
This change knocks off one dependency relying on hoek@2.16.3

The below dependencies i wasn't about to "upgrade out of reliance":

```bash
├─┬ @angular/compiler-cli@5.2.8
│ │ ├─┬ fsevents@1.1.3
│ │ │ ├── nan@2.8.0 deduped
│ │ │ └─┬ node-pre-gyp@0.6.39
│ │ │   ├── detect-libc@1.0.2
│ │ │   ├─┬ hawk@3.1.3
│ │ │   │ ├─┬ boom@2.10.1
│ │ │   │ │ └── hoek@2.16.3 deduped
│ │ │   │ ├─┬ cryptiles@2.0.5
│ │ │   │ │ └── boom@2.10.1 deduped
│ │ │   │ ├── hoek@2.16.3
│ │ │   │ └─┬ sntp@1.0.9
│ │ │   │   └── hoek@2.16.3 deduped

├─┬ phantomjs-prebuilt@2.1.16
│ ├─┬ request@2.81.0
│ │ ├─┬ hawk@3.1.3
│ │ │ ├─┬ boom@2.10.1
│ │ │ │ └── hoek@2.16.3
│ │ │ ├─┬ cryptiles@2.0.5
│ │ │ │ └── boom@2.10.1 deduped
│ │ │ ├── hoek@2.16.3
│ │ │ └─┬ sntp@1.0.9
│ │ │   └── hoek@2.16.3
```