### PR TITLE
Task/improve user group advance filters

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/filter/student-filter.ts
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filter.ts
@@ -12,19 +12,6 @@ export interface StudentFilter {
   migrantStatuses?: string[];
 }
 
-export function createDefaultStudentFilter(options: StudentFilterOptions): StudentFilter {
-  // return {
-  //   genders: options.genders.concat(),
-  //   ethnicities: options.ethnicities.concat(),
-  //   englishLanguageAcquisitionStatuses: [],
-  //   individualEducationPlans: options.individualEducationPlans.concat(),
-  //   limitedEnglishProficiencies: options.limitedEnglishProficiencies.concat(),
-  //   section504s: options.section504s.concat(),
-  //   migrantStatuses: options.migrantStatuses.concat()
-  // };
-  return {};
-}
-
 export type ArrayFilter<T> = (student: T, index: number, students: T[]) => boolean;
 export type StudentArrayFilter = ArrayFilter<Student>;
 

--- a/webapp/src/main/webapp/src/app/shared/filter/student-filter.ts
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filter.ts
@@ -3,25 +3,26 @@ import { Utils } from '../support/support';
 import { Student } from '../../student/search/student';
 
 export interface StudentFilter {
-  genders: string[];
-  ethnicities: string[];
-  englishLanguageAcquisitionStatuses: string[];
-  individualEducationPlans: string[];
+  genders?: string[];
+  ethnicities?: string[];
+  englishLanguageAcquisitionStatuses?: string[];
+  individualEducationPlans?: string[];
   limitedEnglishProficiencies?: string[];
   section504s?: string[];
   migrantStatuses?: string[];
 }
 
 export function createDefaultStudentFilter(options: StudentFilterOptions): StudentFilter {
-  return {
-    genders: options.genders.concat(),
-    ethnicities: options.ethnicities.concat(),
-    englishLanguageAcquisitionStatuses: [],
-    individualEducationPlans: options.individualEducationPlans.concat(),
-    limitedEnglishProficiencies: options.limitedEnglishProficiencies.concat(),
-    section504s: options.section504s.concat(),
-    migrantStatuses: options.migrantStatuses.concat()
-  };
+  // return {
+  //   genders: options.genders.concat(),
+  //   ethnicities: options.ethnicities.concat(),
+  //   englishLanguageAcquisitionStatuses: [],
+  //   individualEducationPlans: options.individualEducationPlans.concat(),
+  //   limitedEnglishProficiencies: options.limitedEnglishProficiencies.concat(),
+  //   section504s: options.section504s.concat(),
+  //   migrantStatuses: options.migrantStatuses.concat()
+  // };
+  return {};
 }
 
 export type ArrayFilter<T> = (student: T, index: number, students: T[]) => boolean;
@@ -53,4 +54,10 @@ export function createStudentArrayFilter(filter: StudentFilter): StudentArrayFil
       || filter.migrantStatuses.includes(student.migrantStatus)
     );
   };
+}
+
+export function countFilters(filter: StudentFilter): number {
+  return Object.entries(filter).reduce((count, [key, value]) => {
+    return count + (value != null ? value.length : 0);
+  }, 0);
 }

--- a/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.html
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.html
@@ -11,6 +11,7 @@
                        [(ngModel)]="value.genders"
                        (ngModelChange)="onChange()"
                        [vertical]="true"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -24,6 +25,7 @@
                        [(ngModel)]="value.migrantStatuses"
                        (ngModelChange)="onChange()"
                        [vertical]="true"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -37,6 +39,7 @@
                        [(ngModel)]="value.section504s"
                        (ngModelChange)="onChange()"
                        [vertical]="true"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -52,6 +55,7 @@
       <sb-button-group [options]="optionsInternal.limitedEnglishProficiencies"
                        [(ngModel)]="value.limitedEnglishProficiencies"
                        (ngModelChange)="onChange()"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -65,7 +69,7 @@
                        [(ngModel)]="value.englishLanguageAcquisitionStatuses"
                        (ngModelChange)="onChange()"
                        [vertical]="true"
-                       [noneStateEnabled]="true"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -78,6 +82,7 @@
       <sb-button-group [options]="optionsInternal.individualEducationPlans"
                        [(ngModel)]="value.individualEducationPlans"
                        (ngModelChange)="onChange()"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>
@@ -94,6 +99,7 @@
                        [(ngModel)]="value.ethnicities"
                        (ngModelChange)="onChange()"
                        [vertical]="true"
+                       allOptionReturnsUndefined="true"
                        analyticsEvent="FilterClick"
                        analyticsCategory="AdvancedFilters"></sb-button-group>
     </div>

--- a/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { StudentFilterOptions } from './student-filter-options';
-import { createDefaultStudentFilter, StudentFilter } from './student-filter';
+import { StudentFilter } from './student-filter';
 import { StudentFilterFormOptions } from './student-filter-form-options';
 import { StudentFilterFormOptionsMapper } from './student-filter-form-options.mapper';
 
@@ -38,7 +38,7 @@ export class StudentFiltersComponent {
   set options(options: StudentFilterOptions) {
     this._options = options;
     this._formOptions = this.mapper.fromOptions(options);
-    this._value = createDefaultStudentFilter(options);
+    this._value = {};
   }
 
   get optionsInternal(): StudentFilterFormOptions {

--- a/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
@@ -46,6 +46,7 @@ export class StudentFiltersComponent {
   }
 
   onChange(): void {
+    console.log('filter', this._value)
     this.changed.emit(this._value);
   }
 

--- a/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/filter/student-filters.component.ts
@@ -46,7 +46,6 @@ export class StudentFiltersComponent {
   }
 
   onChange(): void {
-    console.log('filter', this._value)
     this.changed.emit(this._value);
   }
 

--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
@@ -199,6 +199,7 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
   private _initialized: boolean = false;
   private _initialOptions: Option[];
   private _initialValues: any[];
+  private _allOptionReturnsUndefined: boolean = false; // TODO default should be true
   private _buttonGroupStyles: any = DefaultButtonGroupStyles;
   private _buttonStyles: any = DefaultButtonStyles;
 
@@ -274,6 +275,15 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
   @Input()
   set buttonStyles(value: any) {
     this._buttonStyles = value ? value : DefaultButtonStyles;
+  }
+
+  get allOptionReturnsUndefined(): boolean {
+    return this._allOptionReturnsUndefined;
+  }
+
+  @Input()
+  set allOptionReturnsUndefined(value: boolean) {
+    this._allOptionReturnsUndefined = Utils.booleanValueOf(value);
   }
 
   get initializedInternal(): boolean {
@@ -352,9 +362,11 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
    * @param {Option[]} options
    */
   private updateValue(state, options: Option[]): void {
-    const values = options
-      .filter(option => state.selectedAllOption || state.selectedOptions.has(option))
-      .map(option => option.value);
+    const values = state.selectedAllOption && this._allOptionReturnsUndefined
+      ? undefined
+      : options
+        .filter(option => state.selectedAllOption || state.selectedOptions.has(option))
+        .map(option => option.value);
 
     this.setValueAndNotifyChanges(values);
   }
@@ -384,11 +396,11 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
    * Normalizes and copies values
    * This should be used to process all values provided to the value field
    *
-   * @param value
+   * @param values
    * @returns {any[]}
    */
-  private parseInputValues(value: any): any[] {
-    if (value == null) {
+  private parseInputValues(values: any): any[] {
+    if (values == null) {
       // If the value is undefined and the component allows a no-value state, set value to empty
       if (this.effectiveNoneStateEnabled) {
         return [];
@@ -397,7 +409,7 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
       return this.options.map(option => option.value);
     }
     // Make a copy of the value to avoid side effects
-    return value.concat();
+    return values.concat();
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/student/search/student-search-form.component.html
+++ b/webapp/src/main/webapp/src/app/student/search/student-search-form.component.html
@@ -44,14 +44,17 @@
     </div>
 
     <div class="flex-child text-right">
-      <label>{{'advanced-filters.label' | translate}}</label>
+      <label>{{'advanced-filters.label' | translate}} </label>
       <button id="advanced"
               class="form-control btn btn-sm btn-default"
               (click)="onAdvancedFiltersToggleClick()">
         {{(showAdvancedFilters ? 'common.action.hide' : 'common.action.show') | translate}}
-        <i aria-hidden="true"
+        <i *ngIf="advancedFilterCount === 0"
+           aria-hidden="true"
            class="fa ml-xs"
            [ngClass]="showAdvancedFilters ? 'fa-caret-square-o-up' : 'fa-caret-square-o-down'"></i>
+        <div *ngIf="advancedFilterCount > 0"
+             class="badge aqua ml-xs">{{advancedFilterCount}}</div>
       </button>
     </div>
 

--- a/webapp/src/main/webapp/src/app/student/search/student-search-form.component.ts
+++ b/webapp/src/main/webapp/src/app/student/search/student-search-form.component.ts
@@ -21,6 +21,9 @@ export class StudentSearchFormComponent extends AbstractControlValueAccessor<Stu
     groups: []
   };
 
+  @Input()
+  advancedFilterCount: number = 0;
+
   @Output()
   schoolChange: EventEmitter<School> = new EventEmitter<School>();
 

--- a/webapp/src/main/webapp/src/app/user-group/user-group.component.html
+++ b/webapp/src/main/webapp/src/app/user-group/user-group.component.html
@@ -47,13 +47,14 @@
           <student-search-form #studentSearchForm
                                [options]="studentFormOptions"
                                [(ngModel)]="studentForm"
+                               [advancedFilterCount]="advancedFilterCount"
                                (schoolChange)="onStudentFormSearchChange($event)"
                                (groupChange)="onStudentFormSearchChange($event)"
                                (nameChange)="onStudentFormFilterChange($event)"
                                (showAdvancedFiltersChange)="onShowAdvancedFiltersChange($event)"></student-search-form>
         </div>
 
-        <div *ngIf="showAdvancedFilters"
+        <div [hidden]="!showAdvancedFilters"
              class="well gray-lighter">
           <student-filters [options]="studentFilterOptions"
                            [showEnglishLanguageAcquisitionStatusFilter]="applicationSettings.elasEnabled"

--- a/webapp/src/main/webapp/src/app/user-group/user-group.component.ts
+++ b/webapp/src/main/webapp/src/app/user-group/user-group.component.ts
@@ -17,7 +17,12 @@ import { StudentSearch, StudentService } from '../student/search/student.service
 import { byString, join } from '@kourge/ordering/comparator';
 import { ordering } from '@kourge/ordering';
 import { UserGroupFormComponent } from './user-group-form.component';
-import { createStudentArrayFilter, StudentArrayFilter, StudentFilter } from '../shared/filter/student-filter';
+import {
+  countFilters,
+  createStudentArrayFilter,
+  StudentArrayFilter,
+  StudentFilter
+} from '../shared/filter/student-filter';
 import { StudentFilterOptions } from '../shared/filter/student-filter-options';
 import { FilterOptionsService } from '../shared/filter/filter-options.service';
 import { ApplicationSettingsService } from '../app-settings.service';
@@ -50,6 +55,7 @@ export class UserGroupComponent implements OnInit, OnDestroy {
   applicationSettings: ApplicationSettings;
   showAdvancedFilters: boolean = false;
   loadingStudents: boolean = true;
+  advancedFilterCount: number = 0;
 
   processingSubscription: Subscription;
   initialized: boolean;
@@ -224,6 +230,7 @@ export class UserGroupComponent implements OnInit, OnDestroy {
 
   onAdvancedFilterChange(filter: StudentFilter): void {
     this.studentArrayFilter = createStudentArrayFilter(filter);
+    this.advancedFilterCount = countFilters(filter);
     this.updateFormStudents();
   }
 

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1540,3 +1540,13 @@ table.student-claim-distribution {
     }
   }
 }
+
+user-group {
+  student-filters {
+    .flex-children .flex-child {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
+  }
+}
+

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -72,6 +72,10 @@
   }
 }
 
+.btn-default .badge.aqua {
+  background-color: @aqua;
+}
+
 /**
   Required to meet WCAG 2 AA contrast ratio
  */


### PR DESCRIPTION
Fixed advanced filters so that selecting "All" includes null values.

![image](https://user-images.githubusercontent.com/23462925/40882172-c1df1bd2-668e-11e8-9116-9b2f23890d55.png)

Added advanced filter counter instead of the 'potato chips' we have on the exam result page for now for simplicity.

![image](https://user-images.githubusercontent.com/23462925/40882165-8fc11c54-668e-11e8-9070-30d9077adf10.png)

![image](https://user-images.githubusercontent.com/23462925/40882169-ae1565c0-668e-11e8-8846-5707905e47a5.png)

One nicity i thought might be nice is moving the counter next to the "Advanced Filters" label then making it turn into an `X` on hover so that when clicked all the filters would be removed. I thought this would be departing too far from the existing exam filters though