### PR TITLE
improves chart line toggle ui

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -4,7 +4,7 @@ import { AggregateReportItem } from './aggregate-report-item';
 import { byNumber, byString, Comparator, join, ranking } from '@kourge/ordering/comparator';
 import { ColorService } from '../../shared/color.service';
 import { AssessmentDefinition } from '../assessment/assessment-definition';
-import { District, OrganizationType, School } from '../../shared/organization/organization';
+import { OrganizationType } from '../../shared/organization/organization';
 import { Utils } from '../../shared/support/support';
 import { AggregateReportOptions } from '../aggregate-report-options';
 import { PerformanceLevelDisplayTypes } from '../../shared/display-options/performance-level-display-type';

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -13,6 +13,7 @@ import { AggregateReportTableExportService, ExportOptions } from './aggregate-re
 import { Table } from 'primeng/table';
 import { SortEvent } from 'primeng/api';
 import * as _ from 'lodash';
+import { organizationOrdering, subgroupOrdering } from '../support';
 
 export const SupportedRowCount = 10000;
 export const DefaultRowsPerPageOptions = [ 100, 500, 1000 ];
@@ -24,30 +25,6 @@ export const IdentityColumnOptions: string[] = [
   'dimension'
 ];
 
-const OverallDimensionType: string = 'Overall';
-
-const StateOrdering: Ordering<AggregateReportItem> = ordering(ranking([ OrganizationType.State ]))
-  .reverse()
-  .on(item => item.organization.type);
-
-const DistrictsWithSchoolsByIdOrdering: Ordering<AggregateReportItem> = ordering(byNumber)
-  .on(item => {
-    switch (item.organization.type) {
-      case OrganizationType.District:
-        return (item.organization as District).id;
-      case OrganizationType.School:
-        return (item.organization as School).districtId;
-      default:
-        return -1;
-    }
-  });
-
-const DistrictOrdering: Ordering<AggregateReportItem> = ordering(ranking([ OrganizationType.District ]))
-  .reverse()
-  .on(item => item.organization.type);
-
-const SchoolOrdering: Ordering<AggregateReportItem> = ordering(byString)
-  .on(item => item.organization.name);
 
 const SchoolYearOrdering: Ordering<AggregateReportItem> = ordering(byNumber)
   .on(item => item.schoolYear);
@@ -88,7 +65,6 @@ export class AggregateReportTableComponent implements OnInit {
   private _previousSortEvent: any;
   private _table: AggregateReportTable;
   private _identityColumns: string[] = IdentityColumnOptions.concat();
-  private _districtNamesById: Map<number, string> = new Map();
   private _orderingByColumnField: { [ key: string ]: Ordering<AggregateReportItem> } = {};
   private _valueDisplayType: string = ValueDisplayTypes.Percent;
   private _performanceLevelDisplayType: string = PerformanceLevelDisplayTypes.Separate;
@@ -269,12 +245,11 @@ export class AggregateReportTableComponent implements OnInit {
     const assessmentGradeOrdering = ordering(ranking(options.assessmentGrades))
       .on((item: AggregateReportItem) => item.assessmentGradeCode);
 
-    this._districtNamesById = this.getDistrictNamesById(rows);
     this._orderingByColumnField[ 'assessmentLabel' ] = AssessmentLabelOrdering;
-    this._orderingByColumnField[ 'organization.name' ] = this.createOrganizationOrdering();
+    this._orderingByColumnField[ 'organization.name' ] = organizationOrdering(item => item.organization, rows);
     this._orderingByColumnField[ 'assessmentGradeCode' ] = assessmentGradeOrdering;
     this._orderingByColumnField[ 'schoolYear' ] = SchoolYearOrdering;
-    this._orderingByColumnField[ 'subgroup.id' ] = this.createDimensionOrdering(options);
+    this._orderingByColumnField[ 'subgroup.id' ] = subgroupOrdering(item => item.subgroup, options);
 
     // create columns
     const performanceLevelsByDisplayType = {
@@ -417,17 +392,6 @@ export class AggregateReportTableComponent implements OnInit {
     return index;
   }
 
-  private getDistrictNamesById(items: AggregateReportItem[]): Map<number, string> {
-    const districtNamesById = new Map<number, string>();
-    items.forEach(item => {
-      if (item.organization.type === OrganizationType.District) {
-        const district = item.organization as District;
-        districtNamesById.set(district.id, district.name);
-      }
-    });
-    return districtNamesById;
-  }
-
   private createPerformanceLevelColumns(performanceLevelsByDisplayType: any, assessmentDefinition: AssessmentDefinition): Column[] {
     const performanceColumns: Column[] = [];
     Object.keys(performanceLevelsByDisplayType)
@@ -465,86 +429,6 @@ export class AggregateReportTableComponent implements OnInit {
       : `aggregate-report-table.columns.grouped-performance-level-prefix.${index}`;
   }
 
-  private createOrganizationOrdering(): Ordering<AggregateReportItem> {
-
-    const districtsWithSchoolsByName: Ordering<AggregateReportItem> = ordering(byString)
-      .on(item => {
-        switch (item.organization.type) {
-          case OrganizationType.District:
-            return this._districtNamesById.get((item.organization as District).id) || '';
-          case OrganizationType.School:
-            return this._districtNamesById.get((item.organization as School).districtId) || '';
-          default:
-            return '';
-        }
-      });
-
-    return ordering(join(
-      StateOrdering.compare,
-      districtsWithSchoolsByName.compare,
-      DistrictsWithSchoolsByIdOrdering.compare,
-      DistrictOrdering.compare,
-      SchoolOrdering.compare
-    ));
-  }
-
-  private createDimensionOrdering(options: AggregateReportOptions): Ordering<AggregateReportItem> {
-    const dimensionOptionsByDimensionType = {
-      Gender: options.studentFilters.genders,
-      Ethnicity: options.studentFilters.ethnicities,
-      LEP: options.studentFilters.limitedEnglishProficiencies,
-      ELAS: options.studentFilters.englishLanguageAcquisitionStatuses,
-      MigrantStatus: options.studentFilters.migrantStatuses,
-      Section504: options.studentFilters.migrantStatuses,
-      IEP: options.studentFilters.individualEducationPlans,
-      EconomicDisadvantage: options.studentFilters.economicDisadvantages
-    };
-
-    const dimensionTypeAndCodeRankingValues = options.dimensionTypes.reduce((ranking, dimensionType) => {
-      return ranking.concat(
-        (dimensionOptionsByDimensionType[ dimensionType ] || []).map(dimensionCode => `${dimensionType}:${dimensionCode}`)
-      );
-    }, []);
-
-    const dimensionTypeAndCodeComparator: Comparator<AggregateReportItem> = ordering(ranking(
-      [ OverallDimensionType, ...dimensionTypeAndCodeRankingValues ]
-      ))
-      .on((item: AggregateReportItem) => item.subgroup.id)
-      .compare;
-
-    // Attempt to sort based upon the enrolled grade code as a number ("01", "02", "KG", "UG", etc)
-    // If the code cannot be parsed as a number, the order is undefined
-    // TODO we should have a specific ordering for all grade codes, although the system only currently uses "03" - "12"
-    const enrolledGradeComparator: Comparator<AggregateReportItem> = ordering(byNumber)
-      .on((item: AggregateReportItem) => {
-        const { type, codes } = <any>item.subgroup;
-        if (type == null || type !== 'StudentEnrolledGrade') {
-          return -1;
-        }
-        try {
-          return Number.parseInt(codes[0]);
-        } catch (error) {
-          return 1;
-        }
-      })
-      .compare;
-
-    return ordering(join(
-      dimensionTypeAndCodeComparator,
-      enrolledGradeComparator,
-      // hotfix Overall order on FilteredSubgroup results
-      (a: AggregateReportItem, b: AggregateReportItem) => {
-        if (a.subgroup.id === 'Overall:') {
-          return -1;
-        }
-        if (b.subgroup.id === 'Overall:') {
-          return 1;
-        }
-        return 0;
-      },
-      ordering(byString).on(({ subgroup }) => subgroup.id).compare
-    ));
-  }
 }
 
 export interface AggregateReportTable {

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -7,7 +7,7 @@ import { AggregateReportItemMapper } from "./aggregate-report-item.mapper";
 import { AssessmentDefinition } from "../assessment/assessment-definition";
 import { Subscription } from "rxjs/Subscription";
 import { Utils } from "../../shared/support/support";
-import { Comparator, ranking } from "@kourge/ordering/comparator";
+import { Comparator, join, ranking } from "@kourge/ordering/comparator";
 import { ordering } from "@kourge/ordering";
 import { AggregateReportQuery } from "../../report/aggregate-report-request";
 import { DisplayOptionService } from "../../shared/display-options/display-option.service";
@@ -23,6 +23,7 @@ import { LongitudinalCohortChart } from "./longitudinal-cohort-chart";
 import { AggregateReportService, LongitudinalReport } from "../aggregate-report.service";
 import { LongitudinalCohortChartMapper } from './longitudinal-cohort-chart.mapper';
 import { AggregateReportItem } from './aggregate-report-item';
+import { organizationOrdering, subgroupOrdering } from '../support';
 
 const PollingInterval = 4000;
 
@@ -261,6 +262,13 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
             rows: rows.filter(row => row.assessment.subjectCode === subjectCode),
             assessments: assessments.filter(assessment => assessment.subject === subjectCode)
           });
+
+          view.chart.organizationPerformances.sort(
+            join(
+              organizationOrdering(path => path.organization, view.chart.organizationPerformances).compare,
+              subgroupOrdering(path => path.subgroup, this.options).compare
+            )
+          );
         }
 
         views.push(view);

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
@@ -6,16 +6,13 @@
       <ul class="list-unstyled">
         <li *ngFor="let performancePath of chartView.performancePaths; let index = index"
             class="mb-xs">
-          <button class="btn chart-series color-{{index % 3}} text-left"
-                  [ngClass]="{'chart-series-hidden': !performancePath.visible}"
-                  (click)="performancePath.visible = !performancePath.visible">
-            <div>
-              {{performancePath.organization.name}}
-            </div>
-            <div class="small">
-              {{'common.organization.type.' + performancePath.organization.type | translate}}
-            </div>
-          </button>
+          <a class="chart-series-toggle label-max-width"
+             (click)="onChartSeriesToggleClick(performancePath, index)"
+             [ngClass]="{'chart-series-hidden': !performancePath.visible}">
+            <span class="chart-series-icon color-{{index % 3}}"></span>
+            <span>{{performancePath.organization.name}}:</span>
+            <span class="small">{{performancePath.subgroup.name}}</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
@@ -9,9 +9,11 @@ import {
   NumberRange,
   YearGrade
 } from './longitudinal-cohort-chart';
-import { byNumber } from '@kourge/ordering/comparator';
+import { byNumber, byString, join, ranking } from '@kourge/ordering/comparator';
 import { ordering } from '@kourge/ordering';
-import { Organization } from '../../shared/organization/organization';
+import { District, Organization, OrganizationType } from '../../shared/organization/organization';
+import { Subgroup } from '../subgroup/subgroup';
+import { organizationOrdering } from '../support';
 
 
 /**
@@ -111,6 +113,8 @@ export class LongitudinalCohortChartComponent implements OnInit {
     tickPadding: 10
   };
 
+  private _selectedPaths: Set<number> = new Set();
+
   constructor(private elementReference: ElementRef,
               private translate: TranslateService,
               private schoolYearPipe: SchoolYearPipe) {
@@ -151,6 +155,15 @@ export class LongitudinalCohortChartComponent implements OnInit {
   ngOnInit(): void {
     this.render();
     this._initialized = true;
+  }
+
+  onChartSeriesToggleClick(path: PerformancePath, pathIndex: number): void {
+    this._selectedPaths.has(pathIndex)
+      ? this._selectedPaths.delete(pathIndex)
+      : this._selectedPaths.add(pathIndex);
+
+    this._chartView.performancePaths
+      .forEach((path, index) => path.visible = this._selectedPaths.size === 0 || this._selectedPaths.has(index));
   }
 
   private render(): void {
@@ -219,8 +232,6 @@ export class LongitudinalCohortChartComponent implements OnInit {
 
     this._chartView = <ChartView>{
       performancePaths: this._chart.organizationPerformances
-        // TODO allow different subgroup selection
-        .filter(performance => performance.subgroup.id === 'Overall:')
         .map((performance, i) => <PerformancePath>{
           styles: `scale-score-line color-${i % 3} series-${i}`,
           visible: true,

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
@@ -9,11 +9,9 @@ import {
   NumberRange,
   YearGrade
 } from './longitudinal-cohort-chart';
-import { byNumber, byString, join, ranking } from '@kourge/ordering/comparator';
+import { byNumber } from '@kourge/ordering/comparator';
 import { ordering } from '@kourge/ordering';
-import { District, Organization, OrganizationType } from '../../shared/organization/organization';
-import { Subgroup } from '../subgroup/subgroup';
-import { organizationOrdering } from '../support';
+import { Organization } from '../../shared/organization/organization';
 
 
 /**
@@ -169,7 +167,7 @@ export class LongitudinalCohortChartComponent implements OnInit {
   private render(): void {
 
     if (this.chart == null
-    || this.display == null) {
+      || this.display == null) {
       return;
     }
 
@@ -254,19 +252,19 @@ export class LongitudinalCohortChartComponent implements OnInit {
           organization: performance.organization,
           subgroup: performance.subgroup
         }),
-        performanceLevelPaths: this._chart.performanceLevels.map((level, i) => <PerformanceLevelPath>{
-          styles: `scale-score-area color-${i % 4}`,
-          pathData: d3area(level.yearGradeScaleScoreRanges.map(({ scaleScoreRange }, j) => <any>{
-            x: j,
-            y0: scaleScoreRange.minimum,
-            y1: scaleScoreRange.maximum
-          })),
-          dividerPathData: d3line(level.yearGradeScaleScoreRanges.map(({ scaleScoreRange }, j) => <any>{
-            x: j,
-            y: scaleScoreRange.maximum
-          })),
-          performanceLevel: level
-        }),
+      performanceLevelPaths: this._chart.performanceLevels.map((level, i) => <PerformanceLevelPath>{
+        styles: `scale-score-area color-${i % 4}`,
+        pathData: d3area(level.yearGradeScaleScoreRanges.map(({ scaleScoreRange }, j) => <any>{
+          x: j,
+          y0: scaleScoreRange.minimum,
+          y1: scaleScoreRange.maximum
+        })),
+        dividerPathData: d3line(level.yearGradeScaleScoreRanges.map(({ scaleScoreRange }, j) => <any>{
+          x: j,
+          y: scaleScoreRange.maximum
+        })),
+        performanceLevel: level
+      }),
       performanceLevelPathLabels: levelRangesByYearGradeIndex[ levelRangesByYearGradeIndex.length - 1 ].map(levelRange => {
         const height = yScale(levelRange.scaleScoreRange.maximum) - yScale(levelRange.scaleScoreRange.minimum);
         const margin = { left: 5, top: -2, right: 0, bottom: 2 };

--- a/webapp/src/main/webapp/src/app/aggregate-report/support.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/support.ts
@@ -1,3 +1,11 @@
+import { District, Organization, OrganizationType, School } from '../shared/organization/organization';
+import { Ordering, ordering } from '@kourge/ordering';
+import { byNumber, byString, join, ranking } from '@kourge/ordering/comparator';
+import { AggregateReportOptions } from './aggregate-report-options';
+import { Subgroup } from './subgroup/subgroup';
+
+const OverallDimensionType: string = 'Overall';
+
 /**
  * @param {number} endYear The year to start the list with
  * @param {string[]} gradeCodes The consecutive grade codes covered by the report
@@ -8,5 +16,126 @@ export function computeEffectiveYears(endYear: number, gradeCodes: string[]): nu
   return gradeCodes
     .map(code => Number.parseInt(code))
     .sort((a, b) => b - a)
-    .map((grade, index, grades) => endYear - (grades[0] - grade));
+    .map((grade, index, grades) => endYear - (grades[ 0 ] - grade));
+}
+
+/**
+ * @param {(item: T) => Organization} organizationGetter method accepting an element of the elements to sort that returns that element's organization
+ * @param {T[]} items all items to be compared. This is needed to successfully order schools grouped by district
+ * @returns {Ordering<T>} creates natural organization ordering
+ */
+export function organizationOrdering<T>(organizationGetter: (item: T) => Organization, items: T[]): Ordering<T> {
+
+  const districtNamesById = items.reduce((districtNamesById, item) => {
+    const organization = organizationGetter(item);
+    if (organization.type === OrganizationType.District) {
+      districtNamesById.set((<District>organization).id, organization.name);
+    }
+    return districtNamesById;
+  }, new Map());
+
+  const stateOrdering = ordering(ranking([ OrganizationType.State ]))
+    .reverse()
+    .on(item => organizationGetter(item).type);
+
+  const districtsWithSchoolsByName: Ordering = ordering(byString)
+    .on(item => {
+      switch (organizationGetter(item).type) {
+        case OrganizationType.District:
+          return districtNamesById.get((organizationGetter(item) as District).id) || '';
+        case OrganizationType.School:
+          return districtNamesById.get((organizationGetter(item) as School).districtId) || '';
+        default:
+          return '';
+      }
+    });
+
+  const districtsWithSchoolsByIdOrdering = ordering(byNumber)
+    .on(item => {
+      switch (organizationGetter(item).type) {
+        case OrganizationType.District:
+          return (item.organization as District).id;
+        case OrganizationType.School:
+          return (item.organization as School).districtId;
+        default:
+          return -1;
+      }
+    });
+
+  const districtOrdering = ordering(ranking([ OrganizationType.District ]))
+    .reverse()
+    .on(item => organizationGetter(item).type);
+
+  const schoolOrdering = ordering(byString)
+    .on(item => organizationGetter(item).name);
+
+  return ordering(
+    join(
+      stateOrdering.compare,
+      districtsWithSchoolsByName.compare,
+      districtsWithSchoolsByIdOrdering.compare,
+      districtOrdering.compare,
+      schoolOrdering.compare
+    )
+  );
+}
+
+
+export function subgroupOrdering<T>(subgroupGetter: (item: T) => Subgroup,options: AggregateReportOptions): Ordering<T> {
+
+  const dimensionOptionsByDimensionType = {
+    Gender: options.studentFilters.genders,
+    Ethnicity: options.studentFilters.ethnicities,
+    LEP: options.studentFilters.limitedEnglishProficiencies,
+    ELAS: options.studentFilters.englishLanguageAcquisitionStatuses,
+    MigrantStatus: options.studentFilters.migrantStatuses,
+    Section504: options.studentFilters.migrantStatuses,
+    IEP: options.studentFilters.individualEducationPlans,
+    EconomicDisadvantage: options.studentFilters.economicDisadvantages
+  };
+
+  const dimensionTypeAndCodeRankingValues = options.dimensionTypes.reduce((ranking, dimensionType) => {
+    return ranking.concat(
+      (dimensionOptionsByDimensionType[ dimensionType ] || []).map(dimensionCode => `${dimensionType}:${dimensionCode}`)
+    );
+  }, []);
+
+  const dimensionTypeAndCodeComparator = ordering(ranking(
+    [ OverallDimensionType, ...dimensionTypeAndCodeRankingValues ]
+  ))
+    .on(item => subgroupGetter(item).id)
+    .compare;
+
+  // Attempt to sort based upon the enrolled grade code as a number ("01", "02", "KG", "UG", etc)
+  // If the code cannot be parsed as a number, the order is undefined
+  // TODO we should have a specific ordering for all grade codes, although the system only currently uses "03" - "12"
+  const enrolledGradeComparator = ordering(byNumber)
+    .on(item => {
+      const { type, codes } = subgroupGetter(item);
+      if (type == null || type !== 'StudentEnrolledGrade') {
+        return -1;
+      }
+      try {
+        return Number.parseInt(codes[ 0 ]);
+      } catch (error) {
+        return 1;
+      }
+    })
+    .compare;
+
+  return ordering(join(
+    dimensionTypeAndCodeComparator,
+    enrolledGradeComparator,
+    // hotfix Overall order on FilteredSubgroup results
+    (a: T, b: T) => {
+      if (subgroupGetter(a).id === 'Overall:') {
+        return -1;
+      }
+      if (subgroupGetter(b).id === 'Overall:') {
+        return 1;
+      }
+      return 0;
+    },
+    ordering(byString).on(({ subgroup }) => subgroup.id).compare
+  ));
 }

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -350,10 +350,11 @@ sb-button-typeahead .input-group-btn > .btn,
 }
 
 .label-max-width {
+  white-space: nowrap;
   text-overflow: ellipsis;
   text-align: left;
   overflow: hidden;
-  max-width: 330px;
+  max-width: 300px;
 }
 
 /**
@@ -934,25 +935,32 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
 .chart-series-legend {
 
   &.pallet-a {
-    .chart-series {
+    .chart-series,
+    .chart-series-icon {
       &.color-0 { background-color: @gray-darkest; }
       &.color-1 { background-color: @aqua; }
       &.color-2 { background-color: @green; }
     }
   }
 
-  .chart-series {
-    color: #fff;
-    font-size: 80%;
-    padding: @padding-xs-vertical @padding-xs-horizontal;
-    border-radius: @border-radius-base;
-    outline: none;
-    &:active,&:focus {
-      outline: none;
-    }
-    &.chart-series-hidden {
-      opacity: @opacity-softer;
-    }
+  .chart-series-toggle {
+    font-family: @font-family-base;
+    cursor: pointer;
+    color: @text-color;
+    text-decoration: none;
+    display: block;
+  }
+
+  @chart-series-icon-size: 8px;
+
+  .chart-series-icon {
+    width: @chart-series-icon-size;
+    height: @chart-series-icon-size;
+    display: inline-block;
+  }
+
+  .chart-series-hidden {
+    opacity: @opacity-softer;
   }
 }
 

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -354,7 +354,7 @@ sb-button-typeahead .input-group-btn > .btn,
   text-overflow: ellipsis;
   text-align: left;
   overflow: hidden;
-  max-width: 300px;
+  max-width: 330px;
 }
 
 /**
@@ -946,7 +946,6 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
   .chart-series-toggle {
     font-family: @font-family-base;
     cursor: pointer;
-    color: @text-color;
     text-decoration: none;
     display: block;
   }


### PR DESCRIPTION
Some improvements to the chart series toggle UI

The toggles now have the same default sort as the table rows.

![image](https://user-images.githubusercontent.com/23462925/39657814-6f9e1182-4fc0-11e8-874e-9be6dd3004a4.png)

Also, selection of one highlights only that one. Additional selections will be added to the view instead of incrementally taking things away.

![image](https://user-images.githubusercontent.com/23462925/39657826-9439450c-4fc0-11e8-94c0-002bf7632f7b.png)

I would still like to make an iteration where organizations and subgroups can be toggled independently but for now i think this is an improvement so i'd like to get it out there