### PR TITLE
Update aggregate target result display to account for client feedback.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
@@ -154,51 +154,55 @@
             </span>
           </div>
 
-          <div *ngSwitchCase="'studentRelativeResidualScoresLevel'">
+          <div *ngSwitchCase="'studentRelativeResidualScoresLevel'"
+               class="text-center">
 
             <!-- pick the icon -->
-            <span [ngSwitch]="rowData.studentRelativeResidualScoresLevel"
-              style="font-size: 1.2em">
-              <span *ngSwitchCase="'Above'"
-                    class="sb-iab-green">
-                <sb-icon class="fa-lg" style="stroke-width: 1px; stroke: #000;" icon="sbac-above-average"></sb-icon>
+            <ng-container [ngSwitch]="rowData.studentRelativeResidualScoresLevel">
+              <span *ngSwitchCase="'Above'">
+                <span class="blue"><i class="fa fa-lg fa-arrow-up"></i></span>
+                {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
               </span>
-              <span *ngSwitchCase="'Near'"
-                    class="sb-iab-yellow">
-                <sb-icon class="fa-lg" style="stroke-width: 1px; stroke: #000;" icon="sbac-average"></sb-icon>
+              <span *ngSwitchCase="'Near'">
+                <span class="blue">
+                  <sb-icon class="fa-lg" icon="fa-equals"></sb-icon>
+                </span>
+                {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
               </span>
-              <span *ngSwitchCase="'Below'"
-                    class="sb-iab-red">
-                <sb-icon class="fa-lg" style="stroke-width: 1px; stroke: #000;" icon="sbac-below-average"></sb-icon>
+              <span *ngSwitchCase="'Below'">
+                <span class="blue"><i class="fa fa-lg fa-arrow-down"></i></span>
+                {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
               </span>
               <span *ngSwitchCase="'InsufficientData'"
-                    class="gray-light">
-                <sb-icon class="fa-lg" style="stroke-width: 1px; stroke: #000;" icon="sbac-insufficient-data"></sb-icon>
+                    class="label label-lg gray-light">
+                {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
               </span>
-            </span>
-            {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
+              <span *ngSwitchDefault>
+                {{'aggregate-report-table.target.overall.' + rowData.studentRelativeResidualScoresLevel | translate}}
+              </span>
+            </ng-container>
+
           </div>
 
-          <div *ngSwitchCase="'standardMetRelativeResidualLevel'">
+          <div *ngSwitchCase="'standardMetRelativeResidualLevel'"
+               class="text-center">
 
             <!-- pick the label color -->
             <span [ngSwitch]="rowData.standardMetRelativeResidualLevel">
               <span *ngSwitchCase="'Above'"
-                    class="label sb-iab-green">
+                    class="label label-lg performance-min-width sb-iab-green">
                 {{'aggregate-report-table.target.standard.Above' | translate}}
               </span>
               <span *ngSwitchCase="'Near'"
-                    class="label sb-iab-yellow">
+                    class="label label-lg performance-min-width sb-iab-yellow">
                 {{'aggregate-report-table.target.standard.Near' | translate}}
               </span>
               <span *ngSwitchCase="'Below'"
-                    class="label sb-iab-red">
+                    class="label label-lg performance-min-width sb-iab-red">
                 {{'aggregate-report-table.target.standard.Below' | translate}}
               </span>
-              <span *ngSwitchCase="'InsufficientData'">
-                <span class="gray-light">
-                  <sb-icon class="fa-lg" icon="sbac-insufficient-data"></sb-icon>
-                </span>
+              <span *ngSwitchCase="'InsufficientData'"
+                    class="label label-lg gray-light">
                 {{'aggregate-report-table.target.standard.InsufficientData' | translate}}
               </span>
               <span *ngSwitchCase="'Excluded'">

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
@@ -43,6 +43,18 @@
           <div>{{ 'aggregate-report-table.columns.performance-level-suffix' | translate }}</div>
         </div>
 
+        <span *ngSwitchCase="'studentRelativeResidualScoresLevel'"
+              info-button
+              title="{{'target-report.columns.' + toDash(column.id) | translate}}"
+              content="{{('target-report.columns.' + toDash(column.id) + '-info') | translate}}">
+        </span>
+
+        <span *ngSwitchCase="'standardMetRelativeResidualLevel'"
+              info-button
+              title="{{'target-report.columns.' + toDash(column.id) | translate}}"
+              content="{{('target-report.columns.' + toDash(column.id) + '-info') | translate}}">
+        </span>
+
         <span *ngSwitchDefault>
           {{('aggregate-report-table.columns.' + toDash(column.id)) | translate}}
         </span>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -154,8 +154,6 @@
       "organization": "Organization",
       "performance-level-suffix": "Standard",
       "school-year": "Academic Year",
-      "student-relative-residual-scores-level": "Performance relative to other targets",
-      "standard-met-relative-residual-level": "Performance relative to achievement standards",
       "students-tested": "Students Tested",
       "target": "Target"
     },

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -171,7 +171,7 @@
         "Below": "Worse",
         "Excluded": "Excluded",
         "InsufficientData": "Insufficient Data",
-        "Near": "Similar to Overall"
+        "Near": "Similar"
       },
       "standard": {
         "Above": "Above",

--- a/webapp/src/main/webapp/src/assets/svgs/fa-equals.svg
+++ b/webapp/src/main/webapp/src/assets/svgs/fa-equals.svg
@@ -1,0 +1,6 @@
+<svg aria-hidden="true" data-prefix="fas" data-icon="equals" role="img" xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 448 512" class="svg-inline--fa fa-equals fa-w-14 fa-5x">
+  <path fill="currentColor"
+        d="M416 304H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32zm0-192H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+        class=""></path>
+</svg>

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1552,3 +1552,7 @@ user-group {
   }
 }
 
+.performance-min-width {
+  display: inline-block;
+  min-width: 75px;
+}


### PR DESCRIPTION
The column header was updated to re-use shared header language.
Added a min-width to the "Above" "Below" and "Near" labels so they display at the same width with default display text.
Updated the overall-relative values to use up, down, and equals icons.  Made all icons blue.
Updated "Insufficient Data" display value to use label-styling rather than an icon.
Centered data column values in target results table to align with other aggregate results tables.

![image](https://user-images.githubusercontent.com/617828/40934291-327c530e-67e9-11e8-92e8-3448c948f3c5.png)
