### PR TITLE
Prevent modifying options school year list during display.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.mapper.ts
@@ -68,7 +68,7 @@ export class AggregateReportOptionsMapper {
           value => translate(`common.administration-condition.${value}`),
           value => `Manner of Administration: ${value}`
         )),
-      schoolYears: options.schoolYears.sort()
+      schoolYears: options.schoolYears.concat().sort()
         .map(optionMapper(
           value => this.schoolYearPipe.transform(value),
           value => `School Year: ${value}`


### PR DESCRIPTION
The default school year was 2018 BEFORE display, and 2015 AFTER display, causing the hard-to-reproduce bug.