### PR TITLE
find most recent date for the session date to handle edge cases

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -98,6 +98,18 @@ describe('AssessmentResultsComponent', () => {
     expect(component.sessions[ 1 ].id).toBe("ma-02");
   });
 
+  it('should take most recent date for each session', () => {
+    let assessmentExam = new AssessmentExam();
+    assessmentExam.exams.push(buildExam("Benoit", "ma-02", "2017-01-01T17:05:26Z"));
+    assessmentExam.exams.push(buildExam("Wood", "ma-01", "2017-03-01T17:05:26Z"));
+    assessmentExam.exams.push(buildExam("Joe", "ma-02", "2017-01-03T17:05:26Z"));
+    assessmentExam.exams.push(buildExam("Jane", "ma-01", "2017-03-02T17:05:26Z"));
+
+    component.assessmentExam = assessmentExam;
+    expect(component.sessions[ 0 ].date).toBe("2017-03-02T17:05:26Z");
+    expect(component.sessions[ 1 ].date).toBe("2017-01-03T17:05:26Z");
+  });
+
   it('should toggle sessions filtered to true and false', () => {
     let session = { id: "ma-02", filter: undefined, exams: [] };
 

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -321,6 +321,11 @@ export class AssessmentResultsComponent implements OnInit {
     }
   }
 
+  /**
+   * Find distinct exam sessions and calculate the most recent date for that session
+   * @param {Exam[]} exams
+   * @returns {any[]} sessions
+   */
   private getDistinctExamSessions(exams: Exam[]): any[] {
     let sessions = [];
 
@@ -328,12 +333,8 @@ export class AssessmentResultsComponent implements OnInit {
       if (!sessions.some(x => x.id == exam.session)) {
         sessions.push({
           id: exam.session,
-
-          // get the maximum date for this session in case of timezone issues or data issues where the exams in a session have different dates
-          date: exams.filter(x => x.session == exam.session).reduce((a, b) => {
-              return new Date(a.date) > new Date(b.date) ? a : b
-            }).date,
-          
+          date: exams.filter(x => x.session == exam.session)
+                    .reduce((a, b) => new Date(a.date) > new Date(b.date) ? a : b).date,
           filter: false
         });
       }

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -326,7 +326,16 @@ export class AssessmentResultsComponent implements OnInit {
 
     for (let exam of exams) {
       if (!sessions.some(x => x.id == exam.session)) {
-        sessions.push({ id: exam.session, date: exam.date, filter: false });
+        sessions.push({
+          id: exam.session,
+
+          // get the maximum date for this session in case of timezone issues or data issues where the exams in a session have different dates
+          date: exams.filter(x => x.session == exam.session).reduce((a, b) => {
+              return new Date(a.date) > new Date(b.date) ? a : b
+            }).date,
+          
+          filter: false
+        });
       }
     }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
@@ -1,7 +1,7 @@
 <!-- IAB display -->
 <div *ngIf="hasAverageScore" class="average-scale-score-display">
   <div class="row" *ngIf="!isClaimScoreSelected">
-    <div class="col-md-5">
+    <div class="col-md-5 mb-md">
       <strong>{{ 'average-scale-score.title' | translate }}</strong>
       <div class="well">
         <div class="assessment-results-summary">


### PR DESCRIPTION
There may be timezone issues or data inconsistencies where the dates for the exams aren't all the same.  Right now it is inconsistent what date will show up.. Nohemi saw in QA a different date than I did in QA for the same session.  This changes it to get the most recent date for the session when it determines it.

You can see an April 4th date here but the session says Mar 1.

![image](https://user-images.githubusercontent.com/341584/39786071-b0f7e2fa-52d3-11e8-9a9a-31a8a99d80b4.png)
