### PR TITLE
Fix change notification on sb input components

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
@@ -124,25 +124,22 @@ const ControllerByInputType: {[inpuType: string]: InputController} = {
   selector: 'sb-button-group',
   template: `
     <ng-template #button let-option let-isAllOption="isAllOption">
-      <a class="btn"
-         href="javascript:void(0)"
-         (click)="isAllOption ? onAllOptionClickInternal() : onOptionClickInternal(option)"
-         [ngClass]="computeStylesInternal(buttonStyles, { 
-             active: isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option), 
-             disabled: disabled 
-         })">
+      <label class="btn"
+             [ngClass]="computeStylesInternal(buttonStyles, { 
+                 active: isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option), 
+                 disabled: disabled 
+             })">
         <input type="checkbox"
                [attr.checked]="isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option)"
                [name]="name"
-               notab="notab"
-               tabindex="-1"
                [disabled]="disabled"
+               (click)="isAllOption ? onAllOptionClickInternal() : onOptionClickInternal(option)"
                angulartics2On="click"
                angularticsEvent="{{analyticsEvent}}"
                angularticsCategory="{{analyticsCategory}}"
                [angularticsProperties]="isAllOption ? allOptionAnalyticsProperties : option.analyticsProperties">
         {{option.text}}
-      </a>
+      </label>
     </ng-template>
 
     <div *ngIf="initializedInternal"

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -977,6 +977,33 @@ a.btn.disabled.with-pointer {
   pointer-events: auto;
 }
 
+sb-button-group,
+sb-checkbox-group {
+  .btn {
+    &:focus-within {
+      .tab-focus();
+    }
+  }
+}
+
+sb-radio-button-group .btn-group {
+  &:focus-within {
+    .tab-focus();
+  }
+}
+
+// Make the div behave like a button
+.btn-group,
+.btn-group-vertical {
+  > .btn {
+    // Bring the "focused" button to the front
+    &:focus,
+    &:focus-within {
+      z-index: 3;
+    }
+  }
+}
+
 //TODO move to SBAC UI kit
 distractor-analysis .ui-widget.ui-table table .ui-table-tbody td.green {
   color: contrast(@green, darken(@green, 100%), lighten(@green, 100%));


### PR DESCRIPTION
There was a large issue with `(change)` handlers not being called on sb-button-group instances.

I also gave the stylings a once-over to make sure we were highlighting on focus/focus-within

radio highlight
![image](https://user-images.githubusercontent.com/617828/41492901-004496e0-70b7-11e8-9e64-67349945a3f3.png)

button-group highlight:
![image](https://user-images.githubusercontent.com/617828/41492904-1375ae16-70b7-11e8-8af6-03c24d6d0c05.png)

horizontal button-group highlight:
![image](https://user-images.githubusercontent.com/617828/41492908-260ee646-70b7-11e8-8ba4-4a61724c8029.png)

checkbox-group highlight:
![image](https://user-images.githubusercontent.com/617828/41492914-36a46c06-70b7-11e8-95ee-b97d870bf602.png)

