### PR TITLE
Fix to a deadlock exception in reporting.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-properties'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
+    compile 'org.springframework.retry:spring-retry'
     compile 'com.healthmarketscience.sqlbuilder:sqlbuilder:2.1.7'
 
     optional 'org.springframework.boot:spring-boot-configuration-processor'

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/JdbcRetryConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/JdbcRetryConfiguration.java
@@ -1,0 +1,30 @@
+package org.opentestsystem.rdw.reporting.common.repository;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Spring EnableTransactionManagement are implemented via AOP proxies with the default
+ * {@link Order} = {@link Ordered#LOWEST_PRECEDENCE} = {@link Integer#MAX_VALUE}
+ * <p>
+ * Retry needs to be executed AFTER the transaction is committed.
+ * This requires the explicit order of this Aspect to be lower than Transactions Aspect.
+ * <p>
+ * Without the explicit order it uses a PointcutAdvisor to get an order that returns the
+ * hardcoded value that is equal to {@link Integer#MAX_VALUE} and then the order becomes random
+ * <p>
+ * NOTE: Do not use {@link org.springframework.retry.annotation.EnableRetry} if loading this configuration
+ * It will result in registering two cutpoints and doubling our retry attempts.
+ */
+@Configuration
+@EnableAspectJAutoProxy
+public class JdbcRetryConfiguration extends org.springframework.retry.annotation.RetryConfiguration {
+
+    @Override
+    public int getOrder() {
+        return Integer.MAX_VALUE - 1;
+    }
+}

--- a/report-processor/build.gradle
+++ b/report-processor/build.gradle
@@ -38,3 +38,14 @@ dependencies {
     testCompile 'org.springframework.security:spring-security-test'
     testCompile 'com.opencsv:opencsv:4.0'
 }
+
+//TODO: not sure it this is working; need to verify and configure CI
+//This will allow for running of the multithreaded test application
+task runMTTest(type: JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+
+    main = 'org.opentestsystem.rdw.reporting.processor.multithreaded.MultiThreadedApplicationTest'
+
+    description = 'task to run the MultiThreadedApplication test as a separate test app'
+
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
@@ -2,6 +2,9 @@ package org.opentestsystem.rdw.reporting.processor.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.MapDifference.ValueDifference;
+import com.google.common.collect.Maps;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.Report;
@@ -13,8 +16,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,6 +34,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.http.util.TextUtils.isBlank;
 import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.CompletedChunk;
 
@@ -85,6 +92,7 @@ public class JdbcReportRepository implements ReportRepository {
     }
 
     @Override
+    @Transactional
     public Report create(final Report report) {
         final GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
         final int insertCount = this.template.update(create,
@@ -108,10 +116,12 @@ public class JdbcReportRepository implements ReportRepository {
     }
 
     @Override
+    @Transactional
     public Report update(final Report report) {
+        final long reportId = report.getId();
         final int updated = this.template.update(update,
                 new MapSqlParameterSource()
-                        .addValue("id", report.getId())
+                        .addValue("id", reportId)
                         .addValue("user_login", report.getUser())
                         .addValue("status", report.getStatus().id())
                         .addValue("report_resource_uri", uriAsString(report.getReportResourceUri()))
@@ -120,15 +130,18 @@ public class JdbcReportRepository implements ReportRepository {
                         .addValue("created", Timestamp.from(report.getCreated())));
 
         if (updated != 1) {
-            throw new IllegalStateException("Unable to update report: " + report.getId());
+            throw new IllegalStateException("Unable to update report: " + reportId);
         }
 
-        deleteMetadataForReport(report.getId());
-        for (final Map.Entry<String, String> entry : report.getMetadata().entrySet()) {
-            insertMetadataForReport(report.getId(), entry.getKey(), entry.getValue());
-        }
+        final Map<Long, Map<String, String>> metadataByReportId = getMetadataForReports(newArrayList(reportId));
+        final Map<String, String> existingMetadata = metadataByReportId.containsKey(reportId) ? metadataByReportId.get(reportId) : newHashMap();
 
-        return report;
+        final MapDifference<String, String> metadataDiff = Maps.difference(existingMetadata, report.getMetadata());
+
+        executeMetadataForReportChanges(reportId, combineWithRightValue(metadataDiff.entriesOnlyOnLeft(), metadataDiff.entriesDiffering()), deleteMetadataForReport);
+        executeMetadataForReportChanges(reportId, combineWithRightValue(metadataDiff.entriesOnlyOnRight(), metadataDiff.entriesDiffering()), insertMetadataForReport);
+
+        return findById(reportId);
     }
 
     @Override
@@ -166,6 +179,7 @@ public class JdbcReportRepository implements ReportRepository {
     }
 
     @Override
+    @Transactional
     public Report completeChunk(final Report report) {
         final GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
         final int updatedCount = this.template.update(completeChunk,
@@ -182,6 +196,24 @@ public class JdbcReportRepository implements ReportRepository {
                 .build();
     }
 
+    private void executeMetadataForReportChanges(final long reportId, final Map<String, String> valuesByName, final String sql) {
+        if (!valuesByName.isEmpty()) {
+            final List<SqlParameterSource> batchParameters = newArrayList();
+            for (final String name : valuesByName.keySet()) {
+                batchParameters.add(new MapSqlParameterSource("name", name).addValue("value", valuesByName.get(name)).addValue("report_id", reportId));
+            }
+            template.batchUpdate(sql, batchParameters.toArray(new SqlParameterSource[batchParameters.size()]));
+        }
+    }
+
+    private static Map<String, String> combineWithRightValue(final Map<String, String> one, final Map<String, ValueDifference<String>> another) {
+        final Map<String, String> combined = newHashMap(one);
+        for (final String key : another.keySet()) {
+            combined.put(key, another.get(key).rightValue());
+        }
+        return combined;
+    }
+
     private Map<Long, Map<String, String>> getMetadataForReports(final Collection<Long> reportIds) {
         if (reportIds.isEmpty()) return Collections.emptyMap();
 
@@ -192,18 +224,6 @@ public class JdbcReportRepository implements ReportRepository {
                 asReportMetadata(metadata)
         );
         return metadata;
-    }
-
-    private void deleteMetadataForReport(final long reportId) {
-        template.update(deleteMetadataForReport, new MapSqlParameterSource("report_id", reportId));
-    }
-
-    private void insertMetadataForReport(final long reportId, final String name, final String value) {
-        template.update(insertMetadataForReport,
-                new MapSqlParameterSource()
-                        .addValue("report_id", reportId)
-                        .addValue("name", name)
-                        .addValue("value", value));
     }
 
     private String serializeReportRequest(final AbstractExamReportRequest reportRequest) {
@@ -226,16 +246,6 @@ public class JdbcReportRepository implements ReportRepository {
             logger.error("Unable to deserialize report request", e);
             return null;
         }
-    }
-
-    private URI asUri(final String value) {
-        if (isBlank(value)) return null;
-        return URI.create(value);
-    }
-
-    private String uriAsString(final URI value) {
-        if (value == null) return null;
-        return value.toASCIIString();
     }
 
     private List<Report> saturateMetadata(final Collection<Report> reports) {
@@ -269,7 +279,7 @@ public class JdbcReportRepository implements ReportRepository {
                 .build();
     }
 
-    private RowCallbackHandler asReportMetadata(final Map<Long, Map<String, String>> metadata) {
+    private static RowCallbackHandler asReportMetadata(final Map<Long, Map<String, String>> metadata) {
         return (row) -> {
             final Long reportId = row.getLong("report_id");
             final Map<String, String> reportMetadata = metadata.computeIfAbsent(reportId, (id) -> new HashMap<>());
@@ -278,5 +288,15 @@ public class JdbcReportRepository implements ReportRepository {
                     row.getString("value")
             );
         };
+    }
+
+    private static URI asUri(final String value) {
+        if (isBlank(value)) return null;
+        return URI.create(value);
+    }
+
+    private static String uriAsString(final URI value) {
+        if (value == null) return null;
+        return value.toASCIIString();
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepository.java
@@ -99,7 +99,7 @@ public class JdbcReportRepository implements ReportRepository {
                 new MapSqlParameterSource()
                         .addValue("user_login", report.getUser())
                         .addValue("status", report.getStatus().id())
-                        .addValue("report_resource_uri", uriAsString(report.getReportResourceUri()))
+                        .addValue("report_resource_uri", asStringOrNull(report.getReportResourceUri()))
                         .addValue("label", report.getLabel())
                         .addValue("report_request", serializeReportRequest(report.getReportRequest()))
                         .addValue("report_type", report.getReportRequest().getReportTypeDisplayValue())
@@ -124,7 +124,7 @@ public class JdbcReportRepository implements ReportRepository {
                         .addValue("id", reportId)
                         .addValue("user_login", report.getUser())
                         .addValue("status", report.getStatus().id())
-                        .addValue("report_resource_uri", uriAsString(report.getReportResourceUri()))
+                        .addValue("report_resource_uri", asStringOrNull(report.getReportResourceUri()))
                         .addValue("label", report.getLabel())
                         .addValue("report_request", serializeReportRequest(report.getReportRequest()))
                         .addValue("created", Timestamp.from(report.getCreated())));
@@ -202,7 +202,8 @@ public class JdbcReportRepository implements ReportRepository {
             for (final String name : valuesByName.keySet()) {
                 batchParameters.add(new MapSqlParameterSource("name", name).addValue("value", valuesByName.get(name)).addValue("report_id", reportId));
             }
-            template.batchUpdate(sql, batchParameters.toArray(new SqlParameterSource[batchParameters.size()]));
+
+            template.batchUpdate(sql, batchParameters.toArray(new SqlParameterSource[0]));
         }
     }
 
@@ -272,7 +273,7 @@ public class JdbcReportRepository implements ReportRepository {
                 .id(row.getLong("id"))
                 .user(row.getString("user_login"))
                 .status(ReportStatus.valueOf(row.getInt("status")))
-                .reportResourceUri(asUri(row.getString("report_resource_uri")))
+                .reportResourceUri(asUriOrNull(row.getString("report_resource_uri")))
                 .label(row.getString("label"))
                 .reportRequest(deserializeReportRequest(row.getString("report_request")))
                 .created(row.getTimestamp("created").toInstant())
@@ -290,12 +291,12 @@ public class JdbcReportRepository implements ReportRepository {
         };
     }
 
-    private static URI asUri(final String value) {
+    private static URI asUriOrNull(final String value) {
         if (isBlank(value)) return null;
         return URI.create(value);
     }
 
-    private static String uriAsString(final URI value) {
+    private static String asStringOrNull(final URI value) {
         if (value == null) return null;
         return value.toASCIIString();
     }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/ReportRepository.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/repository/ReportRepository.java
@@ -23,11 +23,7 @@ public interface ReportRepository {
      * Save an updated Report record.
      * NOTE:
      * Must have a valid {@link Report#id}
-     * The {@link Report#completeChunkCount} property is not updated by this method.
-     * @see #completeChunk(Report)
-     *
      * @param report A report record
-     * @return The updated report record
      */
     Report update(Report report);
 
@@ -61,12 +57,13 @@ public interface ReportRepository {
      * and return the updated Report instance.
      *
      * @param report A report
-     * @return  The report with updated chunk completion count
+     * @return The report with updated chunk completion count
      */
     Report completeChunk(Report report);
 
     /**
      * Delete reports with the specified ids
+     *
      * @param ids The ids of the reports we wish to delete
      */
     void deleteIds(Collection<Long> ids);

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/DefaultReportService.java
@@ -4,7 +4,6 @@ import org.opentestsystem.rdw.reporting.processor.model.Report;
 import org.opentestsystem.rdw.reporting.processor.repository.ReportRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +23,6 @@ public class DefaultReportService implements ReportService {
     }
 
     @Override
-    @Transactional
     public Report create(final Report report) {
         return reportRepository.create(report);
     }
@@ -45,7 +43,6 @@ public class DefaultReportService implements ReportService {
     }
 
     @Override
-    @Transactional
     public Report update(final Report report) {
         return reportRepository.update(report);
     }
@@ -56,7 +53,6 @@ public class DefaultReportService implements ReportService {
     }
 
     @Override
-    @Transactional
     public Report completeChunk(final Report report) {
         return reportRepository.completeChunk(report);
     }

--- a/report-processor/src/main/resources/application-no-permission.sql.yml
+++ b/report-processor/src/main/resources/application-no-permission.sql.yml
@@ -35,33 +35,33 @@ sql:
 
     findAllOlderThanNumberOfDays: >-
       ${sql.reportProcessor.snippet.selectFromUserReport}
-      where r.created < date_sub(now(), interval :number_of_days day);
+      where r.created < date_sub(now(), interval :number_of_days day)
 
     deleteByIds: >-
-      delete from `user_report` WHERE `id` in (:ids);
+      delete from `user_report` WHERE `id` in (:ids)
 
     completeChunk: >-
       update user_report_metadata
         set value = cast(LAST_INSERT_ID(cast(value as unsigned) + 1) AS CHAR)
       where
         report_id = :report_id and
-        name = 'completed_chunk_count';
+        name = 'completed_chunk_count'
 
     insertMetadataForReport: >-
       insert into user_report_metadata
         (report_id, name, value)
         values
-        (:report_id, :name, :value);
+        (:report_id, :name, :value)
 
     deleteMetadataForReport: >-
       delete from user_report_metadata
       where
-        report_id = :report_id;
+        report_id = :report_id
 
     findMetadataForReports: >-
       select * from user_report_metadata
       where
-        report_id IN (:report_ids);
+        report_id IN (:report_ids)
 
   reportProcessor:
     snippet:

--- a/report-processor/src/main/resources/application.yml
+++ b/report-processor/src/main/resources/application.yml
@@ -94,6 +94,7 @@ spring:
       ?useSSL=${spring.datasource.use-ssl:false}\
       &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
+      &rewriteBatchedStatements=${spring.reporting_datasource.rewrite-batched-statements:true}\
       "
     username: root
     password:

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedApplicationTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedApplicationTest.java
@@ -1,0 +1,75 @@
+package org.opentestsystem.rdw.reporting.processor.multithreaded;
+
+import org.opentestsystem.rdw.reporting.common.repository.DataSourceConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * A console application that runs all available {@link MultiThreadedTest}s
+ * The exist status 0 indicates a success.
+ * The exist status > 0 indicates a number of failed tests
+ */
+@ComponentScan({
+        "org.opentestsystem.rdw.reporting.processor.model.jackson",
+        "org.opentestsystem.rdw.reporting.processor.model",
+        "org.opentestsystem.rdw.reporting.processor.repository",
+        "org.opentestsystem.rdw.reporting.processor.repository.impl",
+        "org.opentestsystem.rdw.reporting.common.model",
+        "org.opentestsystem.rdw.reporting.common.repository",
+        "org.opentestsystem.rdw.reporting.common.jdbc",
+        "org.opentestsystem.rdw.reporting.processor.multithreaded"
+})
+@Import({YamlPropertiesConfigurator.class,
+        DataSourceAutoConfiguration.class,
+        JdbcTemplateAutoConfiguration.class,
+        DataSourceConfiguration.class,
+        MultiThreadedTestConfiguration.class})
+@EnableTransactionManagement
+public class MultiThreadedApplicationTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedApplicationTest.class);
+    private final static int TestThreadCount = 10;
+    private final static int expectedTests = 1;
+
+    public static void main(final String[] args) throws Exception {
+        final ConfigurableApplicationContext ctx =
+                new SpringApplicationBuilder(MultiThreadedApplicationTest.class)
+                        .profiles("test", "mtTest")
+                        .web(false)
+                        .run(args);
+
+        final List<Integer> failed = newArrayList();
+        final String[] beans = ctx.getBeanNamesForType(MultiThreadedTest.class);
+
+        if (beans.length != expectedTests) {
+            logger.error("Found {} beans, expected {}", beans.length, expectedTests);
+            System.exit(1);
+        }
+
+        final ExecutorService pool = Executors.newFixedThreadPool(TestThreadCount);
+        for (int i = 0; i < 20; i++) {
+            for (final String test : beans) {
+                logger.info("Running test for [" + test + "] with thread count =" + TestThreadCount);
+                final boolean passed = ctx.getBean(test, MultiThreadedTest.class).run(pool, TestThreadCount);
+                logger.info(test + " " + (passed ? "passed" : "failed"));
+
+                failed.add(passed ? 0 : 1);
+            }
+        }
+
+        System.exit(failed.stream().mapToInt(Integer::intValue).sum());
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedReportRepository.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedReportRepository.java
@@ -1,0 +1,58 @@
+package org.opentestsystem.rdw.reporting.processor.multithreaded;
+
+import com.google.common.collect.Lists;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.processor.model.Report;
+import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
+import org.opentestsystem.rdw.reporting.processor.repository.ReportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+@Profile("mtTest")
+@Component
+public class MultiThreadedReportRepository extends MultiThreadedTest {
+    @Autowired
+    private ReportRepository repository;
+
+    @Override
+    protected void work() {
+        final Report report = repository.update(
+                repository.update(
+                        repository.create(Report.builder()
+                                .user("test")
+                                .status(ReportStatus.RUNNING)
+                                .reportRequest(SchoolGradeExamReportRequest.builder()
+                                        .schoolId(123)
+                                        .gradeId(3)
+                                        .build())
+                                .created(Instant.now())
+                                .label("label")
+                                .build()
+                        ).copy()
+                                .metadata("completed_chunk_count", "0")
+                                .metadata("some other name", "value")
+                                .build()
+                ).copy()
+                        .metadata("new value", "0")
+                        .metadata("completed_chunk_count", "0")
+                        .build());
+        repository.completeChunk(report);
+    }
+
+    @Override
+    protected void cleanUp() {
+        final List<String> sqls = newArrayList(
+                "DELETE FROM user_report_metadata",
+                "DELETE FROM user_report"
+        );
+        for (final String sql : Lists.reverse(sqls)) {
+            getJdbcTemplate().getJdbcOperations().execute(sql);
+        }
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTest.java
@@ -1,0 +1,80 @@
+package org.opentestsystem.rdw.reporting.processor.multithreaded;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * A base class for running multi-threaded testing involving jdbc
+ */
+public abstract class MultiThreadedTest {
+    protected static final Logger logger = LoggerFactory.getLogger(MultiThreadedTest.class);
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    protected volatile boolean passed = true;
+
+    public NamedParameterJdbcTemplate getJdbcTemplate() {
+        return jdbcTemplate;
+    }
+
+    /**
+     * Hook to prepare the test data if needed; base class does nothing
+     */
+    protected void before() {
+    }
+
+    /**
+     * Each test must provide an implementation of the work done during the test
+     */
+    protected abstract void work();
+
+    /**
+     * Hook to teardown the test; base class does nothing
+     */
+    protected void after() {
+    }
+
+    /**
+     * A multithreaded test runner
+     *
+     * @return a flag indicating a pass or fail
+     */
+    public boolean run(final ExecutorService pool, final int threadCount) throws InterruptedException {
+        before();
+
+        final Runnable test = newRunnable();
+        final List<Callable<Object>> tasks = newArrayList();
+        for (int i = 0; i < threadCount; i++) {
+            tasks.add(Executors.callable(test));
+        }
+        pool.invokeAll(tasks);
+
+        after();
+        cleanUp();
+        return passed;
+    }
+
+    protected Runnable newRunnable() {
+        return () -> {
+            try {
+                work();
+            } catch (final Exception ex) {
+                logger.error(this.getClass().getSimpleName() + ": " + ex.getMessage());
+                passed = false;
+            }
+        };
+    }
+
+    protected void cleanUp() {
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTestConfiguration.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTestConfiguration.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.reporting.processor.multithreaded;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+@Configuration
+public class MultiThreadedTestConfiguration {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTestDataSourceConfiguration.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/multithreaded/MultiThreadedTestDataSourceConfiguration.java
@@ -1,0 +1,21 @@
+package org.opentestsystem.rdw.reporting.processor.multithreaded;
+
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+public class MultiThreadedTestDataSourceConfiguration {
+
+    @Bean
+    public PlatformTransactionManager txManager(@Qualifier("dataSource") final DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
@@ -38,7 +38,7 @@ import static org.opentestsystem.rdw.reporting.processor.stream.FetchStudents.To
 public class JdbcReportRepositoryIT {
 
     @Autowired
-    private JdbcReportRepository repository;
+    private ReportRepository repository;
 
     @Autowired
     private NamedParameterJdbcTemplate template;

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcReportRepositoryIT.java
@@ -58,7 +58,7 @@ public class JdbcReportRepositoryIT {
         assertThat(inserted.getReportRequest().getSchoolYear()).isEqualTo(report.getReportRequest().getSchoolYear());
 
         final String reportType = template.queryForObject(
-                "SELECT report_type FROM user_report where id = :id",
+                "SELECT report_type FROM user_report WHERE id = :id",
                 new MapSqlParameterSource("id", inserted.getId()),
                 String.class);
         assertThat(reportType).isEqualTo(report.getReportRequest().getReportTypeDisplayValue());
@@ -225,14 +225,14 @@ public class JdbcReportRepositoryIT {
         original.getMetadata().put("some_metadata", "some_value");
         repository.update(original);
 
-        int metadataCount = template.queryForObject("SELECT count(*) from user_report_metadata",
+        int metadataCount = template.queryForObject("SELECT count(*) FROM user_report_metadata",
                 new MapSqlParameterSource(),
                 Integer.class);
         assertThat(metadataCount).isEqualTo(1);
 
         repository.deleteIds(Collections.singleton(original.getId()));
 
-        metadataCount = template.queryForObject("SELECT count(*) from user_report_metadata",
+        metadataCount = template.queryForObject("SELECT count(*) FROM user_report_metadata",
                 new MapSqlParameterSource(),
                 Integer.class);
         assertThat(metadataCount).isEqualTo(0);


### PR DESCRIPTION
I had a few versions of _smart_ explanations, but in short - I really do not know. Based on my explanations, this should still require a retry - but it works without it. 

And yes, I was able to concisely reproduce the error before this change. Both @malaffoon and @wtritch are my witnesses. 

I liked this overview: https://www.percona.com/blog/2012/03/27/innodbs-gap-locks/

The main idea I got is: _avoid multiple 'insert/delete' calls within the same transaction IF/WHEN there are could be concurrent calls that do the same on the index that has values close by_. But this is a very *vague* idea. 

And here is the error we are seeing in production:
```
------------------------
LATEST DETECTED DEADLOCK
------------------------
2018-03-16 21:37:02 2abe8244e700
*** (1) TRANSACTION:
TRANSACTION 263651458, ACTIVE 0 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 5 lock struct(s), heap size 376, 3 row lock(s)
MySQL thread id 138758, OS thread handle 0x2ab33a708700, query id 211233202 10.3.101.158 rdw-reporting update
insert into user_report_metadata
  (report_id, name, value)
  values
  (22338, 'completed_chunk_count', '0')
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2189911 page no 86 n bits 1 index `PRIMARY` of table `reporting`.`user_report_metadata` trx id 263651458 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len=8; bufptr=0x2ab3ef9a4070; hex= 73757072656d756d; asc supremum;;

*** (2) TRANSACTION:
TRANSACTION 263651465, ACTIVE 0 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 5 lock struct(s), heap size 376, 3 row lock(s)
MySQL thread id 138730, OS thread handle 0x2ab5dfa82700, query id 211233201 10.3.38.201 rdw-reporting update
insert into user_report_metadata
  (report_id, name, value)
  values
  (22339, 'completed_chunk_count', '0')
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 2189911 page no 86 n bits 1 index `PRIMARY` of table `reporting`.`user_report_metadata` trx id 263651465 lock_mode X
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len=8; bufptr=0x2ab3ef9a4070; hex= 73757072656d756d; asc supremum;;

*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2189911 page no 86 n bits 1 index `PRIMARY` of table `reporting`.`user_report_metadata` trx id 263651465 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len=8; bufptr=0x2ab3ef9a4070; hex= 73757072656d756d; asc supremum;;
```