### PR TITLE
Collapse results by default for school/grade results

### DIFF
--- a/webapp/src/main/webapp/package-lock.json
+++ b/webapp/src/main/webapp/package-lock.json
@@ -10465,7 +10465,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "uglifyjs-webpack-plugin": {
       "version": "1.2.5",

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.html
@@ -178,6 +178,7 @@
        class="groups-results-wrapper">
     <assessment-results [assessmentExam]="assessment"
                         [showValuesAsPercent]="showValuesAsPercent"
+                        [isDefaultCollapsed]="isDefaultCollapsed"
                         [filterBy]="clientFilterBy"
                         [allowFilterBySessions]="allowFilterBySessions"
                         [assessmentProvider]="assessmentProvider"

--- a/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessments.component.ts
@@ -69,6 +69,13 @@ export class AssessmentsComponent implements OnInit {
   @Input()
   allowFilterBySessions = true;
 
+  /**
+   * If true, the results are collapsed by default, otherwise they are expanded
+   * with the results shown.
+   */
+  @Input()
+  isDefaultCollapsed = false;
+
   @Output()
   export: EventEmitter<any> = new EventEmitter<any>();
 

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -68,6 +68,8 @@ export class AssessmentResultsComponent implements OnInit {
   set assessmentExam(assessment: AssessmentExam) {
     this._assessmentExam = assessment;
 
+    this._assessmentExam.collapsed = this.isDefaultCollapsed;
+
     // if we aren't going to display the sessions, don't waste resources computing them
     if (this.allowFilterBySessions) {
       this.sessions = this.getDistinctExamSessions(assessment.exams);
@@ -104,6 +106,13 @@ export class AssessmentResultsComponent implements OnInit {
    */
   @Input()
   allowFilterBySessions = true;
+
+  /**
+   * If true, the results are collapsed by default, otherwise they are expanded
+   * with the results shown.
+   */
+  @Input()
+  isDefaultCollapsed = true;
 
   /**
    * Represents the cutoff year for when there is no item level response data available.

--- a/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
+++ b/webapp/src/main/webapp/src/app/groups/results/group-results.component.html
@@ -33,6 +33,7 @@
     <assessments [assessmentExams]="assessmentExams"
                  [assessmentProvider]="assessmentProvider"
                  [assessmentExporter]="assessmentExporter"
+                 [isDefaultCollapsed]="false"
                  (export)="exportCsv()"
                  [allowFilterBySessions]="true">
 

--- a/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
+++ b/webapp/src/main/webapp/src/app/school-grade/results/school-results.component.html
@@ -30,6 +30,7 @@
                [hideAssessments]="gradesAreUnavailable"
                [assessmentProvider]="assessmentProvider"
                [assessmentExporter]="assessmentExporter"
+               [isDefaultCollapsed]="true"
                (export)="exportCsv()"
                [allowFilterBySessions]="false">
 

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -264,10 +264,10 @@
     "action": {
       "cancel": "Cancel",
       "close": "Close",
-      "collapse": "Collapse",
+      "collapse": "Collapse Results",
       "create": "Create",
       "delete": "Delete",
-      "expand": "Expand",
+      "expand": "Expand Results",
       "go-home": "Go Home",
       "hide": "Hide",
       "save": "Save",


### PR DESCRIPTION
Request was to have the school/grade results collapsed by default as an administrator is more likely to want the aggregate view than the individual student results.  So we updated the language to say "Expand Results" since there is not the context of having just collapsed the results.  

Going to merge since I'd like it to be there tomorrow for the demo, but will address any feedback and update if needed.