### PR TITLE
avoid empty school year when viewing groups with no results

### DIFF
--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
@@ -91,7 +91,7 @@ export class GroupDashboardComponent implements OnInit {
       const { reload, group, schoolYear, subject, measuredAssessments } = resolvedParameters;
       if (reload) {
         this.group = group;
-        this.schoolYear = Number.parseInt(schoolYear) || undefined;
+        this.schoolYear = Number.parseInt(schoolYear) || this.schoolYear;
         this.updateMeasuredAssessments(measuredAssessments);
       }
       this.subject = subject;


### PR DESCRIPTION
debugging showed schoolYear was initially set in updateRouteWithDefaultFilters and then subscribeToRouteChanges was called which resulted in the schoolYear becoming unset