### PR TITLE
Bugfix/dwr 1766

### DIFF
--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -161,7 +161,8 @@ sql:
           WHERE e2.student_id IS NULL
         )
         AND ${sql.snippet.studentExamPermissionWithoutEmbargo}
-        GROUP BY asmt_id;
+        GROUP BY asmt_id
+        ORDER BY completed_at DESC;
 
     examItem:
         findAllExamItemScoresForAssessment:

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -126,26 +126,34 @@ sql:
           SELECT
             e1.id
           FROM (
-                 SELECT ex1.id, ex1.student_id, ex1.asmt_id, ex1.school_year, ex1.completed_at from exam ex1
+                 SELECT ex1.id, ex1.student_id, ex1.asmt_id, ex1.school_year, ex1.completed_at
+                 FROM exam ex1
+                   JOIN asmt a ON a.id = ex1.asmt_id
                    JOIN student_group_membership gm on gm.student_id = ex1.student_id
                    JOIN user_student_group usg ON usg.student_group_id = gm.student_group_id
+                   JOIN student_group sg ON sg.id = usg.student_group_id
                  WHERE ex1.type_id = 2
                        AND ex1.school_year = :school_year
                        AND ex1.scale_score IS NOT NULL
                        AND ex1.scale_score_std_err IS NOT NULL
                        AND ex1.performance_level IS NOT NULL
                        AND gm.student_group_id = :group_id
+                       AND (sg.subject_id is null OR a.subject_id = sg.subject_id)
                        AND usg.user_login = :user_login
                ) AS e1 LEFT OUTER JOIN
-            ( SELECT ex2.id, ex2.student_id, ex2.asmt_id, ex2.school_year, ex2.completed_at from exam ex2
-              JOIN student_group_membership gm on gm.student_id = ex2.student_id
-              JOIN user_student_group usg ON usg.student_group_id = gm.student_group_id
+            ( SELECT ex2.id, ex2.student_id, ex2.asmt_id, ex2.school_year, ex2.completed_at
+              FROM exam ex2
+                JOIN asmt a ON a.id = ex2.asmt_id
+                JOIN student_group_membership gm on gm.student_id = ex2.student_id
+                JOIN user_student_group usg ON usg.student_group_id = gm.student_group_id
+                JOIN student_group sg ON sg.id = usg.student_group_id
             WHERE ex2.type_id = 2
                   AND ex2.school_year = :school_year
                   AND ex2.scale_score IS NOT NULL
                   AND ex2.scale_score_std_err IS NOT NULL
                   AND ex2.performance_level IS NOT NULL
                   AND gm.student_group_id = :group_id
+                  AND (sg.subject_id is null OR a.subject_id = sg.subject_id)
                   AND usg.user_login = :user_login
             ) AS e2
               ON e1.student_id = e2.student_id  AND e1.asmt_id = e2.asmt_id AND e1.school_year = e2.school_year

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.html
@@ -53,7 +53,8 @@
                 (change)="updateRoute()">
           <option selected [ngValue]="undefined">{{'common.subject.ALL.short-name' | translate}}</option>
           <option *ngFor="let subject of filterOptions.subjects"
-                  [ngValue]="subject">{{'common.subject.' + subject + '.short-name' | translate}}
+                  [ngValue]="subject"
+                  [hidden]="!hasSubject(subject)">{{'common.subject.' + subject + '.short-name' | translate}}
           </option>
         </select>
       </div>

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.html
@@ -83,7 +83,7 @@
   </div>
   <!-- No Results Error -->
   <div class="alert alert-info" *ngIf="measuredAssessments.length == 0">
-    {{'common.assessments.no-results-found' | translate}}
+    {{'group-dashboard.no-results-found' | translate}}
   </div>
 </div>
 

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
@@ -24,6 +24,7 @@ export class GroupDashboardComponent implements OnInit {
   currentGroup: Group;
   private _currentSubject: string;
   private selectedAssessments: MeasuredAssessment[] = [];
+  private _availableSubjects: Set<string>;
 
   constructor(private route: ActivatedRoute,
               private router: Router,
@@ -46,6 +47,7 @@ export class GroupDashboardComponent implements OnInit {
       this.currentSchoolYear = Number.parseInt(schoolYear) || filterOptions.schoolYears[ 0 ];
       this.groupDashboardService.getAvailableMeasuredAssessments(group, this.currentSchoolYear).subscribe(measuredAssessments => {
         this.measuredAssessments = measuredAssessments;
+        this.setAvailableSubjects(measuredAssessments);
       });
     });
   }
@@ -66,6 +68,7 @@ export class GroupDashboardComponent implements OnInit {
       this.groupService.getGroup(this.currentGroup.id).subscribe((group) => {
         this.group = group;
         this.groupDashboardService.getAvailableMeasuredAssessments(group, this.currentSchoolYear).subscribe(measuredAssessments => {
+          this.setAvailableSubjects(measuredAssessments);
           if (!this.currentSubject) {
             this.measuredAssessments = measuredAssessments;
           } else {
@@ -75,6 +78,10 @@ export class GroupDashboardComponent implements OnInit {
         });
       });
     });
+  }
+
+  setAvailableSubjects(measuredAssessments: MeasuredAssessment[]): void {
+    this._availableSubjects = new Set(measuredAssessments.map(x => x.assessment.subject));
   }
 
   viewAssessments(): void {
@@ -114,6 +121,10 @@ export class GroupDashboardComponent implements OnInit {
     this.selectedAssessments = event.selected ? this.selectedAssessments.concat(event.measuredAssessment)
       : this.selectedAssessments.filter(measuredAssessment =>
         measuredAssessment.assessment.id !== event.measuredAssessment.assessment.id);
+  }
+
+  hasSubject(subject: string): boolean {
+    return this._availableSubjects.has(subject);
   }
 
   /**

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -948,7 +948,8 @@
   },
   "group-dashboard": {
     "heading": "Student Groups",
-    "name": "Assessment Reports"
+    "name": "Assessment Reports",
+    "no-results-found": "No test results are available for the current selection.  Please check the filters above as this group may not have access to the subject selected. "
   },
   "group-import": {
     "browse-instruct": "browse for files",


### PR DESCRIPTION
IAB Group Dashboard was not respecting the group subject restrictions

Now the SQL respects the subject_id on the group and the UI will adjust the subject dropdown to not include a subject that is not available based on the assessments for this group.

![image](https://user-images.githubusercontent.com/341584/39729442-b55759a2-5210-11e8-8b94-d64a6f9c2b34.png)

And if you go from a group where you have narrowed the results to ELA only and then switch to a group that doesn't have ELA.  You get a message saying there are no results which I think works well.

![image](https://user-images.githubusercontent.com/341584/39729612-b35eedd0-5211-11e8-9330-743f392ea964.png)


