### PR TITLE
Fix aggregate sample org generation to place generated schools under …

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-table-data.service.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-table-data.service.ts
@@ -198,7 +198,7 @@ export class AggregateReportTableDataService {
 
       if (settings.schools.length >= schoolId
         || ((settings.districts.length || settings.includeAllDistricts) && settings.includeAllSchoolsOfSelectedDistricts)) {
-        organizations.push(this.createSampleSchool(schoolId++));
+        organizations.push(this.createSampleSchool(schoolId++, districtId - 1));
       }
     }
 
@@ -218,11 +218,11 @@ export class AggregateReportTableDataService {
     return district;
   }
 
-  private createSampleSchool(id: number): School {
+  private createSampleSchool(id: number, districtId: number): School {
     const school = new DefaultSchool();
     school.id = id;
     school.name = this.translate.instant('sample-aggregate-table-data-service.school-name', { id: id });
-    school.districtId = id;
+    school.districtId = districtId;
     return school;
   }
 


### PR DESCRIPTION
…generated districts

The issue was that we were generating 1 district and 2 schools, each with it's own districtId.  This change just binds schools to the "last-generated" district so that we end up with hierarchical generated data.