### PR TITLE
Update longitudinal chart sizes so it fits when the table is not wide…

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
@@ -105,8 +105,8 @@ export class LongitudinalCohortChartComponent implements OnInit {
   private _chart: LongitudinalCohortChart;
   private _chartView: ChartView;
   private _display: ChartDisplay = {
-    outerWidth: 910,
-    outerHeight: 480,
+    outerWidth: 840,
+    outerHeight: 470,
     margin: { top: 0, right: 0, bottom: 0, left: 0 },
     padding: { top: 0, right: 150, bottom: 40, left: 40 },
     domainMargin: { top: 25, right: 0.25, bottom: 25, left: 0.25 },

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -946,7 +946,7 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
 
 .chart-series-legend {
   overflow-y: auto;
-  max-width: 325px;
+  max-width: 240px;
 
   &.pallet-a {
     .chart-series,


### PR DESCRIPTION
…r than the main area.

in my tests having the width of the table shrunk to fit in the main area without going wider

![image](https://user-images.githubusercontent.com/341584/40333527-c29b0ec6-5d0d-11e8-811e-fd9e244d7b6e.png)
