### PR TITLE
skiplink using scroll to view

### DIFF
--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -1,5 +1,7 @@
 <header>
-  <a class="sr-only sr-only-focusable" href="#maincontent">{{'home.skip-link' | translate}}</a>
+  <a class="sr-only sr-only-focusable"
+     href="javascript:void(0)"
+     (click)="scrollToMainContent()">{{'home.skip-link' | translate}}</a>
   <div class="container">
     <div class="well">
       <div class="well-body">
@@ -56,8 +58,7 @@
 </header>
 <sb-breadcrumbs></sb-breadcrumbs>
 
-<a name="maincontent"></a>
-<div class="container">
+<div id="maincontent" class="container">
   <router-outlet></router-outlet>
 </div>
 

--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -67,6 +67,12 @@ export class AppComponent {
     this.initializeNavigationLoadingSpinner();
   }
 
+  scrollToMainContent() {
+    setTimeout(() => {
+      document.getElementById('maincontent').scrollIntoView();
+    }, 0);
+  }
+
   private initializeAnalytics(trackingId: string): void {
     const googleAnalyticsProvider: Function = window[ 'ga' ];
     if (googleAnalyticsProvider && trackingId) {


### PR DESCRIPTION
I had implemented the skip link (for accessibility it should be the first link you tab to where you can skip the navigation that is on all the pages) using the traditional anchor and linking to "#maincontent" but that only worked on the homepage with no route info.

i couldn't figure out a way to make that work so instead am implementing like the FAB we have in a couple places and scrolling to the element instead.