### PR TITLE
fix embargo admin display Math count not displaying

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/embargo/embargo-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/embargo/embargo-table.component.html
@@ -36,7 +36,7 @@
 
         <div *ngSwitchCase="'subject'"
              class="text-right">
-          {{embargo.examCountsBySubject[column.code] | number}}
+          {{embargo.examCountsBySubject[column.serverSubjectCode] | number}}
         </div>
 
         <div *ngSwitchCase="'individualEnabled'"

--- a/webapp/src/main/webapp/src/app/admin/embargo/embargo-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/embargo/embargo-table.component.ts
@@ -103,4 +103,8 @@ class Column {
       this.code = code;
     }
   }
+
+  get serverSubjectCode() {
+    return this.code ? this.code.toUpperCase() : this.code;
+  }
 }


### PR DESCRIPTION
This is the simplest fix at the moment.  Since configurable subjects will be changing this I didn't think a bigger change made sense. 

![image](https://user-images.githubusercontent.com/341584/41144882-2c7c16c0-6ab3-11e8-9cb8-972f0dea70fc.png)
