### PR TITLE
Add a subject definition endpoint to the reporting service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.2.0-91"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.2.0-372"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.2.0-92"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.2.0-377"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
@@ -1,0 +1,79 @@
+package org.opentestsystem.rdw.reporting.common.model;
+
+/**
+ * This model represents a subject's properties within the scope of an Assessment Type.
+ */
+public class SubjectDefinition {
+    private String asmtTypeCode;
+    private String subjectCode;
+    private int performanceLevelCount;
+    private Integer performanceLevelStandardCutoff;
+    private Integer claimScorePerformanceLevelCount;
+
+    public String getAsmtTypeCode() {
+        return asmtTypeCode;
+    }
+
+    public String getSubjectCode() {
+        return subjectCode;
+    }
+
+    public int getPerformanceLevelCount() {
+        return performanceLevelCount;
+    }
+
+    public Integer getPerformanceLevelStandardCutoff() {
+        return performanceLevelStandardCutoff;
+    }
+
+    public Integer getClaimScorePerformanceLevelCount() {
+        return claimScorePerformanceLevelCount;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String asmtTypeCode;
+        private String subjectCode;
+        private int performanceLevelCount;
+        private Integer performanceLevelStandardCutoff;
+        private Integer claimScorePerformanceLevelCount;
+
+        public SubjectDefinition build() {
+            final SubjectDefinition definition = new SubjectDefinition();
+            definition.asmtTypeCode = asmtTypeCode;
+            definition.subjectCode = subjectCode;
+            definition.performanceLevelCount = performanceLevelCount;
+            definition.performanceLevelStandardCutoff = performanceLevelStandardCutoff;
+            definition.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            return definition;
+        }
+
+        public Builder asmtTypeCode(final String asmtTypeCode) {
+            this.asmtTypeCode = asmtTypeCode;
+            return this;
+        }
+
+        public Builder subjectCode(final String subjectCode) {
+            this.subjectCode = subjectCode;
+            return this;
+        }
+
+        public Builder performanceLevelCount(final int performanceLevelCount) {
+            this.performanceLevelCount = performanceLevelCount;
+            return this;
+        }
+
+        public Builder performanceLevelStandardCutoff(final Integer performanceLevelStandardCutoff) {
+            this.performanceLevelStandardCutoff = performanceLevelStandardCutoff;
+            return this;
+        }
+
+        public Builder claimScorePerformanceLevelCount(final Integer claimScorePerformanceLevelCount) {
+            this.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            return this;
+        }
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/SubjectDefinitionRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/SubjectDefinitionRepository.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.reporting.common.repository;
+
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+
+import java.util.Collection;
+
+/**
+ * Implementations of this interface are responsible for querying for
+ * {@link SubjectDefinition} instances.
+ */
+public interface SubjectDefinitionRepository {
+
+    /**
+     * Find all SubjectDefinitions within the system.
+     * @return All SubjectDefinitions
+     */
+    Collection<SubjectDefinition> findAll();
+}

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.rdw.reporting.common.repository.impl;
+
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.repository.SubjectDefinitionRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+
+import static org.opentestsystem.rdw.reporting.common.jdbc.QueryUtils.getNullable;
+
+/**
+ * JDBC implementation of a SubjectDefinitionRepository.
+ */
+@Repository
+class JdbcSubjectDefinitionRepository implements SubjectDefinitionRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.subjectDefinition.findAll}")
+    private String findAllQuery;
+
+    public JdbcSubjectDefinitionRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public Collection<SubjectDefinition> findAll() {
+        return template.query(
+                findAllQuery,
+                new MapSqlParameterSource(),
+                (row, index) -> SubjectDefinition.builder()
+                        .asmtTypeCode(row.getString("asmt_type_code"))
+                        .subjectCode(row.getString("subject_code"))
+                        .performanceLevelCount(row.getInt("performance_level_count"))
+                        .performanceLevelStandardCutoff(getNullable(row, row.getInt("performance_level_standard_cutoff")))
+                        .claimScorePerformanceLevelCount(getNullable(row, row.getInt("claim_score_performance_level_count")))
+                        .build()
+        );
+    }
+}

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -116,6 +116,18 @@ sql:
           (s.id IS NOT NULL AND (1=:statewide OR sch.district_group_id IN (:district_group_ids) OR sch.district_id IN (:district_ids) OR sch.school_group_id IN (:school_group_ids) OR sch.id IN (:school_ids)))
         LIMIT 1
 
+  subjectDefinition:
+    findAll: >-
+      SELECT
+        at.code as asmt_type_code,
+        s.code as subject_code,
+        sat.performance_level_count,
+        sat.performance_level_standard_cutoff,
+        sat.claim_score_performance_level_count
+      FROM subject_asmt_type sat
+        JOIN asmt_type at ON at.id = sat.asmt_type_id
+        JOIN subject s ON s.id = sat.subject_id
+
   snippet:
     basicPermission: >-
         (1=:statewide or sc.district_group_id in (:district_group_ids) or sc.district_id in (:district_ids) or sc.school_group_id in (:school_group_ids) or sc.id in (:school_ids))

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
@@ -1,0 +1,45 @@
+package org.opentestsystem.rdw.reporting.common.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.repository.SubjectDefinitionRepository;
+import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
+import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@Import({
+        JdbcSubjectDefinitionRepository.class,
+        ITDataSourceConfiguration.class
+})
+@RepositoryIT
+public class JdbcSubjectDefinitionRepositoryIT {
+
+    @Autowired
+    public SubjectDefinitionRepository repository;
+
+    @Test
+    public void itShouldFindAllSubjectDefinitions() {
+        final Collection<SubjectDefinition> definitions = repository.findAll();
+
+        final SubjectDefinition elaIcaDefinition = SubjectDefinition.builder()
+                .asmtTypeCode("ica")
+                .subjectCode("ELA")
+                .performanceLevelCount(4)
+                .performanceLevelStandardCutoff(3)
+                .claimScorePerformanceLevelCount(3)
+                .build();
+        assertThat(definitions)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(elaIcaDefinition);
+    }
+
+
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subject/DefaultSubjectService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subject/DefaultSubjectService.java
@@ -1,8 +1,8 @@
 package org.opentestsystem.rdw.reporting.subject;
 
 import com.google.common.collect.ImmutableList;
-import org.opentestsystem.rdw.reporting.elas.ElasService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
@@ -19,6 +19,7 @@ public class DefaultSubjectService implements SubjectService {
     }
 
     @Override
+    @Cacheable("subjectdefinitions")
     public List<String> getSubjects() {
         return ImmutableList.copyOf(repository.findAll());
     }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subject/DefaultSubjectService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subject/DefaultSubjectService.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.reporting.subject;
 
 import com.google.common.collect.ImmutableList;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
@@ -19,7 +18,6 @@ public class DefaultSubjectService implements SubjectService {
     }
 
     @Override
-    @Cacheable("subjectdefinitions")
     public List<String> getSubjects() {
         return ImmutableList.copyOf(repository.findAll());
     }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionService.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.reporting.subjectdefinition;
 import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
 import org.opentestsystem.rdw.reporting.common.repository.SubjectDefinitionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -21,6 +22,7 @@ public class DefaultSubjectDefinitionService implements SubjectDefinitionService
     }
 
     @Override
+    @Cacheable("subjectdefinitions")
     public Collection<SubjectDefinition> findAll() {
         return repository.findAll();
     }

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionService.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.reporting.subjectdefinition;
+
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.repository.SubjectDefinitionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+/**
+ * Default implementation of a SubjectDefinitionService.
+ */
+@Service
+public class DefaultSubjectDefinitionService implements SubjectDefinitionService {
+
+    private final SubjectDefinitionRepository repository;
+
+    @Autowired
+    public DefaultSubjectDefinitionService(final SubjectDefinitionRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Collection<SubjectDefinition> findAll() {
+        return repository.findAll();
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionController.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionController.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.reporting.subjectdefinition;
+
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+/**
+ * This controller is responsible for providing SubjectDefinition endpoints.
+ */
+@RestController
+@RequestMapping("/subjectdefinitions")
+class SubjectDefinitionController {
+
+    private final SubjectDefinitionService service;
+
+    public SubjectDefinitionController(final SubjectDefinitionService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Collection<SubjectDefinition> findAll() {
+        return service.findAll();
+    }
+}

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionService.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionService.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.reporting.subjectdefinition;
+
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+
+import java.util.Collection;
+
+/**
+ * Implementations of this interface are responsible for providing
+ * SubjectDefinitions.
+ */
+public interface SubjectDefinitionService {
+
+    /**
+     * Find all SubjectDefinitions within the system.
+     * @return All SubjectDefinitions
+     */
+    Collection<SubjectDefinition> findAll();
+}

--- a/reporting-service/src/main/resources/application.yml
+++ b/reporting-service/src/main/resources/application.yml
@@ -15,6 +15,10 @@ server:
     mime-types: application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,text/csv
 
 spring:
+  cache:
+    type: SIMPLE
+    cache-names: subjectdefinitions
+
   datasource:
     url: "\
       jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:reporting}\

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionServiceTest.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subjectdefinition/DefaultSubjectDefinitionServiceTest.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.reporting.subjectdefinition;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.repository.SubjectDefinitionRepository;
+
+import java.util.Collection;
+
+import static com.google.common.collect.ImmutableList.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultSubjectDefinitionServiceTest {
+
+    @Mock
+    private SubjectDefinitionRepository repository;
+
+    private DefaultSubjectDefinitionService service;
+
+    @Before
+    public void setup() {
+        service = new DefaultSubjectDefinitionService(repository);
+    }
+
+    @Test
+    public void itShouldUseRepositoryToFindAll() {
+        final Collection<SubjectDefinition> definitions = of(mock(SubjectDefinition.class), mock(SubjectDefinition.class));
+        when(repository.findAll()).thenReturn(definitions);
+
+        assertThat(service.findAll()).isEqualTo(definitions);
+    }
+}

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionControllerIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subjectdefinition/SubjectDefinitionControllerIT.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.rdw.reporting.subjectdefinition;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.web.UserAwareControllerSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(value = SubjectDefinitionController.class)
+public class SubjectDefinitionControllerIT extends UserAwareControllerSupport {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private SubjectDefinitionService service;
+
+    @Test
+    public void itShouldReturnWhatServiceReturns() throws Exception {
+        final SubjectDefinition icaMath = SubjectDefinition.builder()
+                .asmtTypeCode("ica")
+                .subjectCode("Math")
+                .performanceLevelCount(4)
+                .performanceLevelStandardCutoff(3)
+                .claimScorePerformanceLevelCount(3)
+                .build();
+        final SubjectDefinition iabEla = SubjectDefinition.builder()
+                .asmtTypeCode("iab")
+                .subjectCode("ELA")
+                .performanceLevelCount(3)
+                .build();
+        when(service.findAll()).thenReturn(ImmutableList.of(icaMath, iabEla));
+
+        mvc.perform(get("/subjectdefinitions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].asmtTypeCode").value("ica"))
+                .andExpect(jsonPath("$[0].subjectCode").value("Math"))
+                .andExpect(jsonPath("$[0].performanceLevelCount").value(4))
+                .andExpect(jsonPath("$[0].performanceLevelStandardCutoff").value(3))
+                .andExpect(jsonPath("$[0].claimScorePerformanceLevelCount").value(3))
+                .andExpect(jsonPath("$[1].asmtTypeCode").value("iab"))
+                .andExpect(jsonPath("$[1].subjectCode").value("ELA"))
+                .andExpect(jsonPath("$[1].performanceLevelCount").value(3))
+                .andExpect(jsonPath("$[1].performanceLevelStandardCutoff").doesNotExist())
+                .andExpect(jsonPath("$[1].claimScorePerformanceLevelCount").doesNotExist());
+    }
+}


### PR DESCRIPTION
This PR adds a "/subjectdefinitions" endpoint to the reporting-service to allow the front-end to retrieve subject definitions within the context of an assessment type.

Sample request: 
http://localhost:8080/api/reporting-service/subjectdefinitions

Sample payload:
```
[
{
asmtTypeCode: "ica",
subjectCode: "ELA",
performanceLevelCount: 4,
performanceLevelStandardCutoff: 3,
claimScorePerformanceLevelCount: 3
},
{
asmtTypeCode: "iab",
subjectCode: "ELA",
performanceLevelCount: 3
},
{
asmtTypeCode: "sum",
subjectCode: "ELA",
performanceLevelCount: 4,
performanceLevelStandardCutoff: 3,
claimScorePerformanceLevelCount: 3
},
{
asmtTypeCode: "ica",
subjectCode: "Math",
performanceLevelCount: 4,
performanceLevelStandardCutoff: 3,
claimScorePerformanceLevelCount: 3
},
{
asmtTypeCode: "iab",
subjectCode: "Math",
performanceLevelCount: 3
},
{
asmtTypeCode: "sum",
subjectCode: "Math",
performanceLevelCount: 4,
performanceLevelStandardCutoff: 3,
claimScorePerformanceLevelCount: 3
}
]
```