### PR TITLE
add configuration options for the landing page and access denied urls

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -20,9 +20,7 @@ public class ViewController implements ErrorController {
     @RequestMapping(value = {"/"})
     public String index(@AuthenticationPrincipal final User user) {
         if (user == null) {
-            return this.landingPageUrl == null || this.landingPageUrl.isEmpty()
-                    ? "forward:/landing.html"
-                    : "redirect:" + this.landingPageUrl;
+            return this.landingPageUrl;
         }
 
         return "forward:/index.html";
@@ -36,9 +34,7 @@ public class ViewController implements ErrorController {
 
     @RequestMapping(value="/error/accessDenied", method = { RequestMethod.GET, RequestMethod.POST })
     public String accessDenied() {
-        return this.accessDeniedUrl == null || this.accessDeniedUrl.isEmpty()
-                ? "forward:/assets/public/access-denied.html"
-                : "redirect:" + this.accessDeniedUrl;
+        return this.accessDeniedUrl;
     }
 
     @RequestMapping(value="/error")

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.reporting.web;
 
 import org.opentestsystem.rdw.reporting.common.web.security.User;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -10,10 +11,18 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @Controller
 public class ViewController implements ErrorController {
 
+    @Value("${reporting.access-denied-url}")
+    private String accessDeniedUrl;
+
+    @Value("${reporting.landing-page-url}")
+    private String landingPageUrl;
+
     @RequestMapping(value = {"/"})
     public String index(@AuthenticationPrincipal final User user) {
         if (user == null) {
-            return "forward:/landing.html";
+            return this.landingPageUrl == null || this.landingPageUrl.isEmpty()
+                    ? "forward:/landing.html"
+                    : "redirect:" + this.landingPageUrl;
         }
 
         return "forward:/index.html";
@@ -27,7 +36,9 @@ public class ViewController implements ErrorController {
 
     @RequestMapping(value="/error/accessDenied", method = { RequestMethod.GET, RequestMethod.POST })
     public String accessDenied() {
-        return "forward:/assets/public/access-denied.html";
+        return this.accessDeniedUrl == null || this.accessDeniedUrl.isEmpty()
+                ? "forward:/assets/public/access-denied.html"
+                : "redirect:" + this.accessDeniedUrl;
     }
 
     @RequestMapping(value="/error")

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -18,10 +18,10 @@ permissionservice:
 
 reporting:
   analytics-tracking-id: ${rdw.reporting.analytics.trackingId:}
-  access-denied-url:
+  access-denied-url: forward:/assets/public/access-denied.html
   interpretive-guide-url: https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf
   iris-vendor-id: ${rdw.reporting.iris.vendorId}
-  landing-page-url:
+  landing-page-url: forward:/landing.html
   min-item-data-year: 2016
   school-year: 2018
   state:

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -18,8 +18,10 @@ permissionservice:
 
 reporting:
   analytics-tracking-id: ${rdw.reporting.analytics.trackingId:}
+  access-denied-url:
   interpretive-guide-url: https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf
   iris-vendor-id: ${rdw.reporting.iris.vendorId}
+  landing-page-url:
   min-item-data-year: 2016
   school-year: 2018
   state:


### PR DESCRIPTION
As part of having multiple tenants, they need the ability to have their own controlled reporting landing page where they can then direct folks to a tenant specific installation.  These options will allow them to keep the existing page or move to an externally Smarter Balanced controlled page/site.