### PR TITLE
ICA/Summative score distribution should use full name "Met Standard"

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.ts
@@ -144,7 +144,7 @@ export class AverageScaleScoreComponent {
   }
 
   examLevelTranslation(performanceLevel: ExamStatisticsLevel): string {
-    return this.translate.instant(performanceLevel.id ? `common.assessment-type.${this.assessmentExam.assessment.type}.performance-level.${performanceLevel.id}.short-name` : 'common.missing')
+    return this.translate.instant(performanceLevel.id ? `common.assessment-type.${this.assessmentExam.assessment.type}.performance-level.${performanceLevel.id}.name` : 'common.missing')
   }
 
   private levelCountPercent(levelCount: number): number {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/341584/41449943-f7caf66a-7018-11e8-9ba6-e74cea711c72.png)
