### PR TITLE
handle deserialization of legacy GroupExamReportRequests

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/UserGroupId.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/UserGroupId.java
@@ -16,6 +16,15 @@ public class UserGroupId {
     }
 
     /**
+     * Constructor for serialization backwards compatibility, assumes type is Admin
+     *
+     * @param id admin group id
+     */
+    private UserGroupId(final long id) {
+        this(id, null);
+    }
+
+    /**
      * Constructor
      *
      * @param groupId     an admin created groups id

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequest.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequest.java
@@ -1,18 +1,12 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
 import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
-import org.opentestsystem.rdw.security.GroupGrant;
 
 public class GroupExamReportRequest extends AbstractBatchExamReportRequest<PrintOptions> {
 
-    private GroupGrant groupGrant;
     private UserGroupId groupId;
 
     public UserGroupId getGroupId() {
-        // Bridge for existing reports.
-        if (groupGrant != null) {
-            return new UserGroupId(groupGrant.getId(), null);
-        }
         return groupId;
     }
 
@@ -29,15 +23,10 @@ public class GroupExamReportRequest extends AbstractBatchExamReportRequest<Print
         return ReportType.Group;
     }
 
+
     public static class Builder extends AbstractBatchExamReportRequest.Builder<PrintOptions, GroupExamReportRequest, Builder> {
 
-        private GroupGrant groupGrant;
         private UserGroupId groupId;
-
-        public Builder groupGrant(final GroupGrant groupGrant) {
-            this.groupGrant = groupGrant;
-            return this;
-        }
 
         public Builder groupId(final UserGroupId groupId) {
             this.groupId = groupId;
@@ -45,14 +34,13 @@ public class GroupExamReportRequest extends AbstractBatchExamReportRequest<Print
         }
 
         public Builder copy(final GroupExamReportRequest request) {
-            return super.copy(this, request)
-                    .groupGrant(request.groupGrant)
-                    .groupId(request.groupId);
+            super.copy(this, request);
+            groupId = request.groupId;
+            return this;
         }
 
         public GroupExamReportRequest build() {
             final GroupExamReportRequest search = super.build(new GroupExamReportRequest());
-            search.groupGrant = groupGrant;
             search.groupId = groupId;
             return search;
         }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializer.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializer.java
@@ -60,15 +60,26 @@ public class AbstractExamReportRequestDeserializer extends StdDeserializer<Abstr
      * group grant can be converted to a UserGroupId; since that has a constructor that takes
      * a group id and assumes Admin, we can just add a node, "groupId" with the value.
      *
+     * Additionally the GroupGrant has the subject id in it which needs to be pushed up to
+     * the parent as the subject code. So we are hard-coding the subject id/code mapping.
+     * Fortunately it is just for legacy report requests.
+     *
      * @param jsonNode root node
      */
     private void mapLegacyGroupGrant(final ObjectNode jsonNode) {
         if (!jsonNode.has("groupGrant")) return;
 
         final JsonNode legacyNode = jsonNode.remove("groupGrant");
-        final long id = legacyNode.get("id").asLong();
-        if (id != 0) {
-            jsonNode.set("groupId", new LongNode(id));
+
+        if (!jsonNode.has("groupId") && legacyNode.has("id")) {
+            jsonNode.set("groupId", new LongNode(legacyNode.get("id").asLong()));
+        }
+
+        if (!jsonNode.has("subjectCode") && legacyNode.has("subjectId")) {
+            final int subjectId = legacyNode.get("subjectId").asInt(0);
+            if (subjectId > 0) {
+                jsonNode.set("subjectCode", new TextNode(Subject.valueOf(subjectId).code()));
+            }
         }
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializer.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.opentestsystem.rdw.common.model.AssessmentType;
@@ -30,15 +31,14 @@ public class AbstractExamReportRequestDeserializer extends StdDeserializer<Abstr
         final ObjectNode jsonNode = mapper.readTree(parser);
         mapLegacySubject(jsonNode);
         mapLegacyAssessmentType(jsonNode);
+        mapLegacyGroupGrant(jsonNode);
         final JsonNode reportTypeNode = jsonNode.get("reportType");
         final ReportType reportType = ReportType.valueOf(reportTypeNode.asText());
         return mapper.readValue(jsonNode.toString(), reportType.getReportClass());
     }
 
     private void mapLegacySubject(final ObjectNode jsonNode) {
-        if (!jsonNode.has("subject") || jsonNode.has("subjectCode")) {
-            return;
-        }
+        if (!jsonNode.has("subject") || jsonNode.has("subjectCode")) return;
 
         final JsonNode legacyNode = jsonNode.remove("subject");
         final Subject subject = Subject.caseInsensitiveValue(legacyNode.asText());
@@ -46,12 +46,29 @@ public class AbstractExamReportRequestDeserializer extends StdDeserializer<Abstr
     }
 
     private void mapLegacyAssessmentType(final ObjectNode jsonNode) {
-        if (!jsonNode.has("assessmentType") || jsonNode.has("assessmentTypeCode")) {
-            return;
-        }
+        if (!jsonNode.has("assessmentType") || jsonNode.has("assessmentTypeCode")) return;
 
         final JsonNode legacyNode = jsonNode.remove("assessmentType");
         final AssessmentType assessmentType = AssessmentType.valueOf(legacyNode.asText());
         jsonNode.set("assessmentTypeCode", new TextNode(assessmentType.code()));
+    }
+
+    /**
+     * The GroupExamReportRequest used to have a GroupGrant (with group id and subject id).
+     * It was changed to have a UserGroupId which has a group id and group type. For the
+     * legacy requests the group type is Admin (since teacher groups didn't exist). So the
+     * group grant can be converted to a UserGroupId; since that has a constructor that takes
+     * a group id and assumes Admin, we can just add a node, "groupId" with the value.
+     *
+     * @param jsonNode root node
+     */
+    private void mapLegacyGroupGrant(final ObjectNode jsonNode) {
+        if (!jsonNode.has("groupGrant")) return;
+
+        final JsonNode legacyNode = jsonNode.remove("groupGrant");
+        final long id = legacyNode.get("id").asLong();
+        if (id != 0) {
+            jsonNode.set("groupId", new LongNode(id));
+        }
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequestTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/GroupExamReportRequestTest.java
@@ -1,11 +1,5 @@
 package org.opentestsystem.rdw.reporting.processor.model;
 
-import org.junit.Test;
-import org.opentestsystem.rdw.reporting.common.model.UserGroupId;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.opentestsystem.rdw.reporting.common.model.UserGroupType.Admin;
-
 public class GroupExamReportRequestTest extends AbstractBatchExamReportRequestTest<PrintOptions, GroupExamReportRequest, GroupExamReportRequest.Builder> {
 
     @Override
@@ -26,16 +20,5 @@ public class GroupExamReportRequestTest extends AbstractBatchExamReportRequestTe
     @Override
     public GroupExamReportRequest.Builder createBuilder() {
         return GroupExamReportRequest.builder();
-    }
-
-    @Test
-    public void itShouldStoreGroupGrant() {
-        final long groupId = 123L;
-        final GroupExamReportRequest request = createBuilder()
-                .groupId(new UserGroupId(groupId, null))
-                .build();
-
-        assertThat(request.getGroupId().getId()).isEqualTo(groupId);
-        assertThat(request.getGroupId().getType()).isEqualTo(Admin);
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
@@ -207,6 +207,7 @@ public class AbstractExamReportRequestDeserializerTest {
         assertThat(deserialized).isInstanceOf(GroupExamReportRequest.class);
         final GroupExamReportRequest request = (GroupExamReportRequest) deserialized;
         assertThat(request.getGroupId().getId()).isEqualTo(23602);
+        assertThat(request.getSubjectCode()).isEqualTo("Math");
     }
 
     @Test
@@ -216,6 +217,7 @@ public class AbstractExamReportRequestDeserializerTest {
         assertThat(deserialized).isInstanceOf(GroupExamReportRequest.class);
         final GroupExamReportRequest request = (GroupExamReportRequest) deserialized;
         assertThat(request.getGroupId().getId()).isEqualTo(151642);
+        assertThat(request.getSubjectCode()).isNull();
     }
 
     @Test

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/model/jackson/AbstractExamReportRequestDeserializerTest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Resources;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.opentestsystem.rdw.reporting.common.model.CustomAggregateReportQuery;
@@ -19,13 +17,14 @@ import org.opentestsystem.rdw.reporting.processor.model.GroupExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.SchoolGradeExamReportRequest;
 import org.opentestsystem.rdw.reporting.processor.model.StudentExamReportRequest;
 
+import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Locale;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
+import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Ethnicity;
 import static org.opentestsystem.rdw.reporting.common.model.DimensionType.Gender;
@@ -138,63 +137,134 @@ public class AbstractExamReportRequestDeserializerTest {
     }
 
     @Test
-    public void itShouldDeserializeALegacyAggregateReportRequestAnAggregateReportRequest() throws Exception {
-        final URL serializedLegacyResource = Resources.getResource("serialized-aggregate-report-request-1_2.json");
-        try (final InputStream resourceData = serializedLegacyResource.openStream()) {
-            final String legacyRequestJson = IOUtils.toString(resourceData);
-            final AggregateReportRequest deserialized = objectMapper.readValue(legacyRequestJson, AggregateReportRequest.class);
+    public void itShouldDeserializeALegacyAggregateReportRequestAnAggregateReportRequest() {
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-aggregate-report-request-1_2.json");
+        assertThat(deserialized).isInstanceOf(AggregateReportRequest.class);
 
-            assertThat(deserialized.getSchoolYear()).isEqualTo(2018);
-            assertThat(deserialized.getName()).isEqualTo("Custom Aggregate Report");
+        final AggregateReportRequest request = (AggregateReportRequest) deserialized;
+        assertThat(request.getSchoolYear()).isEqualTo(2018);
+        assertThat(request.getName()).isEqualTo("Custom Aggregate Report");
 
-            final CustomAggregateReportQuery query = (CustomAggregateReportQuery) deserialized.getQuery();
-            assertThat(query.getAssessmentTypeCode()).isEqualTo("sum");
-            assertThat(query.getSubjectCodes()).containsOnly("ELA", "Math");
-            assertThat(query.getSchoolYears()).containsOnly(2018);
-            assertThat(query.getAssessmentGradeCodes()).containsOnly("06");
-            assertThat(query.isIncludeState()).isTrue();
-            assertThat(query.isIncludeAllDistricts()).isFalse();
-            assertThat(query.isIncludeAllSchoolsOfDistricts()).isFalse();
-            assertThat(query.isIncludeAllDistrictsOfSchools()).isTrue();
-            assertThat(query.getDistrictIds()).isEmpty();
-            assertThat(query.getSchoolIds()).isEmpty();
-            assertThat(query.getCompletenessCodes()).containsOnly("Complete");
-            assertThat(query.getAdministrativeConditionCodes()).containsOnly("Valid");
-            assertThat(query.getDimensionTypes()).containsOnly(Gender, Ethnicity);
-            assertThat(query.getValueDisplayType()).isEqualTo("Percent");
-            assertThat(query.getAchievementLevelDisplayType()).isEqualTo("Separate");
-            assertThat(query.getColumnOrder()).containsExactly(
-                    "organization",
-                    "assessmentGrade",
-                    "schoolYear",
-                    "dimension");
+        final CustomAggregateReportQuery query = (CustomAggregateReportQuery) request.getQuery();
+        assertThat(query.getAssessmentTypeCode()).isEqualTo("sum");
+        assertThat(query.getSubjectCodes()).containsOnly("ELA", "Math");
+        assertThat(query.getSchoolYears()).containsOnly(2018);
+        assertThat(query.getAssessmentGradeCodes()).containsOnly("06");
+        assertThat(query.isIncludeState()).isTrue();
+        assertThat(query.isIncludeAllDistricts()).isFalse();
+        assertThat(query.isIncludeAllSchoolsOfDistricts()).isFalse();
+        assertThat(query.isIncludeAllDistrictsOfSchools()).isTrue();
+        assertThat(query.getDistrictIds()).isEmpty();
+        assertThat(query.getSchoolIds()).isEmpty();
+        assertThat(query.getCompletenessCodes()).containsOnly("Complete");
+        assertThat(query.getAdministrativeConditionCodes()).containsOnly("Valid");
+        assertThat(query.getDimensionTypes()).containsOnly(Gender, Ethnicity);
+        assertThat(query.getValueDisplayType()).isEqualTo("Percent");
+        assertThat(query.getAchievementLevelDisplayType()).isEqualTo("Separate");
+        assertThat(query.getColumnOrder()).containsExactly(
+                "organization",
+                "assessmentGrade",
+                "schoolYear",
+                "dimension");
 
-            final StudentFilters filters = query.getStudentFilters();
-            assertThat(filters.getGenderCodes()).containsOnly("Male");
-            assertThat(filters.getEthnicityCodes()).containsOnly("White", "Asian");
-            assertThat(filters.getLepCodes()).isEmpty();
-            assertThat(filters.getMigrantStatusCodes()).containsOnly("yes");
-            assertThat(filters.getSection504Codes()).containsOnly("yes");
-            assertThat(filters.getIepCodes()).containsOnly("no");
-            assertThat(filters.getEconomicDisadvantageCodes()).containsOnly("no");
-        }
+        final StudentFilters filters = query.getStudentFilters();
+        assertThat(filters.getGenderCodes()).containsOnly("Male");
+        assertThat(filters.getEthnicityCodes()).containsOnly("White", "Asian");
+        assertThat(filters.getLepCodes()).isEmpty();
+        assertThat(filters.getMigrantStatusCodes()).containsOnly("yes");
+        assertThat(filters.getSection504Codes()).containsOnly("yes");
+        assertThat(filters.getIepCodes()).containsOnly("no");
+        assertThat(filters.getEconomicDisadvantageCodes()).containsOnly("no");
     }
 
     @Test
-    public void itShouldSupportV1_2AbstractExamReportRequests() throws Exception {
-        final URL serializedLegacyResource = Resources.getResource("serialized-school-group-report-request-1_2.json");
-        try (final InputStream resourceData = serializedLegacyResource.openStream()) {
-            final String schoolGradeExamRequest_v1_2 = IOUtils.toString(resourceData);
-            final AbstractExamReportRequest deserialized = objectMapper.readValue(schoolGradeExamRequest_v1_2, AbstractExamReportRequest.class);
-            assertThat(deserialized).isEqualToComparingOnlyGivenFields(
-                    SchoolGradeExamReportRequest.builder()
-                            .assessmentTypeCode("ica")
-                            .subjectCode("Math")
-                            .build(),
-                    "assessmentTypeCode",
-                    "subjectCode"
-            );
-        }
+    public void itShouldSupportV1_2AbstractExamReportRequests() {
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-school-group-report-request-1_2.json");
+        assertThat(deserialized).isInstanceOf(SchoolGradeExamReportRequest.class);
+        assertThat(deserialized).isEqualToComparingOnlyGivenFields(
+                SchoolGradeExamReportRequest.builder()
+                        .assessmentTypeCode("ica")
+                        .subjectCode("Math")
+                        .build(),
+                "assessmentTypeCode",
+                "subjectCode"
+        );
     }
 
+    @Test
+    public void itShouldDeserializeAGroupRequest() {
+        // this payload has groupId as an integer, which only happened for a couple weeks during development
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-group-exam-report-request-1_2-.json");
+        assertThat(deserialized).isInstanceOf(GroupExamReportRequest.class);
+        final GroupExamReportRequest request = (GroupExamReportRequest) deserialized;
+        assertThat(request.getGroupId().getId()).isEqualTo(1378);
+    }
+
+    @Test
+    public void itShouldDeserializeAProductionGroupRequestA() {
+        // this payload came from v1.1.x production and has the groupGrant field and no groupId
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-group-report-request-a-1_1.json");
+        assertThat(deserialized).isInstanceOf(GroupExamReportRequest.class);
+        final GroupExamReportRequest request = (GroupExamReportRequest) deserialized;
+        assertThat(request.getGroupId().getId()).isEqualTo(23602);
+    }
+
+    @Test
+    public void itShouldDeserializeAProductionGroupRequestB() {
+        // this payload came from v1.1.x production and has the groupGrant field and no groupId
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-group-report-request-b-1_1.json");
+        assertThat(deserialized).isInstanceOf(GroupExamReportRequest.class);
+        final GroupExamReportRequest request = (GroupExamReportRequest) deserialized;
+        assertThat(request.getGroupId().getId()).isEqualTo(151642);
+    }
+
+    @Test
+    public void itShouldDeserializeAProductionStudentRequestA() {
+        // this payload came from v1.1.x production
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-student-report-request-a-1_1.json");
+        assertThat(deserialized).isInstanceOf(StudentExamReportRequest.class);
+        final StudentExamReportRequest request = (StudentExamReportRequest) deserialized;
+        assertThat(request.getStudentId()).isEqualTo(177669);
+    }
+
+    @Test
+    public void itShouldDeserializeAProductionExamExportRequestA() {
+        // this payload came from v1.1.x production
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-exam-export-report-request-a-1_1.json");
+        assertThat(deserialized).isInstanceOf(ExportExamReportRequest.class);
+        final ExportExamReportRequest request = (ExportExamReportRequest) deserialized;
+        assertThat(request.getSchoolIds()).containsExactly(1344L);
+    }
+
+    @Test
+    public void itShouldDeserializeAProductionSchoolGradeRequestA() {
+        // this payload came from v1.1.x production
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-school-grade-report-request-a-1_1.json");
+        assertThat(deserialized).isInstanceOf(SchoolGradeExamReportRequest.class);
+        final SchoolGradeExamReportRequest request = (SchoolGradeExamReportRequest) deserialized;
+        assertThat(request.getSchoolId()).isEqualTo(1344);
+        assertThat(request.getGradeId()).isEqualTo(11);
+    }
+
+    @Test
+    public void itShouldDeserializeAnAggregateRequestA() {
+        // this payload came from v1.1.x production
+        final AbstractExamReportRequest deserialized = deserializeRequestResource("/serialized-aggregate-report-request-a-1_1.json");
+        assertThat(deserialized).isInstanceOf(AggregateReportRequest.class);
+        final AggregateReportRequest request = (AggregateReportRequest) deserialized;
+
+        final CustomAggregateReportQuery query = (CustomAggregateReportQuery) request.getQuery();
+        assertThat(query.getSchoolYears()).containsExactly(2018);
+        assertThat(query.getAssessmentGradeCodes()).containsExactlyInAnyOrder("03", "05");
+    }
+
+
+    private AbstractExamReportRequest deserializeRequestResource(final String resource) {
+        try (final InputStream is = this.getClass().getResourceAsStream(resource)) {
+            return objectMapper.readValue(is, AbstractExamReportRequest.class);
+        } catch (final IOException e) {
+            fail("failed to deserialize " + resource);
+            return null;
+        }
+    }
 }

--- a/report-processor/src/test/resources/serialized-aggregate-report-request-a-1_1.json
+++ b/report-processor/src/test/resources/serialized-aggregate-report-request-a-1_1.json
@@ -1,0 +1,51 @@
+{
+  "subject": "MATH",
+  "schoolYear": 2018,
+  "name": "Custom Aggregate Report",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "reportQuery": {
+    "assessmentTypeCode": "ica",
+    "subjectCodes": [
+      "Math"
+    ],
+    "schoolYears": [
+      2018
+    ],
+    "assessmentGradeCodes": [
+      "03",
+      "05"
+    ],
+    "includeState": false,
+    "includeAllDistricts": false,
+    "includeAllSchoolsOfDistricts": false,
+    "includeAllDistrictsOfSchools": true,
+    "districtIds": [
+      1173
+    ],
+    "schoolIds": [],
+    "dimensionTypes": [],
+    "valueDisplayType": "Percent",
+    "achievementLevelDisplayType": "Separate",
+    "columnOrder": [
+      "organization",
+      "assessmentGrade",
+      "schoolYear",
+      "dimension"
+    ],
+    "completenessCodes": [
+      "Complete"
+    ],
+    "administrativeConditionCodes": [
+      "SD"
+    ],
+    "genderCodes": [],
+    "ethnicityCodes": [],
+    "lepCodes": [],
+    "migrantStatusCodes": [],
+    "section504Codes": [],
+    "iepCodes": [],
+    "economicDisadvantageCodes": []
+  },
+  "reportType": "AggregateReportRequest"
+}

--- a/report-processor/src/test/resources/serialized-exam-export-report-request-a-1_1.json
+++ b/report-processor/src/test/resources/serialized-exam-export-report-request-a-1_1.json
@@ -1,0 +1,12 @@
+{
+  "schoolYear": 2018,
+  "name": "SFHS Expoet",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "schoolIds": [
+    1344
+  ],
+  "schoolGroupIds": [],
+  "districtIds": [],
+  "reportType": "ExamExport"
+}

--- a/report-processor/src/test/resources/serialized-group-exam-report-request-1_2-.json
+++ b/report-processor/src/test/resources/serialized-group-exam-report-request-1_2-.json
@@ -1,0 +1,12 @@
+{
+  "assessmentTypeCode": "sum",
+  "subjectCode": "ELA",
+  "schoolYear": 2018,
+  "language": "en",
+  "name": "Grade 8 Students",
+  "accommodationsVisible": true,
+  "disableTransferAccess": false,
+  "order": "STUDENT_NAME",
+  "groupId": 1378,
+  "reportType": "Group"
+}

--- a/report-processor/src/test/resources/serialized-group-report-request-a-1_1.json
+++ b/report-processor/src/test/resources/serialized-group-report-request-a-1_1.json
@@ -1,0 +1,14 @@
+{
+  "assessmentType": "SUMMATIVE",
+  "schoolYear": 2018,
+  "language": "en",
+  "name": "5E",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "order": "STUDENT_NAME",
+  "groupGrant": {
+    "id": 23602,
+    "subjectId": 1
+  },
+  "reportType": "Group"
+}

--- a/report-processor/src/test/resources/serialized-group-report-request-b-1_1.json
+++ b/report-processor/src/test/resources/serialized-group-report-request-b-1_1.json
@@ -1,0 +1,13 @@
+{
+  "schoolYear": 2018,
+  "language": "en",
+  "name": "0463-S0D",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "order": "STUDENT_NAME",
+  "groupGrant": {
+    "id": 151642,
+    "subjectId": 1
+  },
+  "reportType": "Group"
+}

--- a/report-processor/src/test/resources/serialized-group-report-request-b-1_1.json
+++ b/report-processor/src/test/resources/serialized-group-report-request-b-1_1.json
@@ -7,7 +7,7 @@
   "order": "STUDENT_NAME",
   "groupGrant": {
     "id": 151642,
-    "subjectId": 1
+    "subjectId": 0
   },
   "reportType": "Group"
 }

--- a/report-processor/src/test/resources/serialized-school-grade-report-request-a-1_1.json
+++ b/report-processor/src/test/resources/serialized-school-grade-report-request-a-1_1.json
@@ -1,0 +1,13 @@
+{
+  "assessmentType": "IAB",
+  "subject": "ELA",
+  "schoolYear": 2018,
+  "language": "en",
+  "name": "Santa Fe High HS",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "order": "STUDENT_NAME",
+  "schoolId": 1344,
+  "gradeId": 11,
+  "reportType": "SchoolGrade"
+}

--- a/report-processor/src/test/resources/serialized-student-report-request-a-1_1.json
+++ b/report-processor/src/test/resources/serialized-student-report-request-a-1_1.json
@@ -1,0 +1,11 @@
+{
+  "assessmentType": "ICA",
+  "subject": "ELA",
+  "schoolYear": 2018,
+  "language": "en",
+  "name": "VAUGHAN, MARCUS",
+  "accommodationsVisible": false,
+  "disableTransferAccess": false,
+  "studentId": 177669,
+  "reportType": "Student"
+}


### PR DESCRIPTION
This started as an incompatibility between the version of GroupExamReportRequest that had individual ids and the UserGroupId object (which could really happen only in QA since there was only a 2 week period when they were different). However, it morphed into handling the backwards compatibility with v1.1 (which had a GroupGrant).