### PR TITLE
summative report repo integration test

### DIFF
--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
@@ -73,11 +73,11 @@ public class JdbcIcaSummativeReportRepositoryIT {
 
         assertThat(reports).hasSize(2);
         assertThat(reports.get(-1L)).hasSize(2);
-        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
-        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubjectCode()).isEqualTo(ELA.code());
 
         assertThat(reports.get(-2L)).hasSize(2);
-        assertThat(reports.get(-2L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+        assertThat(reports.get(-2L).get(ELA).getAssessment().getSubjectCode()).isEqualTo(ELA.code());
     }
 
     @Test
@@ -143,8 +143,8 @@ public class JdbcIcaSummativeReportRepositoryIT {
 
         assertThat(reports).hasSize(1);
         assertThat(reports.get(-1L)).hasSize(2);
-        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
-        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubjectCode()).isEqualTo(ELA.code());
     }
 
     @Test
@@ -219,8 +219,8 @@ public class JdbcIcaSummativeReportRepositoryIT {
 
         assertThat(reports).hasSize(1);
         assertThat(reports.get(-1L)).hasSize(2);
-        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
-        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubjectCode()).isEqualTo(ELA.code());
     }
 
     @Test
@@ -276,8 +276,8 @@ public class JdbcIcaSummativeReportRepositoryIT {
 
         assertThat(reports).hasSize(1);
         assertThat(reports.get(-1L)).hasSize(2);
-        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubject()).isEqualTo(MATH);
-        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+        assertThat(reports.get(-1L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
+        assertThat(reports.get(-1L).get(ELA).getAssessment().getSubjectCode()).isEqualTo(ELA.code());
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
@@ -148,6 +148,25 @@ public class JdbcIcaSummativeReportRepositoryIT {
     }
 
     @Test
+    public void itShouldFindAllSummativeReportsForStudentsByGroup() {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .groupId(-40L)
+                .schoolYear(1997)
+                .queryPermissionType(Group)
+                .gradeId(-1)
+                .assessmentTypeCode("sum")
+                .build();
+        final Map<Long, Map<Subject, IcaSummativeReport>> reports = repository.findAllForStudentsByExamFilter(
+                group(statewide()),
+                of(-1L, -2L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-2L)).hasSize(1);
+        assertThat(reports.get(-2L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
+    }
+
+    @Test
     public void itShouldNotFindAllIcaReportsForStudentsByGroupForUserWithoutGroupAccess() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
                 .groupId(-30L)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
@@ -44,7 +44,7 @@ import static org.opentestsystem.rdw.reporting.processor.test.support.UserTestBu
 @ContextConfiguration(classes = {ITDataSourceConfiguration.class, JdbcIcaSummativeReportRepository.class})
 @Sql(scripts = {"classpath:integration-test-data.sql"})
 @ActiveProfiles("test")
-public class JdbcIcaReportRepositoryIT {
+public class JdbcIcaSummativeReportRepositoryIT {
 
     @Autowired
     private ReportingSystemSettings systemSettings;
@@ -78,6 +78,25 @@ public class JdbcIcaReportRepositoryIT {
 
         assertThat(reports.get(-2L)).hasSize(2);
         assertThat(reports.get(-2L).get(ELA).getAssessment().getSubject()).isEqualTo(ELA);
+    }
+
+    @Test
+    public void itShouldFindAllSummativeReportsForStudentsBySchoolAndYear() {
+        final ExamQueryParams examQueryParams = ExamQueryParams.builder()
+                .schoolId(-10L)
+                .schoolYear(1997)
+                .queryPermissionType(Individual)
+                .gradeId(-1)
+                .assessmentTypeCode("sum")
+                .build();
+        final Map<Long, Map<Subject, IcaSummativeReport>> reports = repository.findAllForStudentsByExamFilter(
+                individual(statewide()),
+                of(-1L, -2L),
+                examQueryParams);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(-2L)).hasSize(1);
+        assertThat(reports.get(-2L).get(MATH).getAssessment().getSubjectCode()).isEqualTo(MATH.code());
     }
 
     @Test

--- a/report-processor/src/test/resources/integration-test-data.sql
+++ b/report-processor/src/test/resources/integration-test-data.sql
@@ -40,7 +40,8 @@ insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, sch
   (-4, 2, 'iab3', -1, 'g1', 1, 1995, 'iab3', 'iab3', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
   (-5, 1, 'ica2', -1, 'g1', 2, 1997, 'ica2', 'ica2', 'v1', 'ica_claim1', 'ica_claim2', 'ica_claim3', 'ica_claim4', 100, 200, 300, 400, 500, -1, '1997-07-18 20:14:34.000000', -1),
   (-6, 2, 'iab4', -1, 'g1', 2, 1997, 'iab2', 'iab4', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
-  (-7, 2, 'iab5', -1, 'g1', 2, 1997, 'iab3', 'iab5', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1);
+  (-7, 2, 'iab5', -1, 'g1', 2, 1997, 'iab3', 'iab5', 'v1', null, null, null, null, 1, null, 2, null, 3, -1, '1997-07-18 20:14:34.000000', -1),
+  (-8, 3, 'sum1', -1, 'g1', 1, 1997, 'sum1', 'sum1', 'v1', 'ica_claim1', 'ica_claim2', 'ica_claim3', 'ica_claim4', 100, 200, 300, 400, 500, -1, '1997-07-18 20:14:34.000000', -1);
 
 -- mean values are intentionally unique here, the test relies on it
 INSERT INTO percentile (id, asmt_id, start_date, end_date, count, mean, standard_deviation, min_score, max_score, update_import_id, updated, migrate_id) VALUES
@@ -117,7 +118,7 @@ insert into exam (id, type_id, grade_id, grade_code, student_id, school_id, oppo
   (-15, 1, -1, 'g1', -2, -10, 0, null, 0, 0, 0, 0, 1997, -1, 'v1', 'Complete', 'Valid', 'session2', 2000, 20, 1, '2016-01-01 00:00:00.000000', 1, 100, 10, 2, 200, 20, 3, 300, 30, 4, 400, 40, null, 'EO', null, -1, '1997-07-18 20:14:34.000000', -1),
   (-16, 2, -2, 'g2', -2, -10, 1, null, 0, 0, 0, 0, 1997, -2, 'v1', 'Complete', 'Valid', 'session3', 2100, 21, 2, '1997-01-01 00:00:00.000000', null, null, null, null, null, null, null, null, null, null, null, null, null, 'EO', null, -1, '1997-07-18 20:14:34.000000', -1),
   (-17, 2, -2, 'g2', -2, -11, 1, null, 0, 1, 0, 0, 1997, -2, 'v1', 'Complete', 'Valid', 'session3', 2100, 21, 2, '1997-01-01 00:00:00.000000', null, null, null, null, null, null, null, null, null, null, null, null, 'TDS_BT_UCT|NEA0|NEA_Abacus', 'RFEP', '1996-08-01', -1, '1997-07-18 20:14:34.000000', -1),
-  (-18, 2, -2, 'g2', -2, -12, 1, null, 0, 0, 0, 0, 1997, -2, 'v1', 'Complete', 'Valid', 'session3', 2100, 21, 2, '1997-01-01 00:00:00.000000', null, null, null, null, null, null, null, null, null, null, null, null, null, 'EO', null, -1, '1997-07-18 20:14:34.000000', -1);
+  (-18, 3, -2, 'g2', -2, -10, 0, null, 0, 0, 0, 0, 1997, -8, 'v1', 'Complete', 'Valid', 'session12', 2000, 20, 1, '1997-01-01 00:00:00.000000', 1, 100, 10, 2, 200, 20, 3, 300, 30, 4, 400, 40, null, 'EO', null, -1, '1997-07-18 20:14:34.000000', -1);
 
 -- groups
 insert into student_group (id, name, school_id, school_year, subject_id, update_import_id, updated, migrate_id) values

--- a/report-processor/src/test/resources/integration-test-data.sql
+++ b/report-processor/src/test/resources/integration-test-data.sql
@@ -124,17 +124,20 @@ insert into exam (id, type_id, grade_id, grade_code, student_id, school_id, oppo
 insert into student_group (id, name, school_id, school_year, subject_id, update_import_id, updated, migrate_id) values
   (-10, 'group1', -10, 1997, 1, -1, '1997-07-18 20:14:34.000000', -1),
   (-20, 'group2', -10, 1997, null, -1, '1997-07-18 20:14:34.000000', -1),
-  (-30, 'group3', -10, 1997, null, -1, '1997-07-18 20:14:34.000000', -1);
+  (-30, 'group3', -10, 1997, null, -1, '1997-07-18 20:14:34.000000', -1),
+  (-40, 'group4', -10, 1997, null, -1, '1997-07-18 20:14:34.000000', -1);
 
 insert into student_group_membership (student_group_id, student_id) values
   (-10, -1),
   (-20, -1),
-  (-30, -1);
+  (-30, -1),
+  (-40, -2);
 
 insert into user_student_group(student_group_id, user_login) values
-   (-10, 'someone@somewhere.com'),
-   (-20, 'someone@somewhere.com'),
-   (-30, 'someoneelse@somewhere.com');
+  (-10, 'someone@somewhere.com'),
+  (-20, 'someone@somewhere.com'),
+  (-30, 'someoneelse@somewhere.com'),
+  (-40, 'someone@somewhere.com');
 
 insert into ethnicity (id, code) values
   (8, 'Filipino');


### PR DESCRIPTION
In previous PR, I updated the shared SQL that existed to take in a type_id instead of hard-coding 1 like it did before for ICA.  So the new logic is setting that type_id appropriately.  

Am I being lazy to just add the one test that checks to see if it gets back the summative appropriately?  Opinion: should I be adding an equivalent Summative version for each of the ICA tests that is currently there for each of the 10 ICA tests?