### PR TITLE
Update results by item, distractor analysis, and writing trait score …

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.spec.ts
@@ -3,8 +3,6 @@ import { Exam } from '../model/exam.model';
 import { AssessmentItem } from '../model/assessment-item.model';
 import { ExamItemScore } from '../model/exam-item-score.model';
 import { ClaimStatistics } from '../model/claim-score.model';
-import { TargetScoreExam } from '../model/target-score-exam.model';
-import { TargetReportingLevel } from '../model/aggregate-target-score-row.model';
 
 describe('Exam Calculator', () => {
 
@@ -261,6 +259,7 @@ describe('Exam Calculator', () => {
       item.numberOfChoices = ai.numberOfChoices;
       item.scores = ai.responses.map(result => {
         let score = new ExamItemScore();
+        score.points = 1;
         score.response = result;
         return score;
       });

--- a/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/exam-statistics-calculator.ts
@@ -6,6 +6,7 @@ import { DynamicItemField } from '../model/item-point-field.model';
 import * as math from 'mathjs';
 import { WritingTraitScoreSummary } from '../model/writing-trait-score-summary.model';
 import { ClaimStatistics } from '../model/claim-score.model';
+import { ExamItemScore } from "../model/exam-item-score.model";
 
 @Injectable()
 export class ExamStatisticsCalculator {
@@ -152,17 +153,21 @@ export class ExamStatisticsCalculator {
     for (let item of assessmentItems) {
       this.assertNumberOfChoicesIsValid(item.numberOfChoices);
 
-      for (let i = 0; i < item.numberOfChoices; i++) {
-        let response = this.potentialResponses[ i ];
+      //Only include "scored" item scores
+      const itemScores: ExamItemScore[] = item.scores.filter(score => score.points >= 0);
 
-        if (item.scores.length > 0) {
-          let compareFunction = item.type == 'MS'
+      for (let i = 0; i < item.numberOfChoices; i++) {
+        const response = this.potentialResponses[ i ];
+
+        if (itemScores.length > 0) {
+          const compareFunction = item.type == 'MS'
             ? (x => x.response != null && x.response.indexOf(response) !== -1)
             : (x => x.response == response);
 
-          let count = item.scores.filter(compareFunction).length;
+          let count = itemScores.filter(compareFunction).length;
+
           item[ this.NumberFieldPrefix + response ] = count;
-          item[ this.PercentFieldPrefix + response ] = count / item.scores.length * 100;
+          item[ this.PercentFieldPrefix + response ] = count / itemScores.length * 100;
         }
         else {
           item[ this.NumberFieldPrefix + response ] = 0;

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-item/results-by-item.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-item/results-by-item.component.ts
@@ -116,7 +116,8 @@ export class ResultsByItemComponent implements OnInit, ExportResults {
 
     for (let assessmentItem of assessmentItems) {
       let filteredItem = Object.assign(new AssessmentItem(), assessmentItem);
-      filteredItem.scores = assessmentItem.scores.filter(score => this._exams.some(exam => exam.id == score.examId));
+      filteredItem.scores = assessmentItem.scores.filter(score =>
+        score.points >= 0 && this._exams.some(exam => exam.id == score.examId));
       filtered.push(filteredItem);
     }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.ts
@@ -146,7 +146,7 @@ export class WritingTraitScoresComponent implements OnInit, ExportResults {
 
     for (let item of items) {
       let filteredItem = Object.assign(new AssessmentItem(), item);
-      filteredItem.scores = item.scores.filter(score => this._exams.some(exam => exam.id == score.examId));
+      filteredItem.scores = item.scores.filter(score => score.points >= 0 && this._exams.some(exam => exam.id == score.examId));
       filtered.push(filteredItem);
     }
 


### PR DESCRIPTION
…components to ignore "unscored" exam item scores.

Display dashes for unscored exam items
![image](https://user-images.githubusercontent.com/617828/41178699-f5a00d90-6b1c-11e8-956b-bf72b4d82a5b.png)

Unscored items are not counted in the total for results by item
![image](https://user-images.githubusercontent.com/617828/41178741-16537522-6b1d-11e8-8433-d17f98b2d505.png)

Unscored items are not counted in the total for distractor analysis (Some rows still don't add to 100% because of a scored item with no response.)
![image](https://user-images.githubusercontent.com/617828/41178776-2df5b802-6b1d-11e8-98ae-a0a396169dad.png)

Unscored items are not counted in the total for writing trait scores
![image](https://user-images.githubusercontent.com/617828/41178826-5403f612-6b1d-11e8-9d83-1387568cd718.png)
