### PR TITLE
Remove extra empty page when generating PDF reports.

### DIFF
--- a/report-processor/src/main/resources/templates/batch-reports.html
+++ b/report-processor/src/main/resources/templates/batch-reports.html
@@ -8,25 +8,41 @@
         <div th:replace="fragments::styles-general"></div>
     </head>
     <body class="pdf">
-        <div th:each="studentCompositeReport : ${studentCompositeReports}">
+        <div th:each="studentCompositeReport, iStat : ${studentCompositeReports}"
+             th:class="${iStat.last}? '' : 'break-page'">
             <div th:if="${studentCompositeReport.iabMath != null}"
-                 th:with="report=${studentCompositeReport.iabMath}">
+                 th:with="report=${studentCompositeReport.iabMath}"
+                 th:class="${studentCompositeReport.iabEla != null ||
+                             studentCompositeReport.icaMath != null ||
+                             studentCompositeReport.icaEla != null ||
+                             studentCompositeReport.summativeMath != null ||
+                             studentCompositeReport.summativeEla != null}? 'break-page'">
                 <div th:replace="iab-body::body"></div>
             </div>
             <div th:if="${studentCompositeReport.iabEla != null}"
-                 th:with="report=${studentCompositeReport.iabEla}">
+                 th:with="report=${studentCompositeReport.iabEla}"
+                 th:class="${studentCompositeReport.icaMath != null ||
+                             studentCompositeReport.icaEla != null ||
+                             studentCompositeReport.summativeMath != null ||
+                             studentCompositeReport.summativeEla != null}? 'break-page'">
                 <div th:replace="iab-body::body"></div>
             </div>
             <div th:if="${studentCompositeReport.icaMath != null}"
-                 th:with="report=${studentCompositeReport.icaMath}">
+                 th:with="report=${studentCompositeReport.icaMath}"
+                 th:class="${studentCompositeReport.icaEla != null ||
+                             studentCompositeReport.summativeMath != null ||
+                             studentCompositeReport.summativeEla != null}? 'break-page'">
                 <div th:replace="ica-body::body"></div>
             </div>
             <div th:if="${studentCompositeReport.icaEla != null}"
-                 th:with="report=${studentCompositeReport.icaEla}">
+                 th:with="report=${studentCompositeReport.icaEla}"
+                 th:class="${studentCompositeReport.summativeMath != null ||
+                             studentCompositeReport.summativeEla != null}? 'break-page'">
                 <div th:replace="ica-body::body"></div>
             </div>
             <div th:if="${studentCompositeReport.summativeMath != null}"
-                 th:with="report=${studentCompositeReport.summativeMath}">
+                 th:with="report=${studentCompositeReport.summativeMath}"
+                 th:class="${studentCompositeReport.summativeEla != null}? 'break-page'">
                 <div th:replace="sum-body::body"></div>
             </div>
             <div th:if="${studentCompositeReport.summativeEla != null}"

--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -26,7 +26,6 @@
 <div th:fragment="styles-general">
     <style>
         footer {
-            page-break-after: always;
             page-break-inside: avoid;
         }
         .row, .well-group {
@@ -369,8 +368,11 @@
             text-align: right;
             font-size: 1rem;
             color: #64666a;
-            page-break-after: always;
             page-break-inside: avoid;
+        }
+
+        .break-page {
+            page-break-after: always;
         }
 
         .overview .standard .score.maroon,


### PR DESCRIPTION
TIL we can't just page-break willy-nilly on every footer, because that leaves us with an extra empty page on all our PDF reports.

This PR only adds a page-break to a report if there is another report after it.