### PR TITLE
don't run the same search multiple times, make sure it is different

### DIFF
--- a/webapp/src/main/webapp/src/app/user-group/user-group.component.ts
+++ b/webapp/src/main/webapp/src/app/user-group/user-group.component.ts
@@ -29,6 +29,7 @@ import { Forms } from '../shared/form/forms';
 import { SchoolAndGroupTypeaheadOptionMapper } from '../student/search/school-and-group-typeahead-option.mapper';
 import { Option as SchoolAndGroupTypeaheadOption } from '../student/search/school-and-group-typeahead.component';
 import { Option } from '../shared/form/option';
+import * as deepEqual from "fast-deep-equal";
 
 const StudentComparator = join(
   ordering(byString).on<Student>(student => student.lastName).compare,
@@ -62,6 +63,7 @@ export class UserGroupComponent implements OnInit, OnDestroy {
   initialized: boolean;
 
   private _saveButtonDisabled: boolean = true;
+  private _previousSearch: StudentSearch = null;
 
   @ViewChild('groupForm')
   groupForm: UserGroupFormComponent;
@@ -248,6 +250,12 @@ export class UserGroupComponent implements OnInit, OnDestroy {
 
   private searchStudents(): void {
     const search = this.createStudentSearch(this.studentForm);
+
+    if (this.isSameSearchRequest(search)) {
+      return;
+    }
+
+    this._previousSearch = search;
     if (Object.keys(search).length) {
       this.loadingStudents = true;
       this.studentService.getStudents(search)
@@ -264,6 +272,10 @@ export class UserGroupComponent implements OnInit, OnDestroy {
       this.students = [];
       this.updateFormStudents();
     }
+  }
+
+  private isSameSearchRequest(search: StudentSearch) {
+    return deepEqual(this._previousSearch, search);
   }
 
   private createStudentSearch(searchForm: StudentSearchForm): StudentSearch {


### PR DESCRIPTION
The student search was being called twice when the page loaded.  The first time was the call from the `ngOnInit`, and the second was the `onStudentFormSearchChange` event that is being triggered from the `ngModelChange` on the school/group dropdown.  

It didn't seem to right to rely on that ngModelChange event for the first API call to get students, so instead I'm tacking the previous search and if it's the same don't do it again.  Am open to thoughts if anyone disagrees and thinks we can just rely on the model change event firing when the dropdown is populated to start.