### PR TITLE
Load subject display text into translation system

### DIFF
--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -1,9 +1,17 @@
 sql:
   translation:
     findAllForLanguage: >-
-        select label_code, label
-        from accommodation_translation
-        where language_code=:language_code
+        SELECT
+          label_code,
+          label
+        FROM accommodation_translation
+        WHERE language_code=:language_code
+        UNION
+        SELECT
+          label_code,
+          label
+        FROM subject_translation
+        WHERE 'eng' = :language_code
 
   organization:
     reporting:

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -6,7 +6,7 @@ sql:
           label
         FROM accommodation_translation
         WHERE language_code=:language_code
-        UNION
+        UNION ALL
         SELECT
           label_code,
           label

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/JdbcTranslationProviderIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/JdbcTranslationProviderIT.java
@@ -5,6 +5,8 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.reporting.common.test.ITDataSourceConfiguration;
 import org.opentestsystem.rdw.reporting.common.test.RepositoryIT;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
@@ -24,6 +26,9 @@ public class JdbcTranslationProviderIT {
     @Autowired
     private JdbcTranslationProvider repository;
 
+    @Autowired
+    private NamedParameterJdbcTemplate template;
+
     @Test
     public void itShouldGetOnlyTheMessagesForTheSelectedLanguage() throws Exception {
         assertThat(repository.getTranslationsByCode(Locale.US))
@@ -34,6 +39,21 @@ public class JdbcTranslationProviderIT {
         assertThat(repository.getTranslationsByCode(Locale.JAPAN))
                 .containsEntry("msg1", "Japanese Message 1")
                 .containsEntry("msg2", "Japanese Message 2");
+    }
+
+    @Test
+    public void itShouldIncludeEnglishSubjectTranslations() throws Exception {
+        template.update("INSERT INTO subject_translation (subject_id, label_code, label) VALUES " +
+                "(1, 'subject.Math.keyA', 'Value A'), " +
+                "(1, 'subject.Math.keyB', 'Value B')",
+                new MapSqlParameterSource());
+
+        assertThat(repository.getTranslationsByCode(Locale.US))
+                .containsEntry("subject.Math.keyA", "Value A")
+                .containsEntry("subject.Math.keyB", "Value B");
+
+        assertThat(repository.getTranslationsByCode(Locale.JAPAN))
+                .doesNotContainKeys("subject.Math.keyA", "subject.Math.keyB");
     }
 
 }


### PR DESCRIPTION
I debated creating separate repositories / translation providers for accommodation translations and subject translations, but thought a UNION with a single DB call felt cleaner.  Thoughts?