### PR TITLE
Handle NULL session IDs in the UI

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -60,7 +60,7 @@
         </div>
 
         <div *ngSwitchCase="'session'">
-          {{ score.session }}
+          {{ score.session | session }}
         </div>
 
         <div *ngSwitchCase="'grade'">

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -44,7 +44,7 @@
            angularticsCategory="AssessmentResults">
           <span class="block-children">
               <strong>{{session.date | date }}</strong>
-              <small class="text-left">{{session.id || 'assessment-results.session-unknown' | translate }}</small>
+              <small class="text-left">{{session.id | session }}</small>
           </span>
         </a>
       </div>

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -151,7 +151,6 @@ describe('AssessmentResultsComponent', () => {
     assessmentExam.exams.push(buildExam("Wood", "ma-12", "2017-03-01T17:05:26Z"));
 
     component.assessmentExam = assessmentExam;
-    console.log(component.sessions);
     expect(component.sessions[ 0 ].filter).toBeTruthy();
     expect(component.sessions[ 0 ].id).toBeNull();
     expect(component.sessions[ 1 ].filter).toBeFalsy();

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.spec.ts
@@ -136,6 +136,28 @@ describe('AssessmentResultsComponent', () => {
     expect(component.exams.length).toBe(0);
   });
 
+  it('should handle all null sessions', () => {
+    let assessmentExam = new AssessmentExam();
+    assessmentExam.exams.push(buildExam("Benoit", null, "2017-03-01T17:05:26Z"));
+    assessmentExam.exams.push(buildExam("Wood", null, "2017-03-01T17:05:26Z"));
+
+    component.assessmentExam = assessmentExam;
+    expect(component.sessions[ 0 ].filter).toBeTruthy();
+  });
+
+  it('should handle some null sessions', () => {
+    let assessmentExam = new AssessmentExam();
+    assessmentExam.exams.push(buildExam("Benoit", null, "2017-03-01T17:05:26Z"));
+    assessmentExam.exams.push(buildExam("Wood", "ma-12", "2017-03-01T17:05:26Z"));
+
+    component.assessmentExam = assessmentExam;
+    console.log(component.sessions);
+    expect(component.sessions[ 0 ].filter).toBeTruthy();
+    expect(component.sessions[ 0 ].id).toBeNull();
+    expect(component.sessions[ 1 ].filter).toBeFalsy();
+    expect(component.sessions[ 1 ].id).toEqual("ma-12");
+  });
+
   function buildExam(studentName: string, session: string, date: any) {
     let exam = new Exam();
     exam.student = new Student();

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -71,6 +71,11 @@ export class AssessmentResultsComponent implements OnInit {
 
     // if we aren't going to display the sessions, don't waste resources computing them
     if (this.allowFilterBySessions) {
+      // temp testing
+      for (let i=0; i < assessment.exams.length; i++) {
+        assessment.exams[i].session = null;
+      }
+
       this.sessions = this.getDistinctExamSessions(assessment.exams);
 
       if (this.sessions.length > 0) {

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -71,11 +71,6 @@ export class AssessmentResultsComponent implements OnInit {
 
     // if we aren't going to display the sessions, don't waste resources computing them
     if (this.allowFilterBySessions) {
-      // temp testing
-      for (let i=0; i < assessment.exams.length; i++) {
-        assessment.exams[i].session = null;
-      }
-
       this.sessions = this.getDistinctExamSessions(assessment.exams);
 
       if (this.sessions.length > 0) {

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
@@ -70,7 +70,7 @@
         </div>
 
         <div *ngSwitchCase="'session'">
-          {{ exam.session }}
+          {{ exam.session | session }}
         </div>
 
         <div *ngSwitchCase="'grade'">

--- a/webapp/src/main/webapp/src/app/shared/format/rdw-format.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/format/rdw-format.module.ts
@@ -3,11 +3,13 @@ import { BrowserModule } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { SchoolYearPipe } from "./school-year.pipe";
 import { SchoolYearsPipe } from "./school-years.pipe";
+import { SessionPipe } from './session.pipe';
 
 @NgModule({
   declarations: [
     SchoolYearPipe,
-    SchoolYearsPipe
+    SchoolYearsPipe,
+    SessionPipe
   ],
   imports: [
     BrowserModule,
@@ -15,11 +17,13 @@ import { SchoolYearsPipe } from "./school-years.pipe";
   ],
   exports: [
     SchoolYearPipe,
-    SchoolYearsPipe
+    SchoolYearsPipe,
+    SessionPipe
   ],
   providers: [
     SchoolYearPipe,
-    SchoolYearsPipe
+    SchoolYearsPipe,
+    SessionPipe
   ]
 })
 export class RdwFormatModule {

--- a/webapp/src/main/webapp/src/app/shared/format/session.pipe.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/format/session.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { async } from "@angular/core/testing";
+import { SessionPipe } from './session.pipe';
+import Spy = jasmine.Spy;
+
+describe('SessionPipe', () => {
+  let target: SessionPipe;
+  let translateService;
+
+  beforeEach(async(() => {
+
+    translateService = jasmine.createSpyObj('TranslateService', [
+      'instant'
+    ]);
+
+    target = new SessionPipe(translateService);
+
+  }));
+
+  it('should return session when it has a value', async(() => {
+    let actual = target.transform("abc-123");
+
+    expect(actual).toBe("abc-123");
+  }));
+
+  it('should return translated message when null, empty or undefined', async(() => {
+    let expectedDisplay = "Not provided";
+
+    (translateService.instant as Spy).and.callFake(() => expectedDisplay);
+
+    expect(target.transform(null)).toEqual(expectedDisplay);
+    expect(target.transform('')).toEqual(expectedDisplay);
+    expect(target.transform(undefined)).toEqual(expectedDisplay);
+  }));
+
+});

--- a/webapp/src/main/webapp/src/app/shared/format/session.pipe.ts
+++ b/webapp/src/main/webapp/src/app/shared/format/session.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { TranslateService } from '@ngx-translate/core';
+import { Utils } from '../support/support';
+
+@Pipe({ name: 'session' })
+export class SessionPipe implements PipeTransform {
+
+  constructor(private translate: TranslateService) {
+  }
+
+  transform(session: string): string {
+    if (Utils.isNullOrEmpty(session)) {
+      return this.translate.instant("assessment-results.session-unknown");
+    }
+
+    return session;
+  }
+}
+

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -226,7 +226,7 @@
     "no-writing-trait-scores": "Writing trait scores are not available for assessments administered prior to 2017-18 school year.",
     "result-view-select": "Select a results view",
     "select-view": "Select View",
-    "session-unknown": "[Unknown]",
+    "session-unknown": "Not provided",
     "sessions-title": "Sessions",
     "transfer-student-instructions": "The highlighted row(s) indicate test results from a previous school.",
     "view": {


### PR DESCRIPTION
To support an optional session TRT field, the UI needs to handle having no session value.  Made sure the session toggle buttons are generated correctly and that the session column is populated.

![image](https://user-images.githubusercontent.com/341584/41323170-c27bf62a-6e61-11e8-89d9-4df59635c5e2.png)
