### PR TITLE
handle null assessment type when generating ICA and Summative student…

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParams.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParams.java
@@ -106,6 +106,19 @@ public class ExamQueryParams {
             return examQueryParams;
         }
 
+        public Builder copy(final ExamQueryParams examQueryParams) {
+            subjectCode(examQueryParams.subjectCode);
+            assessmentTypeCode(examQueryParams.assessmentTypeCode);
+            schoolId(examQueryParams.schoolId);
+            gradeId(examQueryParams.gradeId);
+            groupId(examQueryParams.groupId);
+            schoolYear(examQueryParams.schoolYear);
+            studentId(examQueryParams.studentId);
+            queryPermissionType(examQueryParams.queryPermissionType);
+            disableTransferAccess(examQueryParams.disableTransferAccess);
+            return this;
+        }
+
         public Builder subjectCode(final String subjectCode) {
             this.subjectCode = subjectCode;
             return this;

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.stream;
 
 import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
 import org.opentestsystem.rdw.reporting.common.model.Student;
@@ -123,13 +124,13 @@ public class StudentReportProcessor {
 
         final ExamQueryParams queryParams = getQueryParams(payload.getReportId(), report.getReportRequest());
 
-        if (includeReports("iab", queryParams)) {
+        if (includeReports(AssessmentType.IAB.code(), queryParams)) {
             appendIABReports(studentReports, user, studentReports.keySet(), queryParams);
         }
-        if (includeReports("ica", queryParams)) {
+        if (includeReports(AssessmentType.ICA.code(), queryParams)) {
             appendICAReports(studentReports, user, studentReports.keySet(), queryParams);
         }
-        if (includeReports("sum", queryParams)) {
+        if (includeReports(AssessmentType.SUMMATIVE.code(), queryParams)) {
             appendSummativeReports(studentReports, user, studentReports.keySet(), queryParams);
         }
 
@@ -190,13 +191,11 @@ public class StudentReportProcessor {
                         examQueryParams);
 
 
-        iabReports.forEach((key, value) -> compositeReports.computeIfPresent(key, (id, compositeReport) -> {
-                    return StudentCompositeReport.builder()
-                            .copy(compositeReport)
-                            .iabEla(value.get(ELA))
-                            .iabMath(value.get(MATH))
-                            .build();
-                }
+        iabReports.forEach((key, value) -> compositeReports.computeIfPresent(key, (id, compositeReport) -> StudentCompositeReport.builder()
+                .copy(compositeReport)
+                .iabEla(value.get(ELA))
+                .iabMath(value.get(MATH))
+                .build()
 
         ));
     }
@@ -205,11 +204,16 @@ public class StudentReportProcessor {
                                   final User user,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
+        ExamQueryParams icaQueryParams = ExamQueryParams.builder()
+                .copy(examQueryParams)
+                .assessmentTypeCode(AssessmentType.ICA.code())
+                .build();
+
         final Map<Long, Map<Subject, IcaSummativeReport>> icaReports = icaSummativeReportRepository
                 .findAllForStudentsByExamFilter(
                         user,
                         studentIds,
-                        examQueryParams);
+                        icaQueryParams);
 
         icaReports.forEach((key, value) -> compositeReports.computeIfPresent(key, (id, compositeReport) -> StudentCompositeReport.builder()
                 .copy(compositeReport)
@@ -223,11 +227,16 @@ public class StudentReportProcessor {
                                   final User user,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
+        ExamQueryParams sumQueryParams = ExamQueryParams.builder()
+                .copy(examQueryParams)
+                .assessmentTypeCode(AssessmentType.SUMMATIVE.code())
+                .build();
+
         final Map<Long, Map<Subject, IcaSummativeReport>> summativeReports = icaSummativeReportRepository
                 .findAllForStudentsByExamFilter(
                         user,
                         studentIds,
-                        examQueryParams);
+                        sumQueryParams);
 
         summativeReports.forEach((key, value) -> compositeReports.computeIfPresent(key, (id, compositeReport) -> StudentCompositeReport.builder()
                 .copy(compositeReport)

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -204,7 +204,7 @@ public class StudentReportProcessor {
                                   final User user,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
-        ExamQueryParams icaQueryParams = ExamQueryParams.builder()
+        final ExamQueryParams icaQueryParams = ExamQueryParams.builder()
                 .copy(examQueryParams)
                 .assessmentTypeCode(AssessmentType.ICA.code())
                 .build();
@@ -227,7 +227,7 @@ public class StudentReportProcessor {
                                   final User user,
                                   final Collection<Long> studentIds,
                                   final ExamQueryParams examQueryParams) {
-        ExamQueryParams sumQueryParams = ExamQueryParams.builder()
+        final ExamQueryParams sumQueryParams = ExamQueryParams.builder()
                 .copy(examQueryParams)
                 .assessmentTypeCode(AssessmentType.SUMMATIVE.code())
                 .build();

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParamsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParamsTest.java
@@ -1,0 +1,25 @@
+package org.opentestsystem.rdw.reporting.processor.model;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExamQueryParamsTest {
+    @Test
+    public void itShouldCopyFromExisting() {
+        ExamQueryParams examQueryParams1 = ExamQueryParams.builder()
+                .subjectCode("sub1")
+                .assessmentTypeCode("type1")
+                .schoolId(1L)
+                .gradeId(1)
+                .groupId(1L)
+                .schoolYear(1)
+                .studentId(1L)
+                .queryPermissionType(ExamQueryParams.PermissionType.Group)
+                .disableTransferAccess(true)
+                .build();
+        ExamQueryParams examQueryParams2 = ExamQueryParams.builder().copy(examQueryParams1).build();
+
+        assertThat(examQueryParams1).isEqualToComparingFieldByField(examQueryParams2);
+    }
+}

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
@@ -53,10 +53,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -332,10 +332,14 @@ public class StudentReportProcessorTest {
 
     @Test
     public void itShouldHandleNullAssessmentTypeWhenGeneratingStudentChunk() {
-        when(icaReportRepository.findAllForStudentsByExamFilter(any(User.class), anyCollection(), argThat(p -> p.getAssessmentTypeCode() == null)))
-                .thenThrow(IllegalArgumentException.class);
-
         writer.generateStudentChunkReport(message);
+
+        verify(icaReportRepository, times(2)).findAllForStudentsByExamFilter(
+                any(User.class),
+                anyCollection(),
+                examFilterCaptor.capture()
+        );
+        assertThat(examFilterCaptor.getValue().getAssessmentTypeCode()).isNotBlank();
     }
 
     private ExamQueryParamsParser accepting() {

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
@@ -8,7 +8,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.stream.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
@@ -54,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -160,9 +160,9 @@ public class StudentReportProcessorTest {
             return callback.doWithRetry(mock(RetryContext.class));
         }).when(retryTemplate).execute(any(), any(), any());
 
-        final byte[] pdfConetnt = "pdfContent".getBytes();
+        final byte[] pdfContent = "pdfContent".getBytes();
         when(htmlToPdfProcessor.process(eq(htmlContent), eq(printOptions)))
-                .thenAnswer(invocation -> new ByteArrayInputStream(pdfConetnt));
+                .thenAnswer(invocation -> new ByteArrayInputStream(pdfContent));
 
         when(messageSecurityService.getUser(any(Message.class))).thenReturn(user);
 
@@ -328,6 +328,14 @@ public class StudentReportProcessorTest {
         writer.generateStudentChunkReport(message);
 
         verify(temporaryStorage).writeChunk(eq(payload.getReportId()), eq(0), any(InputStream.class));
+    }
+
+    @Test
+    public void itShouldHandleNullAssessmentTypeWhenGeneratingStudentChunk() {
+        when(icaReportRepository.findAllForStudentsByExamFilter(any(User.class), anyCollection(), argThat(p -> p.getAssessmentTypeCode() == null)))
+                .thenThrow(IllegalArgumentException.class);
+
+        writer.generateStudentChunkReport(message);
     }
 
     private ExamQueryParamsParser accepting() {


### PR DESCRIPTION
… chunk reports

The problem was that the ExamQueryParams has a null assessment type when generating a student report for all types and now those queries need to have a type_id passed in.  We know the type when we are querying so we can add it easily before. 

Having issues with mockito that I could use some suggestions on, see below for more details.