### PR TITLE
avoid overlapping text in pdf reports

### DIFF
--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -342,7 +342,7 @@
             line-height: 1;
         }
         .achievement-descriptions .writing-traits .trait .description {
-            width: 100%;
+            width: 90%;
             display: block;
             margin-top: 0.5em;
         }


### PR DESCRIPTION
Before
![screen shot 2018-06-14 at 12 26 16 pm](https://user-images.githubusercontent.com/33040425/41433577-3f1ca4b4-6fce-11e8-941e-acae8e2fb02a.png)

After
![screen shot 2018-06-14 at 12 26 26 pm](https://user-images.githubusercontent.com/33040425/41433588-45f477bc-6fce-11e8-85c2-d43f02484a09.png)
