### PR TITLE
Refactored the way we retrieve students ethnicity.

### DIFF
--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractExamRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractExamRepository.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.reporting.exam;
 
-import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.jdbc.Exams;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.jdbc.StudentContexts;
@@ -8,20 +7,18 @@ import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.model.Student;
 import org.opentestsystem.rdw.reporting.common.model.StudentContext;
 import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
-import org.springframework.beans.factory.annotation.Value;
+import org.opentestsystem.rdw.reporting.student.StudentEthnicityRepository;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.validation.constraints.NotNull;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
 public abstract class AbstractExamRepository<T extends AbstractExamSearch> implements ExamRepository<T> {
@@ -29,17 +26,17 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
     private final NamedParameterJdbcTemplate template;
     private final SecurityParameterProvider securityParameterProvider;
     private final String findAllForAssessmentQuery;
-
-    @Value("${sql.ethnicity.findEthnicityCodesByStudentIds}")
-    private String findEthnicityCodesByStudentIdsQuery;
+    private final StudentEthnicityRepository ethnicityRepository;
 
     protected AbstractExamRepository(
             @NotNull final NamedParameterJdbcTemplate template,
             @NotNull final SecurityParameterProvider securityParameterProvider,
-            @NotNull final String findAllForAssessmentQuery) {
+            @NotNull final String findAllForAssessmentQuery,
+            @NotNull final StudentEthnicityRepository ethnicityRepository) {
         this.template = template;
         this.securityParameterProvider = securityParameterProvider;
         this.findAllForAssessmentQuery = findAllForAssessmentQuery;
+        this.ethnicityRepository = ethnicityRepository;
     }
 
     abstract protected Map<String, Object> getParameters(final T search);
@@ -72,7 +69,7 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
             studentIds.add(resultSet.getLong("student_id"));
         }
 
-        final Map<Long, Set<String>> ethnicityCodesByStudentId = findEthnicityCodesForStudentIds(studentIds);
+        final Map<Long, Set<String>> ethnicityCodesByStudentId = ethnicityRepository.findEthnicityCodesByStudentIds(studentIds);
 
         resultSet.beforeFirst();
         for (int i = 0; resultSet.next(); i++) {
@@ -94,25 +91,5 @@ public abstract class AbstractExamRepository<T extends AbstractExamSearch> imple
         return exams;
     }
 
-    private Map<Long, Set<String>> findEthnicityCodesForStudentIds(final Collection<Long> studentIds) {
-        if (studentIds == null || studentIds.isEmpty()) {
-            return ImmutableMap.of();
-        }
-        final Map<Long, Set<String>> ethnicityCodesByStudentId = newHashMap();
-        template.query(
-                findEthnicityCodesByStudentIdsQuery,
-                new MapSqlParameterSource("student_ids", studentIds),
-                row -> {
-                    final long studentId = row.getLong("student_id");
-                    final String ethnicityCode = row.getString("ethnicity_code");
 
-                    final Set<String> studentEthnicityCodes = ethnicityCodesByStudentId.get(studentId);
-                    if (studentEthnicityCodes == null) {
-                        ethnicityCodesByStudentId.put(studentId, newHashSet(ethnicityCode));
-                    } else {
-                        studentEthnicityCodes.add(ethnicityCode);
-                    }
-                });
-        return ethnicityCodesByStudentId;
-    }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepository.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.exam.group;
 
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.exam.AbstractExamRepository;
+import org.opentestsystem.rdw.reporting.student.StudentEthnicityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -17,8 +18,9 @@ class JdbcGroupExamRepository extends AbstractExamRepository<GroupExamSearch> im
     JdbcGroupExamRepository(
             final NamedParameterJdbcTemplate template,
             final SecurityParameterProvider securityParameterProvider,
+            final StudentEthnicityRepository ethnicityRepository,
             @Value("${sql.group.exam.findAllForAssessment}") final String findAllForAssessmentQuery) {
-        super(template, securityParameterProvider, findAllForAssessmentQuery);
+        super(template, securityParameterProvider, findAllForAssessmentQuery, ethnicityRepository);
     }
 
     @Override

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeExamRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeExamRepository.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.exam.schoolgrade;
 import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.exam.AbstractExamRepository;
+import org.opentestsystem.rdw.reporting.student.StudentEthnicityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -17,8 +18,9 @@ class JdbcSchoolGradeExamRepository extends AbstractExamRepository<SchoolGradeEx
     JdbcSchoolGradeExamRepository(
             final NamedParameterJdbcTemplate template,
             final SecurityParameterProvider securityParameterProvider,
+            final StudentEthnicityRepository ethnicityRepository,
             @Value("${sql.schoolgrade.exam.findAllForAssessment}") final String findAllForAssessmentQuery) {
-        super(template, securityParameterProvider, findAllForAssessmentQuery);
+        super(template, securityParameterProvider, findAllForAssessmentQuery, ethnicityRepository);
     }
 
     @Override

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
@@ -1,0 +1,50 @@
+package org.opentestsystem.rdw.reporting.student;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Sets.newHashSet;
+
+@Repository
+public class JdbcStudentEthnicityRepository implements StudentEthnicityRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.ethnicity.findEthnicityCodesByStudentIds}")
+    private String findEthnicityCodesByStudentIdsQuery;
+
+    JdbcStudentEthnicityRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public Map<Long, Set<String>> findEthnicityCodesByStudentIds(final Collection<Long> studentIds) {
+        if (studentIds == null || studentIds.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        final Map<Long, Set<String>> ethnicityCodesByStudentId = newHashMap();
+        template.query(
+                findEthnicityCodesByStudentIdsQuery,
+                new MapSqlParameterSource("student_ids", studentIds),
+                row -> {
+                    final long studentId = row.getLong("student_id");
+                    final String ethnicityCode = row.getString("ethnicity_code");
+
+                    final Set<String> studentEthnicityCodes = ethnicityCodesByStudentId.get(studentId);
+                    if (studentEthnicityCodes == null) {
+                        ethnicityCodesByStudentId.put(studentId, newHashSet(ethnicityCode));
+                    } else {
+                        studentEthnicityCodes.add(ethnicityCode);
+                    }
+                });
+        return ethnicityCodesByStudentId;
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
@@ -35,15 +35,9 @@ public class JdbcStudentEthnicityRepository implements StudentEthnicityRepositor
                 findEthnicityCodesByStudentIdsQuery,
                 new MapSqlParameterSource("student_ids", studentIds),
                 row -> {
-                    final long studentId = row.getLong("student_id");
-                    final String ethnicityCode = row.getString("ethnicity_code");
+                    ethnicityCodesByStudentId.computeIfAbsent(row.getLong("student_id"),
+                            id -> newHashSet()).add(row.getString("ethnicity_code"));
 
-                    final Set<String> studentEthnicityCodes = ethnicityCodesByStudentId.get(studentId);
-                    if (studentEthnicityCodes == null) {
-                        ethnicityCodesByStudentId.put(studentId, newHashSet(ethnicityCode));
-                    } else {
-                        studentEthnicityCodes.add(ethnicityCode);
-                    }
                 });
         return ethnicityCodesByStudentId;
     }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepository.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
+import static io.jsonwebtoken.lang.Collections.isEmpty;
 
 @Repository
 public class JdbcStudentEthnicityRepository implements StudentEthnicityRepository {
@@ -27,9 +28,8 @@ public class JdbcStudentEthnicityRepository implements StudentEthnicityRepositor
 
     @Override
     public Map<Long, Set<String>> findEthnicityCodesByStudentIds(final Collection<Long> studentIds) {
-        if (studentIds == null || studentIds.isEmpty()) {
-            return ImmutableMap.of();
-        }
+        if (isEmpty(studentIds)) return ImmutableMap.of();
+
         final Map<Long, Set<String>> ethnicityCodesByStudentId = newHashMap();
         template.query(
                 findEthnicityCodesByStudentIdsQuery,

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepository.java
@@ -73,7 +73,7 @@ class JdbcStudentRepository implements StudentRepository {
         final Map<Long, Set<String>> ethnicityCodesByStudentId = ethnicityRepository.findEthnicityCodesByStudentIds(studentIds);
         return studentBuilders
                 .stream()
-                .map(b -> b.ethnicityCodes(ethnicityCodesByStudentId.getOrDefault(b.getId(), null)).build())
+                .map(b -> b.ethnicityCodes(ethnicityCodesByStudentId.get(b.getId())).build())
                 .collect(toList());
     }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepository.java
@@ -9,30 +9,43 @@ import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.stream.Collectors.toList;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
 import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.nullOrEmptyToDefault;
-import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.safeSplit;
 
 @Repository
 class JdbcStudentRepository implements StudentRepository {
 
     private final NamedParameterJdbcTemplate template;
     private final SecurityParameterProvider securityParameterProvider;
+    private final StudentEthnicityRepository ethnicityRepository;
 
     @Value("${sql.student.findAll}")
     private String findAllQuery;
 
+
     JdbcStudentRepository(final NamedParameterJdbcTemplate template,
-                          final SecurityParameterProvider securityParameterProvider) {
+                          final SecurityParameterProvider securityParameterProvider,
+                          final StudentEthnicityRepository ethnicityRepository) {
         this.template = template;
         this.securityParameterProvider = securityParameterProvider;
+        this.ethnicityRepository = ethnicityRepository;
     }
 
     @Override
     public List<Student> findAll(@NotNull final PermissionSource permissionSource,
                                  @NotNull final StudentSearch search) {
-        return template.query(
+
+        final List<Student.Builder> studentBuilders = newArrayList();
+        final Set<Long> studentIds = newHashSet();
+
+        // SQL returns a sorted list, need to preserve the order
+        template.query(
                 findAllQuery,
                 new MapSqlParameterSource()
                         .addValues(securityParameterProvider.getSecurityParameters(permissionSource))
@@ -40,20 +53,27 @@ class JdbcStudentRepository implements StudentRepository {
                         .addValue("school_id", search.getSchoolId())
                         .addValue("search_student_ids", search.getStudentIds() != null)
                         .addValue("student_ids", nullOrEmptyToDefault(search.getStudentIds(), null)),
-                (row, index) -> Student.builder()
-                        .id(row.getLong("id"))
-                        .ssid(row.getString("ssid"))
-                        .firstName(row.getString("first_name"))
-                        .lastName(row.getString("last_or_surname"))
-                        .genderCode(row.getString("gender_code"))
-                        .ethnicityCodes(safeSplit(row.getString("ethnicity_codes"), "|"))
-                        .englishLanguageAcquisitionStatusCode(row.getString("elas_code"))
-                        .individualEducationPlan(row.getBoolean("iep"))
-                        .limitedEnglishProficiency(getNullable(row, row.getBoolean("lep")))
-                        .section504(getNullable(row, row.getBoolean("section504")))
-                        .migrantStatus(getNullable(row, row.getBoolean("migrant_status")))
-                        .build()
-        );
-    }
+                (row, index) -> {
+                    final Long studentId = row.getLong("id");
+                    studentIds.add(studentId);
+                    studentBuilders.add(Student.builder()
+                            .id(studentId)
+                            .ssid(row.getString("ssid"))
+                            .firstName(row.getString("first_name"))
+                            .lastName(row.getString("last_or_surname"))
+                            .genderCode(row.getString("gender_code"))
+                            .englishLanguageAcquisitionStatusCode(row.getString("elas_code"))
+                            .individualEducationPlan(row.getBoolean("iep"))
+                            .limitedEnglishProficiency(getNullable(row, row.getBoolean("lep")))
+                            .section504(getNullable(row, row.getBoolean("section504")))
+                            .migrantStatus(getNullable(row, row.getBoolean("migrant_status"))));
+                    return row;
+                });
 
+        final Map<Long, Set<String>> ethnicityCodesByStudentId = ethnicityRepository.findEthnicityCodesByStudentIds(studentIds);
+        return studentBuilders
+                .stream()
+                .map(b -> b.ethnicityCodes(ethnicityCodesByStudentId.getOrDefault(b.getId(), null)).build())
+                .collect(toList());
+    }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/Student.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/Student.java
@@ -128,6 +128,10 @@ public class Student {
         private Boolean section504;
         private Boolean migrantStatus;
 
+        public long getId() {
+            return id;
+        }
+
         public Builder id(final long id) {
             this.id = id;
             return this;

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/StudentEthnicityRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/StudentEthnicityRepository.java
@@ -1,0 +1,20 @@
+package org.opentestsystem.rdw.reporting.student;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Responsible for accessing students
+ */
+public interface StudentEthnicityRepository {
+
+    /**
+     * Finds all students ethnicity codes
+     *
+     * @param studentIds ids of the students
+     * @return all students ethnicity codes; since ethnicity is optional, the given student id
+     * is included only if a student has ethnicity values
+     */
+    Map<Long, Set<String>> findEthnicityCodesByStudentIds(Collection<Long> studentIds);
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/StudentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/student/StudentRepository.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.reporting.student;
 import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
 
 import javax.validation.constraints.NotNull;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -15,10 +14,9 @@ public interface StudentRepository {
      * Finds all students for the given search criteria
      *
      * @param permissionSource the permissions of the user searching the students
-     * @param search the student search criteria
-     * @return all students for the given search criteria
+     * @param search           the student search criteria
+     * @return all students for the given search criteria, sorted by the student's last name, first name and ssid.
      */
-    List<Student> findAll(@NotNull PermissionSource permissionSource,
-                          @NotNull StudentSearch search);
+    List<Student> findAll(@NotNull PermissionSource permissionSource, @NotNull StudentSearch search);
 
 }

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -20,8 +20,7 @@ sql:
         e.lep,
         e.elas_code,
         e.section504,
-        e.migrant_status,
-        GROUP_CONCAT(se.ethnicity_code SEPARATOR '|') AS ethnicity_codes
+        e.migrant_status
       FROM exam e
         LEFT OUTER JOIN exam e2
           ON e.student_id = e2.student_id
@@ -36,7 +35,6 @@ sql:
         JOIN school s ON s.id = e.school_id
         JOIN school isch ON st.inferred_school_id = isch.id
         JOIN asmt a ON a.id = e.asmt_id
-        LEFT JOIN student_ethnicity se ON se.student_id = e.student_id
       WHERE e2.student_id IS NULL
         AND (
           :group_id IS NULL
@@ -50,7 +48,6 @@ sql:
         AND (:school_id IS NULL OR e.school_id = :school_id)
         AND (:search_student_ids IS FALSE OR e.student_id IN (:student_ids))
         AND ${sql.reporting.snippet.studentExamPermissionWithEmbargo}
-      GROUP BY e.student_id
       ORDER BY st.last_or_surname, st.first_name, st.ssid
 
   exam:

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
@@ -153,7 +153,7 @@ public final class TestData {
                 .firstName("student1_firstName")
                 .lastName("student1_lastName")
                 .genderCode("g1")
-                .ethnicityCodes(ImmutableSet.of());
+                .ethnicityCodes(ImmutableSet.of("ethnicity-29", "ethnicity-28"));
     }
 
     public static StudentContext.Builder studentContext() {

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepositoryIT.java
@@ -6,6 +6,7 @@ import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.opentestsystem.rdw.reporting.TestData;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.student.JdbcStudentEthnicityRepository;
 import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -18,7 +19,7 @@ import static org.opentestsystem.rdw.reporting.common.test.support.PermissionSco
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.statewide;
 
-@Import(JdbcGroupExamRepository.class)
+@Import({JdbcGroupExamRepository.class, JdbcStudentEthnicityRepository.class})
 @Sql(scripts = {"classpath:integration-test-data.sql"})
 public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
 

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/schoolgrade/JdbcSchoolGradeExamRepositoryIT.java
@@ -5,6 +5,7 @@ import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.opentestsystem.rdw.reporting.TestData;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.opentestsystem.rdw.reporting.student.JdbcStudentEthnicityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
@@ -16,7 +17,7 @@ import static org.opentestsystem.rdw.reporting.common.test.support.PermissionSco
 import static org.opentestsystem.rdw.reporting.common.test.support.PermissionScopes.schools;
 
 
-@Import(JdbcSchoolGradeExamRepository.class)
+@Import({JdbcSchoolGradeExamRepository.class, JdbcStudentEthnicityRepository.class})
 @Sql(scripts = {"classpath:integration-test-data.sql"})
 public class JdbcSchoolGradeExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
 

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepositoryIT.java
@@ -26,4 +26,9 @@ public class JdbcStudentEthnicityRepositoryIT extends JdbcRepositoryWithPermissi
                         entry(-2L, ImmutableSet.of("ethnicity-27"))
                 );
     }
+
+    @Test
+    public void itShouldHandleEmptyInput() {
+        assertThat(repository.findEthnicityCodesByStudentIds(ImmutableList.of())).isEmpty();
+    }
 }

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentEthnicityRepositoryIT.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.reporting.student;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+@Import({JdbcStudentEthnicityRepository.class})
+@Sql(scripts = {"classpath:integration-test-data.sql"})
+public class JdbcStudentEthnicityRepositoryIT extends JdbcRepositoryWithPermissionIT {
+
+    @Autowired
+    private StudentEthnicityRepository repository;
+
+    @Test
+    public void itShouldFind() {
+        assertThat(repository.findEthnicityCodesByStudentIds(ImmutableList.of(-1L, -2L, -3L)))
+                .containsOnly(
+                        entry(-1L, ImmutableSet.of("ethnicity-29", "ethnicity-28")),
+                        entry(-2L, ImmutableSet.of("ethnicity-27"))
+                );
+    }
+}

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/student/JdbcStudentRepositoryIT.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.reporting.student;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +15,7 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@Import(JdbcStudentRepository.class)
+@Import({JdbcStudentRepository.class, JdbcStudentEthnicityRepository.class})
 @Sql(scripts = {"classpath:integration-test-data.sql"})
 public class JdbcStudentRepositoryIT extends JdbcRepositoryWithPermissionIT {
 
@@ -42,11 +41,14 @@ public class JdbcStudentRepositoryIT extends JdbcRepositoryWithPermissionIT {
                 .migrantStatus(null);
     }
 
-    private final Student student1 = student(-1).build();
+    private final Student student1 = student(-1)
+            .ethnicityCodes(ImmutableSet.of("ethnicity-29", "ethnicity-28"))
+            .build();
     private final Student student2 = student(-2)
             .individualEducationPlan(true)
             .limitedEnglishProficiency(true)
             .section504(true)
+            .ethnicityCodes(ImmutableSet.of("ethnicity-27"))
             .build();
     private final Student student4 = student(-4).build();
     private final Student student5 = student(-5).build();

--- a/reporting-service/src/test/resources/integration-test-data.sql
+++ b/reporting-service/src/test/resources/integration-test-data.sql
@@ -1,3 +1,5 @@
+insert into ethnicity VALUES (-29,'ethnicity-29'),(-28,'ethnicity-28'),(-27, 'ethnicity-27'), (-26, 'ethnicity-26');
+
 insert into school_group (id, natural_id, name) values
   (-10, 'schoolGroup1', 'schoolGroup1'),
   (-40, 'schoolGroup4', 'schoolGroup4'),
@@ -44,6 +46,11 @@ insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_co
   (-6, 'student6_ssid', 'student6_lastName', 'student6_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -50, -1, '1997-07-18 20:14:34.000000', -1),
   (-7, 'student7_ssid', 'student7_lastName', 'student7_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -50, -1, '1997-07-18 20:14:34.000000', -1),
   (-100, 'transfer_1', 'from_school3', 'to_school4', -1, 'g1', '1997-01-01 00:00:00.000000', -40, -1, '1997-07-18 20:14:34.000000', -1);
+
+insert into student_ethnicity(student_id, ethnicity_id, ethnicity_code ) values
+  (-1, -29,'ethnicity-29'),
+  (-1, -28,'ethnicity-28'),
+  (-2, -27,'ethnicity-27');
 
 insert into asmt (id, type_id, natural_id, grade_id, grade_code, subject_id, school_year, name, label, version,
   claim1_score_code, claim2_score_code, claim3_score_code, claim4_score_code,


### PR DESCRIPTION
Why?  There are two ways we get students ethnicity: in one repository we used `GROUP_CONCAT` and in another we looked up the ethnicity as a second database call. I need a similar logic for the target report API and I wanted to re-use `GROUP_CONCAT` solution. When I tested it on AWS Dev, it was **very** slow ( I had to kill the query since it was not responding for a while). The main offender is `GROUP BY`. So I changed it to do a second call.