### PR TITLE
Claim Aggregate report CSV export.

### DIFF
--- a/common/src/main/resources/i18n/en.json
+++ b/common/src/main/resources/i18n/en.json
@@ -18,7 +18,8 @@
           "standard-deviation": "ScaleScoreStandardDeviation",
           "student-count": "StudentsTested",
           "subject": "Subject",
-          "year": "SchoolYear"
+          "year": "SchoolYear",
+          "claim": "Claim"
         }
       }
     },

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
@@ -253,7 +253,7 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
     protected abstract List<String> getMeasureHeaders(final Q query);
 
     /**
-     * @return a list of all headers. This allows custom implementations to override the default behaviour.
+     * @return a list of headers. This allows custom implementations to override the default behaviour.
      */
     protected List<String> getReportCustomHeaders() {
         return newArrayList();
@@ -266,7 +266,7 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
     protected abstract List<String> getMeasuresValues(final CsvContext context, final R result);
 
     /**
-     * @return a list of all values. Must be aligned with the results from getReportCustomHeaders.
+     * @return a list of values. Must be aligned with the results from getReportCustomHeaders.
      * This allows custom implementations to override the default behaviour
      */
     protected List<String> getReportCustomValues(final CsvContext context, final R result) {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
@@ -148,6 +148,8 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
         headers.add(getMessage("report.aggregate.export.header.subject"));
         headers.add(getMessage("report.aggregate.export.header.grade"));
         headers.add(getMessage("report.aggregate.export.header.year"));
+        //this allows custom implementations to add headers
+        headers.addAll(getReportCustomHeaders());
         headers.add(getMessage("report.aggregate.export.header.dimension"));
         headers.add(getMessage("report.aggregate.export.header.dimension-code"));
         //this allows custom implementations to add measure(s)
@@ -166,6 +168,8 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
         rowValues.add(result.getAssessment().getSubjectCode());
         rowValues.add(result.getAssessment().getGradeCode());
         rowValues.add(String.valueOf(result.getAssessment().getExamSchoolYear()));
+        //this allows custom implementations to add values
+        rowValues.addAll(getReportCustomValues(context, result));
         rowValues.add(result.getDimension().getType().code());
         //this allows custom implementations to override the dimension values
         rowValues.add(getDimensionValue(context, result.getDimension()));
@@ -249,10 +253,25 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
     protected abstract List<String> getMeasureHeaders(final Q query);
 
     /**
+     * @return a list of all headers. This allows custom implementations to override the default behaviour.
+     */
+    protected List<String> getReportCustomHeaders() {
+        return newArrayList();
+    }
+
+    /**
      * @return a list of all {@link Measures} values. Must be aligned with the results from getMeasureHeaders.
      * This allows custom implementations to override the default behaviour
      */
     protected abstract List<String> getMeasuresValues(final CsvContext context, final R result);
+
+    /**
+     * @return a list of all values. Must be aligned with the results from getReportCustomHeaders.
+     * This allows custom implementations to override the default behaviour
+     */
+    protected List<String> getReportCustomValues(final CsvContext context, final R result) {
+        return newArrayList();
+    }
 
     /**
      * @return a helper to return measures related values
@@ -291,7 +310,7 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
         attributes.add(label + ": " + AttributeValueJoiner.join(values));
     }
 
-    private String getMessage(final String key) {
+    protected String getMessage(final String key) {
         return messageSource.getMessage(key, EmptyObjectArray, ReportLocale);
     }
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandler.java
@@ -37,7 +37,6 @@ public class ClaimAggregateReportCsvHandler extends AbstractAggregateReportCsvHa
         final List<String> headers = newArrayList();
         headers.add(getMessage("report.aggregate.export.header.student-count"));
         for (int i = 1; i <= 3; i++) {
-            //this should not happen for IABs
             headers.add(getMessage("report.claim.level." + i + ".label"));
         }
         return headers;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandler.java
@@ -1,0 +1,71 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentestsystem.rdw.reporting.common.model.AggregateQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimRow;
+import org.opentestsystem.rdw.reporting.common.model.Measures;
+import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
+import org.opentestsystem.rdw.reporting.processor.web.ReportContentResource;
+import org.springframework.context.MessageSource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.opentestsystem.rdw.reporting.common.model.AggregateReportType.Claim;
+
+@Component
+public class ClaimAggregateReportCsvHandler extends AbstractAggregateReportCsvHandler<ClaimAggregateReportQuery, ClaimRow> {
+
+    public ClaimAggregateReportCsvHandler(final MessageSource messageSource, final ObjectMapper objectMapper) {
+        super(messageSource, objectMapper);
+    }
+
+    @Override
+    public boolean accept(final ReportContentResource resource, final MediaType requestedMediaType) {
+        final boolean accept = super.accept(resource, requestedMediaType);
+        if (!accept) return false;
+
+        final AggregateQuery query = ((AggregateReportRequest) resource.getReport().getReportRequest()).getQuery();
+        return query.getReportType() == Claim;
+    }
+
+    @Override
+    protected List<String> getMeasureHeaders(final ClaimAggregateReportQuery query) {
+        final List<String> headers = newArrayList();
+        headers.add(getMessage("report.aggregate.export.header.student-count"));
+        for (int i = 1; i <= 3; i++) {
+            //this should not happen for IABs
+            headers.add(getMessage("report.claim.level." + i + ".label"));
+        }
+        return headers;
+    }
+
+    @Override
+    protected List<String> getMeasuresValues(final CsvContext context, final ClaimRow result) {
+        final List<String> measuresValues = newArrayList();
+        final Measures measures = result.getMeasures();
+        measuresValues.add(String.valueOf(measures.getStudentCount()));
+        measuresValues.add(String.valueOf(measures.getLevel1Count()));
+        measuresValues.add(String.valueOf(measures.getLevel2Count()));
+        measuresValues.add(String.valueOf(measures.getLevel3Count()));
+        return measuresValues;
+    }
+
+    @Override
+    protected List<String> getReportCustomHeaders() {
+        return newArrayList(getMessage("report.aggregate.export.header.claim"));
+    }
+
+    @Override
+    protected List<String> getReportCustomValues(final CsvContext context, final ClaimRow result) {
+        return newArrayList(getMessage("report.claim." + result.getClaimCode() + ".name"));
+    }
+
+    @Override
+    protected Class<ClaimRow> getRowInstanceClass() {
+        return ClaimRow.class;
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandlerWithBasicQueryTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandlerWithBasicQueryTest.java
@@ -1,0 +1,54 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.model.AbstractAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimRow;
+import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.springframework.context.MessageSource;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static org.opentestsystem.rdw.common.model.AssessmentType.SUMMATIVE;
+import static org.opentestsystem.rdw.common.model.Subject.MATH;
+import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Gender;
+import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Overall;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClaimAggregateReportCsvHandlerWithBasicQueryTest extends AbstractAggregateReportCsvHandlerWithBasicQueryTest<ClaimRow> {
+
+    @Override
+    protected ClaimRow reportRow(final Organization organization) {
+        return super.reportRowBuilder(ClaimRow.builder(), organization)
+                .dimension(Dimension.builder().type(Overall).build())
+                .claimCode("2-W")
+                .build();
+    }
+
+    @Override
+    protected ClaimAggregateReportCsvHandler createHandlerUnderTest(final MessageSource messageSource, final ObjectMapper objectMapper) {
+        return new ClaimAggregateReportCsvHandler(messageSource, objectMapper);
+    }
+
+    @Override
+    protected AbstractAggregateReportQuery.Builder getQueryBuilder() {
+        return ClaimAggregateReportQuery.builder()
+                .assessmentTypeCode(SUMMATIVE.code())
+                .subjectCodes(of(MATH.code().toLowerCase(), Subject.ELA.code().toUpperCase()))
+                .schoolYears(of(2018))
+                .assessmentGradeCodes(of("01", "02", "03", "04", "05"))
+                .includeState(true)
+                .includeAllDistricts(false)
+                .dimensionTypes(of(Gender))
+                .districtIds(of(1L))
+                .schoolIds(of(1L));
+    }
+
+    @Override
+    protected int getHeadersCount() {
+        return 15;
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandlerWithFilteredSubgroupQueryTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/converter/ClaimAggregateReportCsvHandlerWithFilteredSubgroupQueryTest.java
@@ -1,0 +1,68 @@
+package org.opentestsystem.rdw.reporting.processor.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opentestsystem.rdw.common.model.Subject;
+import org.opentestsystem.rdw.reporting.common.model.AbstractAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimAggregateReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ClaimRow;
+import org.opentestsystem.rdw.reporting.common.model.Dimension;
+import org.opentestsystem.rdw.reporting.common.model.DimensionType;
+import org.opentestsystem.rdw.reporting.common.model.Organization;
+import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.springframework.context.MessageSource;
+
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static com.google.common.collect.Maps.newHashMap;
+import static org.opentestsystem.rdw.common.model.AssessmentType.ICA;
+import static org.opentestsystem.rdw.common.model.Subject.MATH;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClaimAggregateReportCsvHandlerWithFilteredSubgroupQueryTest extends AbstractAggregateReportCsvHandlerWithFilteredSubgroupQueryTest<ClaimRow> {
+
+    @Override
+    protected ClaimRow reportRow(final String subgroupKey, final Organization organization) {
+        return super.reportRowBuilder(ClaimRow.builder(), organization)
+                .dimension(Dimension.builder().type(DimensionType.Custom).code(subgroupKey).build())
+                .claimCode("W-2")
+                .build();
+    }
+
+    @Override
+    protected ClaimAggregateReportCsvHandler createHandlerUnderTest(final MessageSource messageSource, final ObjectMapper objectMapper) {
+        return new ClaimAggregateReportCsvHandler(messageSource, objectMapper);
+    }
+
+    @Override
+    protected AbstractAggregateReportQuery.Builder getQueryBuilder() {
+        final Map<String, StudentFilters> subgroups = newHashMap();
+        subgroups.put("overall", StudentFilters.builder()
+                .build());
+        subgroups.put("subgroupA", StudentFilters.builder()
+                .genderCodes(of("Male"))
+                .build());
+        subgroups.put("subgroupB", StudentFilters.builder()
+                .genderCodes(of("Female"))
+                .build());
+
+        return ClaimAggregateReportQuery.builder()
+                .assessmentTypeCode(ICA.code())
+                .subjectCodes(of(MATH.code().toLowerCase(), Subject.ELA.code().toUpperCase()))
+                .schoolYears(of(2017, 2018))
+                .assessmentGradeCodes(of("01", "02", "03", "04", "05"))
+                .includeState(true)
+                .includeAllDistricts(false)
+                .subgroups(subgroups)
+                .districtIds(of(1L))
+                .schoolIds(of(1L))
+                .claimCodes(of("W-2"));
+    }
+
+    @Override
+    protected int getHeadersCount() {
+        return 15;
+    }
+}


### PR DESCRIPTION
This completes the backend work for the Claim Aggregate report with the exception of 25,000 Repository RSTs. Will be working on them next.