### PR TITLE
handle loading of all the initial exams as a forkJoin so that the ini…

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -187,8 +187,12 @@
 </ng-container>
 
 <!-- No Results Error -->
-<div class="alert alert-info" *ngIf="assessmentExams.length == 0 || hideAssessments">
+<div class="alert alert-info" *ngIf="(!loadingInitialResults && assessmentExams.length == 0) || hideAssessments">
   {{'common.assessments.no-results-found' | translate}}
+</div>
+
+<div class="alert alert-info" *ngIf="loadingInitialResults && assessmentExams.length == 0">
+  <i class="fa fa-spinner fa-pulse fa-2x"></i> {{'common.messages.loading' | translate}}
 </div>
 
 <div class="fab">


### PR DESCRIPTION
…tial selected assessments list always includes all of them since it waits for them to all load

Wanted to get some thoughts on the approach to fixing https://jira.fairwaytech.com/browse/DWR-1776

When the user pre-selects assessments on the IAB Dashboard and passes those IDs to the group results page, we take the IDs and iterate over them to get the results for each assessment.  Because of that, there are cases where it displays the Selected Assessments on the page before all of the exam data is back so it will list 2 out of the 3 selected ones there.

I saw 2 approaches: 1) every time we get a API call back with exam results specifically trigger redrawing the list of selected assessments or 2) wait until we get all of the results back and use a forkJoin to basically tell the user we are Loading results until they are all received.

While option 1 is probably simpler, I went with 2 because it feels like it might be confusing if we start getting results and sorting them on the results and the selected list it seems like it might be confusing.  It feels like if the user specifically selected 4 assessments they will want to see those when the page loads.

But I'm not sold on it and could be convinced otherwise.