### PR TITLE
added target math warning text about only having a single claim included

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -183,6 +183,14 @@
                                     [identityColumns]="view.columnOrdering"></aggregate-report-table>
           </div>
         </div>
+
+        <div *ngIf="showTargetMathCautionMessage"
+             class="row mt-sm">
+          <div class="col-md-12">
+            <p class="small">{{ 'target-report.math-claim-caution-message' | translate }}</p>
+          </div>
+        </div>
+
       </div>
     </ng-container>
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.ts
@@ -189,6 +189,10 @@ export class AggregateReportComponent implements OnInit, OnDestroy {
     return this.query.reportType === ServerAggregateReportType.Longitudinal;
   }
 
+  get showTargetMathCautionMessage(): boolean {
+    return this.query.reportType == ServerAggregateReportType.Target && this.query.subjectCode == 'Math';
+  }
+
   private updateViewState(): void {
     const targetViewState = this.getTargetViewState();
     this.onViewStateChange(this._viewState, targetViewState);

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
@@ -22,11 +22,11 @@
               {{'average-scale-score.results-label' | translate}}
             </div>
           </td>
-          <td class="">
-        <span class="text-left gray-darkest">
-          <span class="score font-large">{{ overallRow.studentsTested }}</span>
-          <span class="ml-xs">{{ (overallRow.studentsTested == 1 ? 'average-scale-score.result' : 'average-scale-score.results') | translate }}</span>
-        </span>
+          <td>
+            <span class="text-left gray-darkest">
+              <span class="score font-large">{{ overallRow.studentsTested }}</span>
+              <span class="ml-xs">{{ (overallRow.studentsTested == 1 ? 'average-scale-score.result' : 'average-scale-score.results') | translate }}</span>
+            </span>
           </td>
         </tr>
       </table>

--- a/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.html
@@ -7,7 +7,7 @@
 
 <div *ngIf="showResults" class="row mb-xs">
   <div class="col-md-10">
-    <span class="target-caution-message">* {{ 'target-report.caution-message' | translate }}</span>
+    <p class="small">{{ 'target-report.caution-message' | translate }}</p>
   </div>
   <div class="col-md-2 text-right">
     <span>
@@ -184,3 +184,5 @@
     </tr>
   </ng-template>
 </p-table>
+
+<p *ngIf="isMath" class="small mt-sm">{{ 'target-report.math-claim-caution-message' | translate }}</p>

--- a/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
@@ -221,6 +221,10 @@ export class TargetReportComponent implements OnInit, ExportResults {
     return this.aggregateTargetScoreRows && this.aggregateTargetScoreRows.length !== 0;
   }
 
+  get isMath(): boolean {
+    return this.assessment.subject == 'Math';
+  }
+
   /**
    * Sort the data
    *

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1416,6 +1416,7 @@
       "standard-met-relative-residual-level": "Performance Relative to Standard Met (Level 3)",
       "standard-met-relative-residual-level-info": "Indicates whether students' performance on a target was above, near, or below Standard Met (Level 3).  A \"Below Standard Met\" indicator suggests that students have not yet mastered the content assessed in a target; however, the students' overall performance on the test may be near or above standard."
     },
+    "math-claim-caution-message": "For mathematics, target reports are only available for the Concepts and Procedures claim. The mathematics targets are the cluster headings of the Standards for Mathematical Content. See the Interpretive Guide for additional information about target reports.",
     "not-enough-results": "There are currently not enough results available to display the target level report.",
     "subgroup-options": "Subgroups"
   },

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1596,11 +1596,6 @@ table.student-claim-distribution {
   }
 }
 
-.target-caution-message {
-  font-color: @gray-darkest;
-  font-size: 0.8em;
-}
-
 user-group {
   student-filters {
     .flex-children .flex-child {


### PR DESCRIPTION
This request is specific to SB Math subject and won't apply to any other subjects since all claims are included in target reports except for a hard-coded rule for SB Math.

![image](https://user-images.githubusercontent.com/341584/41618903-4b92cc7a-73b9-11e8-88cd-15ab4df3c751.png)

