### PR TITLE
reduce the z-index of top-sticky

### DIFF
--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1634,7 +1634,7 @@ tr.highlight {
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  z-index: 9999;
+  z-index: 2;
 }
 
 .iab-dashboard-filters {


### PR DESCRIPTION
Still behaves correctly when scrolling. This avoids issues with modal popups