### PR TITLE
An attempt to fix slow queries with the common group filter snippet.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/UserGroupId.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/UserGroupId.java
@@ -1,0 +1,37 @@
+package org.opentestsystem.rdw.reporting.common.model;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Represents either a teacher group or an admin created user group id
+ */
+public class UserGroupId {
+    private long id;
+    private int type;
+
+    /**
+     * Default constructor for serialization
+     */
+    private UserGroupId() {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param groupId an admin created groups id
+     * @param userGroupId a user created group id
+     */
+    public UserGroupId(final Long groupId, final Long userGroupId) {
+        checkArgument((groupId != null || userGroupId != null) && (groupId != userGroupId), "one and only one group id must be not null");
+        this.id = groupId == null ? userGroupId : groupId;
+        this.type = groupId == null ? 2 : 1;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public long getId() {
+        return id;
+    }
+}

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -241,32 +241,23 @@ sql:
       ei.trait_conventions_score as ei_trait_conventions_score,
       i.performance_task_writing_type
 
-    # dependencies: student st, asmt a, :group_id, :user_group_id
+    # dependencies: sg (sql.snippet.selectFromBothGroupTypes), student st, asmt a
     groupFilters: >-
-      (
-        (
-          :group_id IS NULL
-          OR EXISTS(
-            SELECT 1
-            FROM student_group_membership sgm
-              JOIN student_group sg ON sg.id = sgm.student_group_id
-              JOIN user_student_group usg ON usg.student_group_id = sgm.student_group_id
-            WHERE sgm.student_group_id = :group_id
-              AND sgm.student_id = st.id
-              AND usg.user_login = :user_login
-              AND (sg.subject_id is null OR sg.subject_id = a.subject_id)
-          )
-        )
-        AND (
-          :user_group_id IS NULL
-          OR EXISTS(
-            SELECT 1
-            FROM teacher_student_group_membership tsgm
-              JOIN teacher_student_group tsg ON tsg.id = tsgm.teacher_student_group_id
-            WHERE tsgm.teacher_student_group_id = :user_group_id
-              AND tsgm.student_id = st.id
-              AND tsg.user_login = :user_login
-              AND (tsg.subject_id IS NULL OR tsg.subject_id = a.subject_id)
-          )
-        )
+      sg.id = :group_id
+      AND sg.user_login = :user_login
+      AND sg.group_type = :group_type
+      AND sg.student_id = st.id
+      AND (sg.subject_id IS NULL OR sg.subject_id = a.subject_id)
+
+    selectFromBothGroupTypes: >-
+      (SELECT sg.id, gm.student_id, sg.subject_id, usg.user_login, 1 AS group_type
+        FROM student_group_membership gm
+          JOIN student_group sg ON sg.id = gm.student_group_id
+          JOIN user_student_group usg ON usg.student_group_id = gm.student_group_id
+
+      UNION ALL
+
+      SELECT tsg.id, tsgm.student_id, tsg.subject_id, tsg.user_login, 2 AS group_type
+        FROM teacher_student_group_membership tsgm
+          JOIN teacher_student_group tsg ON tsg.id = tsgm.teacher_student_group_id
       )

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParams.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParams.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
+
 /**
  * This model represents an exam repository filter.
  */
@@ -8,8 +10,7 @@ public class ExamQueryParams {
     private String assessmentTypeCode;
     private Long schoolId;
     private Integer gradeId;
-    private Long groupId;
-    private Long userGroupId;
+    private UserGroupId groupId;
     private Integer schoolYear;
     private Long studentId;
     private PermissionType queryPermissionType;
@@ -43,17 +44,8 @@ public class ExamQueryParams {
         return gradeId;
     }
 
-    /**
-     * @return The student group id
-     */
-    public Long getUserGroupId() {
-        return userGroupId;
-    }
 
-    /**
-     * @return The student group id
-     */
-    public Long getGroupId() {
+    public UserGroupId getGroupId() {
         return groupId;
     }
 
@@ -94,8 +86,7 @@ public class ExamQueryParams {
         private String assessmentTypeCode;
         private Long schoolId;
         private Integer gradeId;
-        private Long groupId;
-        private Long userGroupId;
+        private UserGroupId groupId;
         private Integer schoolYear;
         private Long studentId;
         private PermissionType queryPermissionType;
@@ -108,7 +99,6 @@ public class ExamQueryParams {
             examQueryParams.schoolId = schoolId;
             examQueryParams.gradeId = gradeId;
             examQueryParams.groupId = groupId;
-            examQueryParams.userGroupId = userGroupId;
             examQueryParams.schoolYear = schoolYear;
             examQueryParams.studentId = studentId;
             examQueryParams.queryPermissionType = queryPermissionType;
@@ -149,13 +139,8 @@ public class ExamQueryParams {
             return this;
         }
 
-        public Builder groupId(final Long groupId) {
+        public Builder groupId(final UserGroupId groupId) {
             this.groupId = groupId;
-            return this;
-        }
-
-        public Builder userGroupId(final Long userGroupId) {
-            this.userGroupId = userGroupId;
             return this;
         }
 

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequest.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequest.java
@@ -1,27 +1,19 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.security.GroupGrant;
 
 public class GroupExamReportRequest extends AbstractBatchExamReportRequest<PrintOptions> {
 
     private GroupGrant groupGrant;
-    private Long groupId;
-    private Long userGroupId;
+    private UserGroupId groupId;
 
-    public GroupGrant getGroupGrant() {
-        return groupGrant;
-    }
-
-    public Long getGroupId() {
+    public UserGroupId getGroupId() {
         // Bridge for existing reports.
         if (groupGrant != null) {
-            return groupGrant.getId();
+            return new UserGroupId(groupGrant.getId(), null);
         }
         return groupId;
-    }
-
-    public Long getUserGroupId() {
-        return userGroupId;
     }
 
     public Builder copy() {
@@ -40,21 +32,15 @@ public class GroupExamReportRequest extends AbstractBatchExamReportRequest<Print
     public static class Builder extends AbstractBatchExamReportRequest.Builder<PrintOptions, GroupExamReportRequest, Builder> {
 
         private GroupGrant groupGrant;
-        private Long groupId;
-        private Long userGroupId;
+        private UserGroupId groupId;
 
         public Builder groupGrant(final GroupGrant groupGrant) {
             this.groupGrant = groupGrant;
             return this;
         }
 
-        public Builder groupId(final Long groupId) {
+        public Builder groupId(final UserGroupId groupId) {
             this.groupId = groupId;
-            return this;
-        }
-
-        public Builder userGroupId(final Long userGroupId) {
-            this.userGroupId = userGroupId;
             return this;
         }
 
@@ -68,10 +54,7 @@ public class GroupExamReportRequest extends AbstractBatchExamReportRequest<Print
             final GroupExamReportRequest search = super.build(new GroupExamReportRequest());
             search.groupGrant = groupGrant;
             search.groupId = groupId;
-            search.userGroupId = userGroupId;
             return search;
         }
-
     }
-
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParser.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParser.java
@@ -25,7 +25,6 @@ public class GroupExamQueryParamsParser implements ExamQueryParamsParser {
         return ExamQueryParams.builder()
                 .schoolYear(request.getSchoolYear())
                 .groupId(request.getGroupId())
-                .userGroupId(request.getUserGroupId())
                 .assessmentTypeCode(request.getAssessmentTypeCode())
                 .subjectCode(request.getSubjectCode())
                 .queryPermissionType(Group)

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/ReportProcessorUtils.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/util/ReportProcessorUtils.java
@@ -42,11 +42,13 @@ public class ReportProcessorUtils {
         );
         parameters.put("school_id", queryParameters.getSchoolId());
         parameters.put("grade_id", queryParameters.getGradeId());
-        parameters.put("group_id", queryParameters.getGroupId());
-        parameters.put("user_group_id", queryParameters.getUserGroupId());
         parameters.put("school_year", queryParameters.getSchoolYear());
         parameters.put("student_id", queryParameters.getStudentId());
         parameters.put("disable_transfer_access", queryParameters.isDisableTransferAccess());
+        if (queryParameters.getGroupId() != null) {
+            parameters.put("group_id", queryParameters.getGroupId().getId());
+            parameters.put("group_type", queryParameters.getGroupId().getType());
+        }
         return parameters;
     }
 

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -43,6 +43,7 @@ sql:
         ${sql.snippet.writingTraits},
         ${sql.snippet.exam}
       JOIN district d ON s.district_id=d.id
+      JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
       LEFT JOIN exam_item ei ON ei.exam_id=e.id
       LEFT JOIN item i ON i.id=ei.item_id
       ${sql.reportProcessor.snippet.percentileLeftJoin}
@@ -108,6 +109,7 @@ sql:
         JOIN item i ON i.id=ei.item_id
         WHERE i.performance_task_writing_type is not null
       ) wt ON wt.exam_id = e.id
+      JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
       WHERE e.student_id in (:student_ids)
         AND ${sql.snippet.groupFilters}
         AND (:school_year is null or e.school_year=:school_year)
@@ -270,6 +272,7 @@ sql:
 
     findByExamQueryParamsGroupPermissions: >-
       ${sql.reportProcessor.snippet.selectFromStudent}
+      JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
       WHERE ${sql.snippet.groupFilters}
         AND (:student_id is null or st.id = :student_id)
         AND (:school_year is null or e.school_year = :school_year)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParamsTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/ExamQueryParamsTest.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
 import org.junit.Test;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,7 +13,7 @@ public class ExamQueryParamsTest {
                 .assessmentTypeCode("type1")
                 .schoolId(1L)
                 .gradeId(1)
-                .groupId(1L)
+                .groupId(new UserGroupId(1L, null))
                 .schoolYear(1)
                 .studentId(1L)
                 .queryPermissionType(ExamQueryParams.PermissionType.Group)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequestTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequestTest.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
 import org.junit.Test;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,10 +31,10 @@ public class GroupExamReportRequestTest extends AbstractBatchExamReportRequestTe
     public void itShouldStoreGroupGrant() {
         final long groupId = 123L;
         final GroupExamReportRequest request = createBuilder()
-                .groupId(groupId)
+                .groupId(new UserGroupId(groupId, null))
                 .build();
 
-        assertThat(request.getGroupId()).isEqualTo(groupId);
+        assertThat(request.getGroupId().getId()).isEqualTo(groupId);
+        assertThat(request.getGroupId().getType()).isEqualTo(1);
     }
-
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.common.model.CustomAggregateReportQuery;
 import org.opentestsystem.rdw.reporting.common.model.StudentFilters;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.model.jackson.AggregateReportModule;
 import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.AggregateReportRequest;
@@ -58,13 +59,14 @@ public class AbstractExamReportRequestDeserializerTest {
     @Test
     public void itShouldRoundTripAGroupRequest() throws Exception {
         final GroupExamReportRequest request = GroupExamReportRequest.builder()
-                .groupId(123L)
+                .groupId(new UserGroupId(123L, null))
                 .schoolYear(1234)
                 .build();
         final String json = objectMapper.writeValueAsString(request);
         final GroupExamReportRequest deserialized = (GroupExamReportRequest) objectMapper.readValue(json, AbstractExamReportRequest.class);
         assertThat(deserialized.getSchoolYear()).isEqualTo(1234);
-        assertThat(deserialized.getGroupId()).isEqualTo(123);
+        assertThat(deserialized.getGroupId().getId()).isEqualTo(123);
+        assertThat(deserialized.getGroupId().getType()).isEqualTo(1);
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIabReportRepositoryIT.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemSettings;
 import org.opentestsystem.rdw.reporting.common.model.ExamWithPercentile;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
@@ -118,7 +119,7 @@ public class JdbcIabReportRepositoryIT {
     @Test
     public void itShouldFindAllIabReportsForStudentsByGroupAndYear() {
         final ExamQueryParams examQueryParams = builder()
-                .groupId(-20L)
+                .groupId(new UserGroupId(-20L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -137,7 +138,7 @@ public class JdbcIabReportRepositoryIT {
     @Test
     public void itShouldNotFindAllIabReportsForStudentsByGroupForUserWithoutGroupAccess() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .groupId(-30L)
+                .groupId(new UserGroupId(-30L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -164,7 +165,7 @@ public class JdbcIabReportRepositoryIT {
     @Test
     public void itShouldFindAllIabReportsForStudentsByGroupAndYearRespectingTransferAccess() {
         final ExamQueryParams examQueryParams = builder()
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .schoolYear(1998)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -191,7 +192,7 @@ public class JdbcIabReportRepositoryIT {
     @Test
     public void itShouldFindAllIabReportsForStudentsByUserGroupAndYearRespectingTransferAccess() {
         final ExamQueryParams examQueryParams = builder()
-                .userGroupId(-100L)
+                .groupId(new UserGroupId(null, -100L))
                 .schoolYear(1998)
                 .queryPermissionType(Group)
                 .gradeId(-1)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemSettings;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
@@ -129,7 +130,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldFindAllIcaReportsForStudentsByGroup() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .groupId(-20L)
+                .groupId(new UserGroupId(-20L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -149,7 +150,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldFindAllIcaReportsForStudentsByUserGroup() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .userGroupId(-20L)
+                .groupId(new UserGroupId(null, -20L))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -169,7 +170,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldFindAllSummativeReportsForStudentsByGroup() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .groupId(-40L)
+                .groupId(new UserGroupId(-40L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -188,7 +189,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldNotFindAllIcaReportsForStudentsByGroupForUserWithoutGroupAccess() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .groupId(-30L)
+                .groupId(new UserGroupId(-30L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -216,7 +217,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldFindAllIcaReportsForStudentsByGroupRespectingTransferAccess() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .schoolYear(1998)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -243,7 +244,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
     @Test
     public void itShouldFindAllIcaReportsForStudentsByUserGroupRespectingTransferAccess() {
         final ExamQueryParams examQueryParams = ExamQueryParams.builder()
-                .userGroupId(-100L)
+                .groupId(new UserGroupId(null, -100L))
                 .schoolYear(1998)
                 .queryPermissionType(Group)
                 .gradeId(-1)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcStudentRepositoryIT.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemSettings;
 import org.opentestsystem.rdw.reporting.common.model.Student;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
@@ -106,7 +107,7 @@ public class JdbcStudentRepositoryIT {
     @Test
     public void itShouldFindStudentIdsByGroupId() {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
-                .groupId(-10L)
+                .groupId(new UserGroupId(-10L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -116,7 +117,7 @@ public class JdbcStudentRepositoryIT {
         assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
 
         final ExamQueryParams g2Params = ExamQueryParams.builder()
-                .groupId(-20L)
+                .groupId(new UserGroupId(-20L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -129,7 +130,7 @@ public class JdbcStudentRepositoryIT {
     @Test
     public void itShouldFindStudentIdsByUserGroupId() {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
-                .userGroupId(-10L)
+                .groupId(new UserGroupId(null, -10L))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -139,7 +140,7 @@ public class JdbcStudentRepositoryIT {
         assertThat(g1Students.stream().map(Student::getId)).containsOnly(-1L);
 
         final ExamQueryParams g2Params = ExamQueryParams.builder()
-                .groupId(-20L)
+                .groupId(new UserGroupId(-20L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -152,7 +153,7 @@ public class JdbcStudentRepositoryIT {
     @Test
     public void itShouldNotFindStudentIdsByGroupIdForUserWithoutGroupAccess() {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
-                .groupId(-30L)
+                .groupId(new UserGroupId(-30L, null))
                 .schoolYear(1997)
                 .queryPermissionType(Group)
                 .gradeId(-1)
@@ -174,7 +175,7 @@ public class JdbcStudentRepositoryIT {
     @Test
     public void itShouldFindStudentIdsByGroupIdRespectingTransferAccess() {
         final ExamQueryParams g1Params = ExamQueryParams.builder()
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .schoolYear(1998)
                 .queryPermissionType(Group)
                 .gradeId(-1)

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParserTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/requesthandler/GroupExamQueryParamsParserTest.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.reporting.processor.requesthandler;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.processor.model.GroupExamReportRequest;
@@ -29,15 +30,15 @@ public class GroupExamQueryParamsParserTest {
         final GroupExamReportRequest request = GroupExamReportRequest.builder()
                 .schoolYear(1997)
                 .subjectCode("ELA")
-                .groupId(123L)
+                .groupId(new UserGroupId(123L, null))
                 .assessmentTypeCode("iab")
                 .build();
         final ExamQueryParams params = parser.parseQueryParams(request);
 
         assertThat(params.getAssessmentTypeCode()).isEqualTo("iab");
-        assertThat(params.getGroupId()).isEqualTo(123L);
+        assertThat(params.getGroupId().getId()).isEqualTo(123L);
+        assertThat(params.getGroupId().getType()).isEqualTo(1);
         assertThat(params.getSubjectCode()).isEqualTo("ELA");
         assertThat(params.getSchoolYear()).isEqualTo(1997);
     }
-
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/web/ReportControllerIT.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.model.jackson.AggregateReportModule;
 import org.opentestsystem.rdw.reporting.common.test.support.ReportQueries;
 import org.opentestsystem.rdw.reporting.common.web.DefaultJsonContentConfiguration;
@@ -79,7 +80,7 @@ public class ReportControllerIT {
             .build();
 
     private static final GroupExamReportRequest GroupRequest = GroupExamReportRequest.builder()
-            .groupId(1L)
+            .groupId(new UserGroupId(1L, null))
             .subjectCode("Math")
             .schoolYear(2)
             .assessmentTypeCode("ica")

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/DefaultGroupAssessmentService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/DefaultGroupAssessmentService.java
@@ -36,7 +36,6 @@ class DefaultGroupAssessmentService implements GroupAssessmentService {
         final GroupExamSearch examSearch = GroupExamSearch.builder()
                 .schoolYear(search.getSchoolYear())
                 .groupId(search.getGroupId())
-                .userGroupId(search.getUserGroupId())
                 .assessmentId(assessment.getId())
                 .build();
 

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupAssessmentSearch.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupAssessmentSearch.java
@@ -1,11 +1,11 @@
 package org.opentestsystem.rdw.reporting.exam.group;
 
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.exam.AbstractAssessmentSearch;
 
 class GroupAssessmentSearch extends AbstractAssessmentSearch {
 
-    private Long groupId;
-    private Long userGroupId;
+    private UserGroupId groupId;
 
     private GroupAssessmentSearch() {
     }
@@ -14,35 +14,23 @@ class GroupAssessmentSearch extends AbstractAssessmentSearch {
         return new Builder();
     }
 
-    public Long getGroupId() {
+    public UserGroupId getGroupId() {
         return groupId;
-    }
-
-    public Long getUserGroupId() {
-        return userGroupId;
     }
 
     public static class Builder extends AbstractAssessmentSearch.Builder<GroupAssessmentSearch, Builder> {
 
-        private Long groupId;
-        private Long userGroupId;
+        private UserGroupId groupId;
 
-        public Builder groupId(final Long groupId) {
+        public Builder groupId(final UserGroupId groupId) {
             this.groupId = groupId;
-            return this;
-        }
-
-        public Builder userGroupId(final Long userGroupId) {
-            this.userGroupId = userGroupId;
             return this;
         }
 
         public GroupAssessmentSearch build() {
             final GroupAssessmentSearch search = super.build(new GroupAssessmentSearch());
             search.groupId = groupId;
-            search.userGroupId = userGroupId;
             return search;
         }
-
     }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupAssessmentSearchArgumentResolver.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupAssessmentSearchArgumentResolver.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.reporting.exam.group;
 
+import com.google.common.primitives.Longs;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -26,18 +28,11 @@ class GroupAssessmentSearchArgumentResolver implements HandlerMethodArgumentReso
         if (schoolYear != null) {
             search.schoolYear(Integer.parseInt(schoolYear));
         }
-
-        final String groupId = request.getParameter("groupId");
-        if (groupId != null) {
-            search.groupId(Long.parseLong(groupId));
-        }
-
-        final String userGroupId = request.getParameter("userGroupId");
-        if (userGroupId != null) {
-            search.userGroupId(Long.parseLong(userGroupId));
-        }
-
-        return search.build();
+        return search.groupId(new UserGroupId(tryToParseLong(request.getParameter("groupId")), tryToParseLong(request.getParameter("userGroupId")))).build();
     }
 
+    private static Long tryToParseLong(final String value) {
+        if (value == null) return null;
+        return Longs.tryParse(value);
+    }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupExamSearch.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupExamSearch.java
@@ -1,12 +1,16 @@
 package org.opentestsystem.rdw.reporting.exam.group;
 
 import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.exam.AbstractExamSearch;
 
+/**
+ * Represents a search by either teacher group or an admin created user group
+ * It assumes that only one group id is present
+ */
 class GroupExamSearch extends AbstractExamSearch {
 
-    private Long groupId;
-    private Long userGroupId;
+    private UserGroupId groupId;
     private ImmutableSet<String> itemTypes; // TODO belongs in dedicated GroupExamItemSearch
 
     private GroupExamSearch() {
@@ -16,12 +20,8 @@ class GroupExamSearch extends AbstractExamSearch {
         return new Builder();
     }
 
-    public Long getGroupId() {
+    public UserGroupId getGroupId() {
         return groupId;
-    }
-
-    public Long getUserGroupId() {
-        return userGroupId;
     }
 
     public ImmutableSet<String> getItemTypes() {
@@ -30,17 +30,11 @@ class GroupExamSearch extends AbstractExamSearch {
 
     public static class Builder extends AbstractExamSearch.Builder<GroupExamSearch, Builder> {
 
-        private Long groupId;
-        private Long userGroupId;
+        private UserGroupId groupId;
         private Iterable<String> itemTypes;
 
-        public Builder groupId(final Long groupId) {
+        public Builder groupId(final UserGroupId groupId) {
             this.groupId = groupId;
-            return this;
-        }
-
-        public Builder userGroupId(final Long userGroupId) {
-            this.userGroupId = userGroupId;
             return this;
         }
 
@@ -52,11 +46,8 @@ class GroupExamSearch extends AbstractExamSearch {
         public GroupExamSearch build() {
             final GroupExamSearch search = super.build(new GroupExamSearch());
             search.groupId = groupId;
-            search.userGroupId = userGroupId;
             search.itemTypes = itemTypes != null ? ImmutableSet.copyOf(itemTypes) : ImmutableSet.of();
             return search;
         }
-
     }
-
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupExamSearchArgumentResolver.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/GroupExamSearchArgumentResolver.java
@@ -1,7 +1,10 @@
 package org.opentestsystem.rdw.reporting.exam.group;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
 import org.apache.commons.lang.ArrayUtils;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -22,32 +25,22 @@ class GroupExamSearchArgumentResolver implements HandlerMethodArgumentResolver {
             final NativeWebRequest request,
             final WebDataBinderFactory binderFactory) {
 
-        final GroupExamSearch.Builder search = GroupExamSearch.builder();
+        return GroupExamSearch.builder()
+                .itemTypes(ImmutableList.copyOf(ArrayUtils.nullToEmpty(request.getParameterValues("types"))))
+                .schoolYear(tryToParseInt(request.getParameter("schoolYear")))
+                .assessmentId(tryToParseInt(request.getParameter("assessmentId")))
+                .groupId(new UserGroupId(tryToParseLong(request.getParameter("groupId")), tryToParseLong(request.getParameter("userGroupId"))))
+                .build();
 
-        final String schoolYear = request.getParameter("schoolYear");
-        if (schoolYear != null) {
-            search.schoolYear(Integer.parseInt(schoolYear));
-        }
-
-        final String assessmentId = request.getParameter("assessmentId");
-        if (assessmentId != null) {
-            search.assessmentId(Integer.parseInt(assessmentId));
-        }
-
-        final String groupId = request.getParameter("groupId");
-        if (groupId != null) {
-            search.groupId(Long.parseLong(groupId));
-        }
-
-        final String userGroupId = request.getParameter("userGroupId");
-        if (userGroupId != null) {
-            search.userGroupId(Long.parseLong(userGroupId));
-        }
-
-        final String[] itemTypes = ArrayUtils.nullToEmpty(request.getParameterValues("types"));
-        search.itemTypes(ImmutableList.copyOf(itemTypes));
-
-        return search.build();
     }
 
+    private static Long tryToParseLong(final String value) {
+        if (value == null) return null;
+        return Longs.tryParse(value);
+    }
+
+    private static Integer tryToParseInt(final String value) {
+        if (value == null) return null;
+        return Ints.tryParse(value);
+    }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupAssessmentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupAssessmentRepository.java
@@ -37,8 +37,8 @@ class JdbcGroupAssessmentRepository extends AbstractAssessmentRepository<GroupAs
     @Override
     protected Map<String, Object> getParameters(final GroupAssessmentSearch search) {
         final Map<String, Object> parameters = newHashMap();
-        parameters.put("group_id", search.getGroupId());
-        parameters.put("user_group_id", search.getUserGroupId());
+        parameters.put("group_id", search.getGroupId().getId());
+        parameters.put("group_type", search.getGroupId().getType());
         return parameters;
     }
 

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamItemRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamItemRepository.java
@@ -24,9 +24,8 @@ class JdbcGroupExamItemRepository extends AbstractExamItemRepository<GroupExamSe
     @Override
     protected Map<String, Object> getParameters(final GroupExamSearch search) {
         final Map<String, Object> parameters = new HashMap<>();
-        parameters.put("group_id", search.getGroupId());
-        parameters.put("user_group_id", search.getUserGroupId());
+        parameters.put("group_id", search.getGroupId().getId());
+        parameters.put("group_type", search.getGroupId().getType());
         return parameters;
     }
-
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepository.java
@@ -26,8 +26,8 @@ class JdbcGroupExamRepository extends AbstractExamRepository<GroupExamSearch> im
     @Override
     protected Map<String, Object> getParameters(final GroupExamSearch search) {
         final Map<String, Object> parameters = new HashMap<>();
-        parameters.put("group_id", search.getGroupId());
-        parameters.put("user_group_id", search.getUserGroupId());
+        parameters.put("group_id", search.getGroupId().getId());
+        parameters.put("group_type", search.getGroupId().getType());
         return parameters;
     }
 }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamWithTargetScoreRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamWithTargetScoreRepository.java
@@ -55,13 +55,13 @@ class JdbcGroupExamWithTargetScoreRepository implements GroupExamWithTargetScore
                         .addValues(securityParameterProvider.getSecurityParameters(permissionSource))
                         .addValue("school_year", search.getSchoolYear())
                         .addValue("assessment_id", search.getAssessmentId())
-                        .addValue("group_id", search.getGroupId())
-                        .addValue("user_group_id", search.getUserGroupId()),
+                        .addValue("group_id", search.getGroupId().getId())
+                        .addValue("group_type", search.getGroupId().getType()),
                 (row, index) -> {
                     examBuilders.add(Exams.map(row, ExamWithTargetScore.builder()
-                            .targetId(row.getInt("target_id"))
-                            .studentRelativeResidualScore(getNullable(row, row.getDouble("student_relative_residual_score")))
-                            .standardMetRelativeResidualScore(getNullable(row, row.getDouble("standard_met_relative_residual_score")))
+                                    .targetId(row.getInt("target_id"))
+                                    .studentRelativeResidualScore(getNullable(row, row.getDouble("student_relative_residual_score")))
+                                    .standardMetRelativeResidualScore(getNullable(row, row.getDouble("standard_met_relative_residual_score")))
                                     .studentContext(StudentContexts.map(row, StudentContext.builder()).build()),
                             permissionSource.getPermissionsById()));
 

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -104,6 +104,7 @@ sql:
             JOIN school s ON e.school_id = s.id
             JOIN student st ON e.student_id = st.id
             JOIN school isch ON st.inferred_school_id = isch.id
+            JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
           WHERE e.school_year = :school_year
             AND a.id = e.asmt_id
             AND ${sql.snippet.groupFilters}
@@ -117,6 +118,7 @@ sql:
             JOIN school s ON e.school_id=s.id
             JOIN student st ON e.student_id = st.id
             JOIN school isch ON st.inferred_school_id = isch.id
+            JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
           WHERE e.school_year = :school_year
             AND ${sql.snippet.groupFilters}
             AND ${sql.reporting.snippet.studentExamPermissionWithEmbargo}
@@ -132,6 +134,7 @@ sql:
           e.migrant_status,
           ${sql.snippet.claimColumns},
           ${sql.snippet.exam}
+          JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
         WHERE a.id = :assessment_id
           AND e.school_year = :school_year
           AND ${sql.snippet.groupFilters}
@@ -152,6 +155,7 @@ sql:
           JOIN school isch on st.inferred_school_id = isch.id
           JOIN exam_target_score ets on ets.exam_id = e.id
           JOIN target t on t.id = ets.target_id
+          JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
          WHERE a.id = :assessment_id
             AND e.school_year = :school_year
             AND ${sql.snippet.groupFilters}
@@ -185,26 +189,28 @@ sql:
           SELECT
             e1.id
           FROM (
-                 SELECT ex1.id, ex1.student_id, ex1.asmt_id, ex1.school_year, ex1.completed_at
-                 FROM exam ex1
-                   JOIN asmt a ON a.id = ex1.asmt_id
-                   JOIN student st ON st.id = ex1.student_id
-                 WHERE ex1.type_id = 2
-                       AND ex1.school_year = :school_year
-                       AND ex1.scale_score IS NOT NULL
-                       AND ex1.scale_score_std_err IS NOT NULL
-                       AND ex1.performance_level IS NOT NULL
+                 SELECT e.id, e.student_id, e.asmt_id, e.school_year, e.completed_at
+                 FROM exam e
+                   JOIN asmt a ON a.id = e.asmt_id
+                   JOIN student st ON st.id = e.student_id
+                   JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
+                 WHERE e.type_id = 2
+                       AND e.school_year = :school_year
+                       AND e.scale_score IS NOT NULL
+                       AND e.scale_score_std_err IS NOT NULL
+                       AND e.performance_level IS NOT NULL
                        AND ${sql.snippet.groupFilters}
                ) AS e1 LEFT OUTER JOIN
-            ( SELECT ex2.id, ex2.student_id, ex2.asmt_id, ex2.school_year, ex2.completed_at
-              FROM exam ex2
-                JOIN asmt a ON a.id = ex2.asmt_id
-                JOIN student st ON st.id = ex2.student_id
-            WHERE ex2.type_id = 2
-                  AND ex2.school_year = :school_year
-                  AND ex2.scale_score IS NOT NULL
-                  AND ex2.scale_score_std_err IS NOT NULL
-                  AND ex2.performance_level IS NOT NULL
+            ( SELECT e.id, e.student_id, e.asmt_id, e.school_year, e.completed_at
+              FROM exam e
+                JOIN asmt a ON a.id = e.asmt_id
+                JOIN student st ON st.id = e.student_id
+                JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
+            WHERE e.type_id = 2
+                  AND e.school_year = :school_year
+                  AND e.scale_score IS NOT NULL
+                  AND e.scale_score_std_err IS NOT NULL
+                  AND e.performance_level IS NOT NULL
                   AND ${sql.snippet.groupFilters}
             ) AS e2
               ON e1.student_id = e2.student_id  AND e1.asmt_id = e2.asmt_id AND e1.school_year = e2.school_year
@@ -217,6 +223,7 @@ sql:
     examItem:
         findAllExamItemScoresForAssessment:
           ${sql.reporting.snippet.selectFromExamItem}
+          JOIN ${sql.snippet.selectFromBothGroupTypes} sg ON sg.student_id = e.student_id
           WHERE e.asmt_id = :assessment_id
             AND e.school_year = :school_year
             AND ${sql.snippet.groupFilters}

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupAssessmentRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupAssessmentRepositoryIT.java
@@ -6,6 +6,7 @@ import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.opentestsystem.rdw.reporting.TestData;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.model.MeasuredAssessment;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.group.GroupRepository;
 import org.opentestsystem.rdw.reporting.group.JdbcGroupRepository;
@@ -38,32 +39,32 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
 
     private GroupAssessmentSearch.Builder search() {
         return GroupAssessmentSearch.builder()
-                .groupId(-10L)
+                .groupId(new UserGroupId(-10L, null))
                 .schoolYear(1997);
     }
 
     private GroupAssessmentSearch.Builder userGroupSearch() {
         return GroupAssessmentSearch.builder()
-                .userGroupId(-10L)
+                .groupId(new UserGroupId(null, -10L))
                 .schoolYear(1997);
     }
 
     @Test
     public void findAllShouldFindNothingForMissingGroup() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(), search()
-                .groupId(0L).build())).isEmpty();
+                .groupId(new UserGroupId(0L, null)).build())).isEmpty();
     }
 
     @Test
     public void findAllMeasuredAssessmentsShouldFindNothingForMissingGroup() {
         assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search()
-                .groupId(0L).build())).isEmpty();
+                .groupId(new UserGroupId(0L, null)).build())).isEmpty();
     }
 
     @Test
     public void findAllForUserGroupShouldFindNothingForMissingGroup() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch()
-                .userGroupId(0L).build())).isEmpty();
+                .groupId(new UserGroupId(null, 0L)).build())).isEmpty();
     }
 
     @Test
@@ -114,42 +115,42 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
 
     @Test
     public void itShouldFindOnlyScoredMeasuredAssessments() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(-50L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(new UserGroupId(-50L, null)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT5_MEASURED_ASSESSMENTS);
     }
 
     @Test
     public void findAllMeasuredAssessmentsForUserGroupShouldOnlyFindScoredAssessments() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().userGroupId(-50L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().groupId(new UserGroupId(null, -50L)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT5_MEASURED_ASSESSMENTS);
     }
 
     @Test
     public void itShouldFindAllScaleScoreMeasuredAssessments() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(-60L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(new UserGroupId(-60L, null)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT6_MEASURED_ASSESSMENTS);
     }
 
     @Test
     public void findAllMeasuredAssessmentsForUserGroupShouldFindAllScaleScores() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().userGroupId(-60L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().groupId(new UserGroupId(null, -60L)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT6_MEASURED_ASSESSMENTS);
     }
 
     @Test
     public void itShouldFindAllScaleScoreStdErrMeasuredAssessments() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(-70L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), search().groupId(new UserGroupId(-70L, null)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENTS_MEASURED_ASSESSMENTS);
     }
 
     @Test
     public void findAllMeasuredAssessmentsForUserGroupShouldFindAllScaleScoreStandardError() {
-        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().userGroupId(-70L).build()))
+        assertThat(repository.findAllMeasuredAssessments(userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().groupId(new UserGroupId(null, -70L)).build()))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENTS_MEASURED_ASSESSMENTS);
     }
@@ -157,7 +158,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
     @Test
     public void itShouldCountMeasuredAssessmentsAndBeDifferentThanStudentGroupSize() {
         final User user = userBuilder().permissionsById(groupStatewide).build();
-        final List<MeasuredAssessment> measuredAssessments = repository.findAllMeasuredAssessments(user, search().groupId(-80L).build());
+        final List<MeasuredAssessment> measuredAssessments = repository.findAllMeasuredAssessments(user, search().groupId(new UserGroupId(-80L, null)).build());
         assertThat(measuredAssessments)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnlyElementsOf(TestData.STUDENT6_MEASURED_ASSESSMENTS);
@@ -169,42 +170,42 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
     @Test
     public void findAllShouldFindAllForGroupWithAllSubjects() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(),
-                GroupAssessmentSearch.builder().groupId(-30L).schoolYear(1997).build()).size()).isEqualTo(2);
+                GroupAssessmentSearch.builder().groupId(new UserGroupId(-30L, null)).schoolYear(1997).build()).size()).isEqualTo(2);
     }
 
     @Test
     public void findAllForUserGroupShouldFindAllForGroupWithAllSubjects() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(),
-                GroupAssessmentSearch.builder().userGroupId(-30L).schoolYear(1997).build()).size()).isEqualTo(2);
+                GroupAssessmentSearch.builder().groupId(new UserGroupId(null, -30L)).schoolYear(1997).build()).size()).isEqualTo(2);
     }
 
     @Test
     public void findAllShouldFindAllForGroupWithOneSubject() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(),
-                GroupAssessmentSearch.builder().groupId(-90L).schoolYear(1997).build()).size()).isEqualTo(1);
+                GroupAssessmentSearch.builder().groupId(new UserGroupId(-90L, null)).schoolYear(1997).build()).size()).isEqualTo(1);
     }
 
     @Test
     public void findAllForUserGroupShouldFindAllForGroupWithOneSubject() {
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(),
-                GroupAssessmentSearch.builder().userGroupId(-90L).schoolYear(1997).build()).size()).isEqualTo(1);
+                GroupAssessmentSearch.builder().groupId(new UserGroupId(null, -90L)).schoolYear(1997).build()).size()).isEqualTo(1);
     }
 
     @Test
     public void findLatestShouldFindTheLatestExam() {
-        final Assessment actual = repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), GroupAssessmentSearch.builder().groupId(-30L).schoolYear(1997).build());
+        final Assessment actual = repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), GroupAssessmentSearch.builder().groupId(new UserGroupId(-30L, null)).schoolYear(1997).build());
         assertThat(actual).isEqualTo(TestData.ALL_ASSESSMENTS_BY_ID.get(-1));
     }
 
     @Test
     public void findLatestForUserGroupShouldFindTheLatestExam() {
-        final Assessment actual = repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), GroupAssessmentSearch.builder().userGroupId(-30L).schoolYear(1997).build());
+        final Assessment actual = repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), GroupAssessmentSearch.builder().groupId(new UserGroupId(null, -30L)).schoolYear(1997).build());
         assertThat(actual).isEqualTo(TestData.ALL_ASSESSMENTS_BY_ID.get(-1));
     }
 
     @Test
     public void findLatestShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(-20L).schoolYear(1997).build();
+        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(new UserGroupId(-20L, null)).schoolYear(1997).build();
 
         //user with a different group access
         assertThat(repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), search)).isNull();
@@ -219,7 +220,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
 
     @Test
     public void findLatestForUserGroupShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().userGroupId(-20L).schoolYear(1997).build();
+        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(new UserGroupId(null, 20L)).schoolYear(1997).build();
 
         //user with a different group access
         assertThat(repository.findLatest(userBuilder().permissionsById(groupStatewide).build(), search)).isNull();
@@ -234,7 +235,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
 
     @Test
     public void findAllShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(-20L).schoolYear(1997).build();
+        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(new UserGroupId(-20L, null)).schoolYear(1997).build();
 
         //user with a different group access
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -250,7 +251,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
 
     @Test
     public void findAllForUserGroupShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().userGroupId(-20L).schoolYear(1997).build();
+        final GroupAssessmentSearch search = GroupAssessmentSearch.builder().groupId(new UserGroupId(null, -20L)).schoolYear(1997).build();
 
         //user with a different group access
         assertThat(repository.findAll(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -268,7 +269,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
     public void findAllShouldFindAllRespectingTransferAccess() {
         final GroupAssessmentSearch query = search()
                 .schoolYear(1998)
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();
@@ -282,7 +283,7 @@ public class JdbcGroupAssessmentRepositoryIT extends JdbcRepositoryWithPermissio
     public void findAllForUserGroupShouldFindAllRespectingTransferAccess() {
         final GroupAssessmentSearch query = userGroupSearch()
                 .schoolYear(1998)
-                .userGroupId(-100L)
+                .groupId(new UserGroupId(null, -100L))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamItemRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamItemRepositoryIT.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.opentestsystem.rdw.reporting.common.model.ExamItem;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.security.Permission;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,14 +30,14 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
 
     private GroupExamSearch.Builder search() {
         return GroupExamSearch.builder()
-                .groupId(-10L)
+                .groupId(new UserGroupId(-10L, null))
                 .schoolYear(1997)
                 .assessmentId(-1);
     }
 
     private GroupExamSearch.Builder userGroupSearch() {
         return GroupExamSearch.builder()
-                .userGroupId(-10L)
+                .groupId(new UserGroupId(null, -10L))
                 .schoolYear(1997)
                 .assessmentId(-1);
     }
@@ -68,13 +69,13 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
     @Test
     public void findAllExamItemScoresForAssessmentShouldBeEmptyForMismatchingGroup() {
         assertThat(repository.findAllExamItemScoresForAssessment(
-                userBuilder().permissionsById(groupStatewide).build(), search().groupId(0L).build())).isEmpty();
+                userBuilder().permissionsById(groupStatewide).build(), search().groupId(new UserGroupId(0L, null)).build())).isEmpty();
     }
 
     @Test
     public void findAllExamItemScoresForAssessmentByUserGroupShouldBeEmptyForMismatchingGroup() {
         assertThat(repository.findAllExamItemScoresForAssessment(
-                userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().userGroupId(0L).build())).isEmpty();
+                userBuilder().permissionsById(groupStatewide).build(), userGroupSearch().groupId(new UserGroupId(null, 0L)).build())).isEmpty();
     }
 
     @Test
@@ -127,7 +128,7 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
 
     @Test
     public void findAllExamItemScoresForAssessmentShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupExamSearch search = search().groupId(-20L).build();
+        final GroupExamSearch search = search().groupId(new UserGroupId(-20L, null)).build();
 
         //user with a different group access
         assertThat(repository.findAllExamItemScoresForAssessment(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -144,7 +145,7 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
 
     @Test
     public void findAllExamItemScoresForAssessmentByUserGroupShouldFindNothingForUserWithNoAccessToGroup() {
-        final GroupExamSearch search = userGroupSearch().userGroupId(-20L).build();
+        final GroupExamSearch search = userGroupSearch().groupId(new UserGroupId(null, -20L)).build();
 
         //user with a different group access
         assertThat(repository.findAllExamItemScoresForAssessment(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -164,7 +165,7 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
 
         final GroupExamSearch query = search()
                 .schoolYear(1998)
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();
@@ -182,7 +183,7 @@ public class JdbcGroupExamItemRepositoryIT extends JdbcRepositoryWithPermissionI
 
         final GroupExamSearch query = userGroupSearch()
                 .schoolYear(1998)
-                .userGroupId(-100L)
+                .groupId(new UserGroupId(null, -100L))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamRepositoryIT.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
 import org.opentestsystem.rdw.reporting.TestData;
 import org.opentestsystem.rdw.reporting.common.model.Exam;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.student.JdbcStudentEthnicityRepository;
 import org.opentestsystem.rdw.security.Permission;
@@ -28,14 +29,14 @@ public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
 
     private GroupExamSearch.Builder search() {
         return GroupExamSearch.builder()
-                .groupId(-10L)
+                .groupId(new UserGroupId(-10L, null))
                 .assessmentId(-1)
                 .schoolYear(1997);
     }
 
     private GroupExamSearch.Builder userGroupSearch() {
         return GroupExamSearch.builder()
-                .userGroupId(-10L)
+                .groupId(new UserGroupId(null, -10L))
                 .assessmentId(-1)
                 .schoolYear(1997);
     }
@@ -56,7 +57,7 @@ public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
 
     @Test
     public void findAllShouldFindNothingForUserWithoutGroupAccess() {
-        final GroupExamSearch search = search().groupId(-20L).build();
+        final GroupExamSearch search = search().groupId(new UserGroupId(-20L, null)).build();
 
         //user with a different group access
         assertThat(repository.findAllForAssessment(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -73,7 +74,7 @@ public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
 
     @Test
     public void findAllByUserGroupShouldFindNothingForUserWithoutGroupAccess() {
-        final GroupExamSearch search = userGroupSearch().userGroupId(-20L).build();
+        final GroupExamSearch search = userGroupSearch().groupId(new UserGroupId(null, -20L)).build();
 
         //user with a different group access
         assertThat(repository.findAllForAssessment(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -92,7 +93,7 @@ public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
     public void findAllForAssessmentShouldRespectTransferAccess() {
         final GroupExamSearch query = search()
                 .schoolYear(1998)
-                .groupId(-100L)
+                .groupId(new UserGroupId(-100L, null))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();
@@ -106,7 +107,7 @@ public class JdbcGroupExamRepositoryIT extends JdbcRepositoryWithPermissionIT {
     public void findAllForAssessmentByUserGroupShouldRespectTransferAccess() {
         final GroupExamSearch query = userGroupSearch()
                 .schoolYear(1998)
-                .userGroupId(-100L)
+                .groupId(new UserGroupId(null, -100L))
                 .build();
 
         final User user = userBuilder().permissionsById(permissions(groupOf(schools(-40L)))).build();

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamWithTargetScoreRepositoryIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/exam/group/JdbcGroupExamWithTargetScoreRepositoryIT.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.exam.group;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.JdbcRepositoryWithPermissionIT;
+import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
 import org.opentestsystem.rdw.reporting.common.web.security.User;
 import org.opentestsystem.rdw.reporting.student.JdbcStudentEthnicityRepository;
 import org.opentestsystem.rdw.security.Permission;
@@ -32,14 +33,14 @@ public class JdbcGroupExamWithTargetScoreRepositoryIT extends JdbcRepositoryWith
 
     private GroupExamSearch.Builder search() {
         return GroupExamSearch.builder()
-                .groupId(-20L)
+                .groupId(new UserGroupId(-20L, null))
                 .schoolYear(1997)
                 .assessmentId(-4);
     }
 
     private GroupExamSearch.Builder userGroupSearch() {
         return GroupExamSearch.builder()
-                .userGroupId(-20L)
+                .groupId(new UserGroupId(null,-20L))
                 .schoolYear(1997)
                 .assessmentId(-4);
     }
@@ -62,7 +63,7 @@ public class JdbcGroupExamWithTargetScoreRepositoryIT extends JdbcRepositoryWith
 
     @Test
     public void findAllShouldFindNothingForUserWithoutGroupAccess() {
-        final GroupExamSearch search = search().groupId(-10L).build();
+        final GroupExamSearch search = search().groupId(new UserGroupId(-10L, null)).build();
 
         //user with a different group access
         assertThat(repository.findAllByGroupExamSearch(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();
@@ -79,7 +80,7 @@ public class JdbcGroupExamWithTargetScoreRepositoryIT extends JdbcRepositoryWith
 
     @Test
     public void findAllByUserGroupShouldFindNothingForUserWithoutGroupAccess() {
-        final GroupExamSearch search = userGroupSearch().userGroupId(-10L).build();
+        final GroupExamSearch search = userGroupSearch().groupId(new UserGroupId(null, -10L)).build();
 
         //user with a different group access
         assertThat(repository.findAllByGroupExamSearch(userBuilder().permissionsById(groupStatewide).build(), search)).isEmpty();


### PR DESCRIPTION
For those who did not see Jeff's findings: there are at least two SQLs with the common group filter /snippet that take about 25 min on `awsdev`. The source of the problem seems to be an `EXISTS` clause. 

There are total of 10 SQLs that use this common snippet.

My objective is to avoid two different SQLs based on the type of the student groups. This review is an attempt to try a different version of the common snippets. I have tested it with the 2 found offenders and it works, but I have not tested the other 8 queries. I think it will be faster to use `jmeter` for this. 

And yes, we do use `EXISTS` in our common permission snippet, but for some reason it seems to work there just fine.