### PR TITLE
Revert "make cards tab selectable (#1501)"

### DIFF
--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.html
@@ -1,6 +1,6 @@
-<button class="card assessment-aggregate"
-        [ngClass]="{selected: selected}"
-        (click)="selectCard()">
+<div class="card assessment-aggregate"
+     [ngClass]="{selected: selected}"
+     (click)="selectCard()">
 
   <div class="check">
     <i class="fa fa-check"></i>
@@ -42,4 +42,4 @@
       </div>
     </div>
   </div>
-</button>
+</div>

--- a/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
@@ -1,6 +1,6 @@
-<button class="card assessment-aggregate"
-        [ngClass]="{selected: latestExam.selected}"
-        (click)="selectCard()">
+<div class="card assessment-aggregate"
+     [ngClass]="{selected: latestExam.selected}"
+     (click)="selectCard()">
 
   <div class="check">
     <i class="fa fa-check"></i>
@@ -38,4 +38,4 @@
   <div class="result-count center-block mt-sm">
     {{'student-assessment-card.results' | translate:{resultCount: resultCount} }}
   </div>
-</button>
+</div>

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1318,7 +1318,6 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
   will-change: transform, border-color;
   transition-duration: @duration-exit;
   transition-timing-function: @easing-decel;
-  width: 100%;
   .check {
     position: absolute;
     top: @spacer / 1.7;
@@ -1340,7 +1339,7 @@ distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
     transition-duration: @duration-exit;
     transition-timing-function: @easing-decel;
   }
-  &:hover, &:focus {
+  &:hover {
     border-color: @gray-light;
     cursor: pointer;
     .check {
@@ -1494,7 +1493,7 @@ wide-radio-group {
 
   .toggle-group .btn.disabled {
     pointer-events: auto;
-    &:hover, &:focus, &:active {
+    &:hover, &:active {
       background-color: @white;
       border-color: @gray-light;
       color: @gray-mid;


### PR DESCRIPTION
This reverts commit ce30944d38ac82c55eda8d2725459800358dfb97.

The change to make the cards buttons caused display issues and in some browsers messed with the selected cards and the view assessments button working.  Reverting for now and we'll need to find a better solution.  I'd say we ty links instead of buttons for the cards.