### PR TITLE
attempt at fixing grid for ms edge

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/wide-radio-group.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/wide-radio-group.component.html
@@ -1,6 +1,6 @@
 <div class="btn-toolbar-grid toggle-group"
      [ngClass]="buttonGroupStyles"
-     [ngStyle]="{'grid-template-rows': 'repeat(' + (rowCount * 2) + ', auto)'}"
+     [ngStyle]="gridStyles"
      data-toggle="buttons">
   <ng-container *ngFor="let option of options">
     <label

--- a/webapp/src/main/webapp/src/app/aggregate-report/wide-radio-group.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/wide-radio-group.component.ts
@@ -31,6 +31,13 @@ export class WideRadioGroupComponent extends AbstractControlValueAccessor<any[]>
   private _initialized = false;
   private _initialOptions: Option[];
 
+  get gridStyles(): any {
+    return {
+      '-ms-grid-rows': 'auto '.repeat(this.rowCount).trim(),
+      'grid-template-rows': 'repeat(' + (this.rowCount * 2) + ', auto)'
+    };
+  }
+
   get buttonGroupStyles(): any {
     return this._buttonGroupStyles;
   }

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1310,6 +1310,7 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
 .card-grid {
   display: grid;
   grid-gap: @spacer;
+  -ms-grid-columns: (@spacer * 21) (@spacer * 21) (@spacer * 21);
   grid-template-columns: repeat(@cards-per-row, @spacer * 21);
 }
 
@@ -1418,11 +1419,30 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
     }
   }
 
-  .grid-2 { grid-template-columns: repeat(2, 1fr); }
-  .grid-3 { grid-template-columns: repeat(3, 1fr); }
-  .grid-4 { grid-template-columns: repeat(4, 1fr); }
-  .grid-5 { grid-template-columns: repeat(5, 1fr); }
-  .grid-6 { grid-template-columns: repeat(6, 1fr); }
+  .grid-2 {
+    -ms-grid-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid-3 {
+    -ms-grid-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .grid-4 {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .grid-5 {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(5, 1fr);
+  }
+
+  .grid-6 {
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(6, 1fr);
+  }
 
   .perc-container {
     display: grid;
@@ -1497,6 +1517,7 @@ wide-radio-group {
 
   .btn-toolbar-grid {
     display: grid;
+    -ms-grid-rows: auto auto;
     grid-template-rows: repeat(2, auto);
     grid-auto-flow: column;
     grid-gap: 0 @spacer;


### PR DESCRIPTION
Applied changes recommended here:
https://stackoverflow.com/questions/45786788/css-grid-layout-not-working-in-edge-and-ie-11-even-with-ms-prefix

It seems only the latest version of edge supports repeat() and ie11 still doesn't?

Anyway, this is an untested shot at a fix so if someone with ie11 could pull the branch and test it in edge that would be awesome 👌 