### PR TITLE
removed restriction of only ICA and IAB on assessment items.  needed …

### DIFF
--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/assessment/JdbcAssessmentItemRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/assessment/JdbcAssessmentItemRepository.java
@@ -38,7 +38,6 @@ class JdbcAssessmentItemRepository implements AssessmentItemRepository {
         return template.query(
                 findAllForAssessmentQuery,
                 new MapSqlParameterSource("assessment_id", assessmentId)
-                        .addValue("assessmentTypes", ImmutableSet.of(IAB.id(), ICA.id()))
                         .addValue("includeAllItemTypes", true)
                         .addValue("types", ""),
                 (row, index) -> AssessmentItems.map(row)
@@ -50,7 +49,6 @@ class JdbcAssessmentItemRepository implements AssessmentItemRepository {
         return template.query(
                 findAllForAssessmentQuery,
                 new MapSqlParameterSource("assessment_id", assessmentId)
-                        .addValue("assessmentTypes", ImmutableSet.of(IAB.id(), ICA.id()))
                         .addValue("includeAllItemTypes", false)
                         .addValue("types", types),
                 (row, index) -> AssessmentItems.map(row)

--- a/reporting-service/src/main/resources/application-no-permission.sql.yml
+++ b/reporting-service/src/main/resources/application-no-permission.sql.yml
@@ -39,8 +39,7 @@ sql:
       findAllForAssessment: >-
         ${sql.reporting.snippet.selectFromItem}
           join asmt a on i.asmt_id=a.id
-        where a.type_id in (:assessmentTypes)
-        and i.asmt_id=:assessment_id
+        where i.asmt_id=:assessment_id
         and (1=:includeAllItemTypes or i.type in (:types))
 
       findAllForExam: >-

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/assessment/JdbcAssessmentItemRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/assessment/JdbcAssessmentItemRepositoryIT.java
@@ -233,12 +233,6 @@ public class JdbcAssessmentItemRepositoryIT {
     }
 
     @Test
-    public void itShouldFindNoAssessmentItemsForAssementWithTypeSummative() {
-        List<AssessmentItem> actual = repository.findAllForAssessmentAndTypes(-4L, Arrays.asList("MS", "MC"));
-        assertThat(actual).size().isEqualTo(0);
-    }
-
-    @Test
     public void itShouldReturnEmptyWhenFailingToFindAssessmentItemsByExam() {
         assertThat(repository.findAllForExam(1234L)).isEmpty();
     }


### PR DESCRIPTION
…for Writing Trait Scores aggregate for Summative

There was a hard-coded restriction for IAB and ICA since it did not allow for the WER items to be returned.  Since we will be restricting sensitive data for summative items during migrate (no responses and no answer keys) I'm thinking we can return these safely.  

The alternative is just to allow this for WER items which seems like an odd restriction, if it's fine for that then it's probably fine for all.

Thoughts?