### PR TITLE
include item claim labels in translation file since report processor …

### DIFF
--- a/common/src/main/resources/i18n/en.json
+++ b/common/src/main/resources/i18n/en.json
@@ -600,6 +600,19 @@
       "item1": "Interim assessments may be scored by local teachers. This scoring is not subject to the rigorous controls used in summative assessment and local results may show some variations.",
       "item2": "Exposure to, and familiarity with test questions may affect student performance and the accuracy of interim results."
     },
+    "item-claim-name": {
+      "1": "Concepts and Procedures",
+      "2": "Problem Solving",
+      "3": "Communicating Reasoning",
+      "4": "Modeling and Data Analysis",
+      "1-IT": "Reading - Informational Text",
+      "1-LT": "Reading - Literary Text",
+      "2-W": "Writing",
+      "3-L": "Listening",
+      "3-S": "Listening",
+      "4-CR": "Research and Inquiry",
+      "NA": "NA"
+    },
     "not-scored": "Not Scored",
     "overall-achievement": {
       "grade": {
@@ -901,6 +914,24 @@
       "score-range": "{0}-{1}",
       "short-name": "SUM",
       "title": "Summative Assessment Report"
+    },
+    "target": {
+      "overall": {
+        "Above": "Better",
+        "Below": "Worse",
+        "Excluded": "Excluded",
+        "InsufficientData": "Insufficient Data",
+        "Near": "Similar",
+        "NoResults": "-"
+      },
+      "standard": {
+        "Above": "Above",
+        "Below": "Below",
+        "Excluded": "Excluded",
+        "InsufficientData": "Insufficient Data",
+        "Near": "Near",
+        "NoResults": "-"
+      }
     },
     "writing": {
       "description": "Students write an extended response (i.e., essay) with one of the following purposes: narrative, opinion, informational, explanatory, or argumentative. {0} received the following scores on the essay:",

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/TargetAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/TargetAggregateReportCsvHandler.java
@@ -48,8 +48,8 @@ public class TargetAggregateReportCsvHandler extends AbstractAggregateReportCsvH
         measuresValues.add(String.valueOf(row.getMeasures().getStudentCount()));
         measuresValues.add(String.valueOf(row.getMeasures().getAvgScaleScore()));
         measuresValues.add(String.valueOf(row.getMeasures().getAvgStdErr()));
-        measuresValues.add(row.getStudentRelativeResidualScoresLevel().name());
-        measuresValues.add(row.getStandardMetRelativeResidualLevel().name());
+        measuresValues.add(getMessage("report.target.overall." + row.getStudentRelativeResidualScoresLevel().name()));
+        measuresValues.add(getMessage("report.target.standard." + row.getStandardMetRelativeResidualLevel().name()));
         return measuresValues;
     }
 
@@ -64,7 +64,7 @@ public class TargetAggregateReportCsvHandler extends AbstractAggregateReportCsvH
     @Override
     protected List<String> getReportCustomValues(final CsvContext context, final TargetRow result) {
         final List<String> values = newArrayList();
-        values.add(getMessage("report.claim." + result.getClaimCode() + ".name"));
+        values.add(getMessage("report.item-claim-name." + result.getClaimCode()));
         //TODO: complete after migrating of configurable subjects to reporting
         values.add(result.getTargetNaturalId());
         return values;


### PR DESCRIPTION
…only had the scorable claims in there

translate the TargetReportLevel name value (which is Above, Near, etc.) into the proper display value