### PR TITLE
use the IAB header names for claim aggregate report display

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -494,7 +494,7 @@ export class AggregateReportTableComponent implements OnInit {
 
   private getPerformanceLevelColumnHeaderTranslationCode(displayType: string, level: number, index: number) {
     return displayType === 'Separate'
-      ? `common.assessment-type.${this.table.assessmentDefinition.typeCode}.performance-level.${level}.name-prefix`
+      ? `common.assessment-type.${this.table.reportType == 'Claim' ? 'iab' : this.table.assessmentDefinition.typeCode}.performance-level.${level}.name-prefix`
       : `aggregate-report-table.columns.grouped-performance-level-prefix.${index}`;
   }
 


### PR DESCRIPTION
This is a bit of a quick fix.  I think there is a better way and it probably will be impacted by configurable subjects.  @wtritch need to consider if claim performance levels will always match IAB performance levels?

Again, merging to have in place before the demo.