### PR TITLE
Refactor UI subject-scoped ordering to be backed by the API

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -411,7 +411,11 @@ export class AggregateReportTableComponent implements OnInit {
       const orderingObservables: Observable<Comparator<AggregateReportItem>>[] = subjects.map(subject =>
         this.orderingService.getScorableClaimOrdering(subject, assessmentDefinition.typeCode)
           .pipe(
-            map(ordering => ordering.on((row: AggregateReportItem) => row.claimCode).compare)
+            map(ordering => ordering
+              .on((row: AggregateReportItem) =>
+                row.subjectCode === subject ? row.claimCode : null
+              ).compare
+            )
           ));
       forkJoin(orderingObservables)
         .subscribe(comparators => {

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.ts
@@ -16,10 +16,14 @@ import * as _ from 'lodash';
 import { organizationOrdering, subgroupOrdering } from '../support';
 import { TranslateService } from '@ngx-translate/core';
 import { BaseColumn } from '../../shared/datatable/base-column.model';
-import { byNumericString, createScorableClaimOrdering, SubjectClaimOrderings } from '../../shared/ordering/orderings';
+import { byNumericString, getOrganizationalClaimOrdering, } from '../../shared/ordering/orderings';
 import { IdentityColumnOptions } from '../assessment/assessment-definition.service';
 import { AggregateReportType } from '../aggregate-report-form-settings';
 import { byTargetReportingLevel } from '../../assessments/model/aggregate-target-score-row.model';
+import { OrderingService } from "../../shared/ordering/ordering.service";
+import { map } from "rxjs/operators";
+import { Observable } from "rxjs/Observable";
+import { forkJoin } from "rxjs/observable/forkJoin";
 
 export const SupportedRowCount = 10000;
 export const DefaultRowsPerPageOptions = [ 100, 500, 1000 ];
@@ -30,10 +34,9 @@ const SchoolYearOrdering: Ordering<AggregateReportItem> = ordering(byNumber)
 const AssessmentLabelOrdering: Ordering<AggregateReportItem> = ordering(byString)
   .on(item => item.assessmentLabel);
 
-// TODO:ConfigurableSubjects this needs to be provided by the backend
 const OrganizationalClaimOrderingProvider: (subjectCode: string, preview: boolean) => Ordering<AggregateReportItem> = (subjectCode, preview) => {
-  const currentOrdering: Ordering<string> = !preview && SubjectClaimOrderings.has(subjectCode)
-    ? SubjectClaimOrderings.get(subjectCode)
+  const currentOrdering: Ordering<string> = !preview
+    ? getOrganizationalClaimOrdering(subjectCode)
     : ordering(byString);
   return currentOrdering.on(item => item.claimCode);
 };
@@ -90,7 +93,8 @@ export class AggregateReportTableComponent implements OnInit {
 
   constructor(public colorService: ColorService,
               private translate: TranslateService,
-              private exportService: AggregateReportTableExportService) {
+              private exportService: AggregateReportTableExportService,
+              private orderingService: OrderingService) {
   }
 
   ngOnInit(): void {
@@ -333,11 +337,6 @@ export class AggregateReportTableComponent implements OnInit {
     this._orderingByColumnField[ 'organization.name' ] = organizationOrdering(item => item.organization, rows);
     this._orderingByColumnField[ 'assessmentGradeCode' ] = assessmentGradeOrdering;
     this._orderingByColumnField[ 'schoolYear' ] = SchoolYearOrdering;
-    this._orderingByColumnField[ 'claimCode' ] = reportType === AggregateReportType.Target
-      ? OrganizationalClaimOrderingProvider(rows[ 0 ].subjectCode, this.preview)
-      : ordering(join(...rows.map(row => {
-        return createScorableClaimOrdering(row.subjectCode).on<any>(row => row.claimCode).compare;
-      })));
     this._orderingByColumnField[ 'subgroup.id' ] = subgroupOrdering(item => item.subgroup, options);
     this._orderingByColumnField[ 'targetNaturalId' ] = TargetOrdering;
     this._orderingByColumnField[ 'studentRelativeResidualScoresLevel' ] = ordering(byTargetReportingLevel)
@@ -384,6 +383,7 @@ export class AggregateReportTableComponent implements OnInit {
         );
         break;
       case AggregateReportType.Target:
+        this._orderingByColumnField[ 'claimCode' ] = OrganizationalClaimOrderingProvider(rows[ 0 ].subjectCode, this.preview);
         dataColumns.push(
           new Column({ id: 'studentsTested' }),
           new Column({ id: 'studentRelativeResidualScoresLevel', valueColumn: true }),
@@ -398,8 +398,31 @@ export class AggregateReportTableComponent implements OnInit {
       ...dataColumns
     ];
 
-    this.calculateTreeColumns();
-    this.sortRows();
+    if (reportType === AggregateReportType.Claim) {
+      //Get subjects in report
+      const subjects = rows.reduce((rowSubjects, row) => {
+        if (rowSubjects.indexOf(row.subjectCode) < 0) {
+          rowSubjects.push(row.subjectCode);
+        }
+        return rowSubjects;
+      }, []);
+
+      //Get claim comparators for subjects in report
+      const orderingObservables: Observable<Comparator<AggregateReportItem>>[] = subjects.map(subject =>
+        this.orderingService.getScorableClaimOrdering(subject, assessmentDefinition.typeCode)
+          .pipe(
+            map(ordering => ordering.on((row: AggregateReportItem) => row.claimCode).compare)
+          ));
+      forkJoin(orderingObservables)
+        .subscribe(comparators => {
+          this._orderingByColumnField[ 'claimCode' ] = ordering(join(...comparators));
+          this.sortRows();
+        });
+
+    } else {
+      this.sortRows();
+    }
+
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/assessments/model/aggregate-target-score-row.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/aggregate-target-score-row.model.ts
@@ -5,7 +5,6 @@ export class AggregateTargetScoreRow {
   targetId: number;
   target: string;
   claim: string;
-  claimOrder: number;
   subgroup: Subgroup;
   studentsTested: number;
   standardMetRelativeLevel: TargetReportingLevel;

--- a/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
@@ -8,7 +8,6 @@ import { Target } from '../model/target.model';
 import * as deepEqual from "fast-deep-equal";
 import { ExamFilterOptions } from '../model/exam-filter-options.model';
 import { Subgroup } from '../../aggregate-report/subgroup/subgroup';
-import { SubjectClaimOrder } from '../../shared/ordering/orderings';
 
 @Injectable()
 export class TargetStatisticsCalculator {
@@ -89,7 +88,6 @@ export class TargetStatisticsCalculator {
     return <AggregateTargetScoreRow>{
       targetId: groupedScore.targetId,
       claim: groupedScore.claim,
-      claimOrder: (SubjectClaimOrder.get(groupedScore.subject) || []).indexOf(groupedScore.claim),
       target: groupedScore.target,
       subgroup: groupedScore.subgroup,
       studentsTested: numStudents,

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
@@ -8,17 +8,17 @@ import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { Assessment } from "../../../model/assessment.model";
 import { InstructionalResourcesService } from "../../instructional-resources.service";
 import { CachingDataService } from "../../../../shared/data/caching-data.service";
-import { SubjectService } from "../../../../subject/subject.service";
 import { of } from "rxjs/observable/of";
+import { ordering } from "@kourge/ordering";
+import { byString } from "@kourge/ordering/comparator";
+import { OrderingService } from "../../../../shared/ordering/ordering.service";
 
 describe('ResultsByStudentComponent', () => {
   let component: ResultsByStudentComponent;
   let fixture: ComponentFixture<TestComponentWrapper>;
 
-  const mockSubjectService = jasmine.createSpyObj('SubjectService', [ 'getSubjectDefinition' ]);
-  mockSubjectService.getSubjectDefinition.and.returnValue(of({
-    scorableClaims: []
-  }));
+  const mockOrderingService = jasmine.createSpyObj('OrderingService', [ 'getScorableClaimOrdering' ]);
+  mockOrderingService.getScorableClaimOrdering.and.returnValue(of(ordering(byString)));
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -34,7 +34,7 @@ describe('ResultsByStudentComponent', () => {
         MenuActionBuilder,
         InstructionalResourcesService,
         CachingDataService,
-        {provide: SubjectService, useValue: mockSubjectService}
+        {provide: OrderingService, useValue: mockOrderingService}
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.spec.ts
@@ -4,21 +4,26 @@ import { ResultsByStudentComponent } from './results-by-student.component';
 import { CommonModule } from "../../../../shared/common.module";
 import { MenuActionBuilder } from "../../../menu/menu-action.builder";
 import { TestModule } from "../../../../../test/test.module";
-import { TranslateModule } from "@ngx-translate/core";
 import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { Assessment } from "../../../model/assessment.model";
 import { InstructionalResourcesService } from "../../instructional-resources.service";
 import { CachingDataService } from "../../../../shared/data/caching-data.service";
+import { SubjectService } from "../../../../subject/subject.service";
+import { of } from "rxjs/observable/of";
 
 describe('ResultsByStudentComponent', () => {
   let component: ResultsByStudentComponent;
   let fixture: ComponentFixture<TestComponentWrapper>;
 
+  const mockSubjectService = jasmine.createSpyObj('SubjectService', [ 'getSubjectDefinition' ]);
+  mockSubjectService.getSubjectDefinition.and.returnValue(of({
+    scorableClaims: []
+  }));
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        TranslateModule.forRoot(),
         TestModule
       ],
       declarations: [
@@ -28,7 +33,8 @@ describe('ResultsByStudentComponent', () => {
       providers: [
         MenuActionBuilder,
         InstructionalResourcesService,
-        CachingDataService
+        CachingDataService,
+        {provide: SubjectService, useValue: mockSubjectService}
       ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
@@ -9,9 +9,8 @@ import { InstructionalResourcesService } from '../../instructional-resources.ser
 import { InstructionalResource } from '../../../model/instructional-resources.model';
 import { Observable } from 'rxjs/Observable';
 import { PopupMenuAction } from '../../../../shared/menu/popup-menu-action.model';
-import { createRankingOrStringOrdering, } from '../../../../shared/ordering/orderings';
-import { SubjectService } from '../../../../subject/subject.service';
 import { Ordering } from '@kourge/ordering';
+import { OrderingService } from "../../../../shared/ordering/ordering.service";
 
 @Component({
   selector: 'results-by-student',
@@ -52,11 +51,11 @@ export class ResultsByStudentComponent implements OnInit {
   constructor(private actionBuilder: MenuActionBuilder,
               private translate: TranslateService,
               private instructionalResourcesService: InstructionalResourcesService,
-              private subjectService: SubjectService) {
+              private orderingService: OrderingService) {
   }
 
   ngOnInit() {
-    this.subjectService.getSubjectDefinition(this.assessment.subject, this.assessment.type).subscribe(subjectDefinition => {
+    this.orderingService.getScorableClaimOrdering(this.assessment.subject, this.assessment.type).subscribe(ordering => {
       this.columns = [
         new Column({ id: 'name', field: 'student.lastName' }),
         new Column({ id: 'date' }),
@@ -66,9 +65,7 @@ export class ResultsByStudentComponent implements OnInit {
         new Column({ id: 'status', headerInfo: true, overall: true }),
         new Column({ id: 'level', overall: true }),
         new Column({ id: 'score', headerInfo: true, overall: true }),
-        ...this.createClaimColumns(
-          createRankingOrStringOrdering(subjectDefinition.scorableClaims)
-        )
+        ...this.createClaimColumns(ordering)
       ];
       this.actions = this.createActions();
       this.hasTransferStudent = this.exams.some(x => x.transfer);

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.ts
@@ -56,7 +56,7 @@ export class ResultsByStudentComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.subjectService.getScorableClaimsBySubject().subscribe(scorableClaimsBySubject => {
+    this.subjectService.getSubjectDefinition(this.assessment.subject, this.assessment.type).subscribe(subjectDefinition => {
       this.columns = [
         new Column({ id: 'name', field: 'student.lastName' }),
         new Column({ id: 'date' }),
@@ -67,7 +67,7 @@ export class ResultsByStudentComponent implements OnInit {
         new Column({ id: 'level', overall: true }),
         new Column({ id: 'score', headerInfo: true, overall: true }),
         ...this.createClaimColumns(
-          createRankingOrStringOrdering(scorableClaimsBySubject.get(this.assessment.subject))
+          createRankingOrStringOrdering(subjectDefinition.scorableClaims)
         )
       ];
       this.actions = this.createActions();

--- a/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { Target } from '../../../model/target.model';
 import { Ordering, ordering } from '@kourge/ordering';
-import { byNumber, byString, Comparator, join } from '@kourge/ordering/comparator';
+import { byNumber, Comparator, join } from '@kourge/ordering/comparator';
 import { TargetService } from '../../../../shared/target/target.service';
 import { AssessmentExamMapper } from '../../../assessment-exam.mapper';
 import { BaseColumn } from '../../../../shared/datatable/base-column.model';
@@ -27,7 +27,7 @@ import { ExamFilterOptions } from '../../../model/exam-filter-options.model';
 import { TargetStatisticsCalculator } from '../../target-statistics-calculator';
 import { Subgroup } from '../../../../aggregate-report/subgroup/subgroup';
 import { AssessmentProvider } from '../../../assessment-provider.interface';
-import { byNumericString, SubjectClaimOrderings } from '../../../../shared/ordering/orderings';
+import { byNumericString, getOrganizationalClaimOrdering } from '../../../../shared/ordering/orderings';
 import { ApplicationSettingsService } from '../../../../app-settings.service';
 import { ExportResults } from '../../assessment-results.component';
 import { ExportTargetReportRequest } from '../../../model/export-target-report-request.model';
@@ -286,7 +286,7 @@ export class TargetReportComponent implements OnInit, ExportResults {
   private createOrdering(field: string): Ordering<AggregateTargetScoreRow> {
     switch (field) {
       case 'claim':
-        const claimOrdering: Ordering<string> = (SubjectClaimOrderings.get(this.assessment.subject) || ordering(byString));
+        const claimOrdering: Ordering<string> = getOrganizationalClaimOrdering(this.assessment.subject);
         return claimOrdering.on<AggregateTargetScoreRow>(row => row.claim);
       case 'target':
         return ordering(byNumericString).on<AggregateTargetScoreRow>(row => this.targetDisplayMap.get(row.targetId).name);

--- a/webapp/src/main/webapp/src/app/shared/common.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/common.module.ts
@@ -44,8 +44,8 @@ import { RdwFilterModule } from './filter/rdw-filter.module';
 import { RdwIconModule } from "./icon/rdw-icon.module";
 import { TargetService } from './target/target.service';
 import { DataTableService } from './datatable/datatable-service';
-import { Subject } from 'rxjs/Subject';
 import { SubjectModule } from '../subject/subject.module';
+import { OrderingService } from "./ordering/ordering.service";
 
 
 @NgModule({
@@ -132,6 +132,7 @@ import { SubjectModule } from '../subject/subject.module';
     ColorService,
     DataTableService,
     NotificationService,
+    OrderingService,
     TargetService
   ]
 })

--- a/webapp/src/main/webapp/src/app/shared/ordering/ordering.service.ts
+++ b/webapp/src/main/webapp/src/app/shared/ordering/ordering.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@angular/core";
+import { SubjectService } from "../../subject/subject.service";
+import { Ordering, ordering } from "@kourge/ordering";
+import { Observable } from "rxjs/Observable";
+import { ranking } from "@kourge/ordering/comparator";
+import { map } from "rxjs/operators";
+
+@Injectable()
+export class OrderingService {
+
+  constructor(private subjectService: SubjectService) {
+  }
+
+  public getSubjectOrdering(): Observable<Ordering<string>> {
+    return this.subjectService.getSubjectCodes()
+      .pipe(
+        map(codes => ordering(ranking(codes)))
+      );
+  }
+
+  public getScorableClaimOrdering(subject: string, assessmentType: string): Observable<Ordering<any>> {
+    return this.subjectService.getSubjectDefinition(subject, assessmentType)
+      .pipe(
+        map(definition => ordering(ranking(definition.scorableClaims)))
+      );
+  }
+}

--- a/webapp/src/main/webapp/src/app/shared/ordering/orderings.ts
+++ b/webapp/src/main/webapp/src/app/shared/ordering/orderings.ts
@@ -46,7 +46,3 @@ export const byNumericString = (a: string, b: string) => {
 
   return a.localeCompare(b);
 };
-
-export function createRankingOrStringOrdering<T>(rankings: any[]): Ordering<T> {
-  return ordering(rankings != null ? ranking(rankings) : byString);
-}

--- a/webapp/src/main/webapp/src/app/shared/ordering/orderings.ts
+++ b/webapp/src/main/webapp/src/app/shared/ordering/orderings.ts
@@ -3,43 +3,32 @@ import { Ordering, ordering } from '@kourge/ordering';
 
 export const AssessmentTypeOrdering = ordering(ranking(['sum', 'ica', 'iab']));
 
-// TODO:ConfigurableSubjects these should be provided by the backend
-/** @deprecated */
-export const SubjectOrdering = ordering(ranking(['Math', 'ELA']));
-
 export const BooleanOrdering = ordering(ranking([ 'yes', 'no', 'undefined' ]));
 
 export const CompletenessOrdering = ordering(ranking([ 'Complete', 'Partial' ]));
-/** @deprecated */
-export const ScorableClaimOrder: Map<string, string[]> = new Map([
-  [ 'Math', [ '1', 'SOCK_2', '3' ] ],
-  [ 'ELA', [ 'SOCK_R', '2-W', 'SOCK_LS', '4-CR' ] ]
-]);
-/** @deprecated */
-export const ScorableClaimOrderings: Map<string, Ordering<string>> = new Map([
-  [ 'Math', ordering(ranking(ScorableClaimOrder.get('Math'))) ],
-  [ 'ELA', ordering(ranking(ScorableClaimOrder.get('ELA'))) ]
-]);
-/** @deprecated */
-export const createScorableClaimOrdering: (subjectCode: string) => Ordering<any> = (subjectCode) => {
-  return ScorableClaimOrderings.has(subjectCode)
-    ? ScorableClaimOrderings.get(subjectCode)
-    : ordering(byString);
-};
 
-// TODO:ConfigurableSubjects this needs to be provided by the backend
-/** @deprecated */
-export const SubjectClaimOrder: Map<string, string[]> = new Map([
+const SubjectClaimOrder: Map<string, string[]> = new Map([
   ['Math', ['1', '2', '3', '4']],
   ['ELA', ['1-LT', '1-IT', '2-W', '3-L', '3-S', '4-CR']]
 ]);
-
-// TODO:ConfigurableSubjects this needs to be provided by the backend
-/** @deprecated */
-export const SubjectClaimOrderings: Map<string, Ordering<string>> = new Map([
+const SubjectClaimOrderings: Map<string, Ordering<string>> = new Map([
   ['Math', ordering(ranking(SubjectClaimOrder.get('Math')))],
   ['ELA', ordering(ranking(SubjectClaimOrder.get('ELA')))]
 ]);
+
+/**
+ * Create an Ordering for the given subject's organizational claims.
+ * NOTE that only SBAC organizational claims are explicitly sorted, configurable
+ * subjects will order organizational claims alphabetically.
+ *
+ * @param {string} subject      A subject code
+ * @returns {Ordering<string>}  The ordering for the subject's organizational claim codes
+ */
+export function getOrganizationalClaimOrdering(subject: string): Ordering<string> {
+  return SubjectClaimOrderings.has(subject)
+    ? SubjectClaimOrderings.get(subject)
+    : ordering(byString);
+}
 
 /**
  * Comparator for ordering two strings which may represent numbers such that
@@ -57,7 +46,6 @@ export const byNumericString = (a: string, b: string) => {
 
   return a.localeCompare(b);
 };
-
 
 export function createRankingOrStringOrdering<T>(rankings: any[]): Ordering<T> {
   return ordering(rankings != null ? ranking(rankings) : byString);

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.spec.ts
@@ -20,6 +20,9 @@ import { TestModule } from '../../../test/test.module';
 import { ReportingEmbargoService } from '../../shared/embargo/reporting-embargo.service';
 import { MockActivatedRoute } from '../../shared/test/mock.activated-route';
 import { StudentResultsFilterService } from './student-results-filter.service';
+import { OrderingService } from "../../shared/ordering/ordering.service";
+import { ranking } from "@kourge/ordering/comparator";
+import { ordering } from "@kourge/ordering";
 
 describe('StudentResultsComponent', () => {
   let component: StudentResultsComponent;
@@ -53,6 +56,9 @@ describe('StudentResultsComponent', () => {
 
     router = new MockRouter();
 
+    const mockOrderingService = jasmine.createSpyObj('OrderingService', [ 'getSubjectOrdering' ]);
+    mockOrderingService.getSubjectOrdering.and.returnValue(of(ordering(ranking(["Math", "ELA"]))));
+
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
@@ -67,6 +73,7 @@ describe('StudentResultsComponent', () => {
         { provide: ApplicationSettingsService, useValue: mockApplicationSettingsService },
         { provide: ReportingEmbargoService, useValue: embargoService },
         { provide: ActivatedRoute, useValue: mockRoute },
+        { provide: OrderingService, useValue: mockOrderingService },
         StudentResultsFilterService,
         ExamFilterService
       ],

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-table.component.ts
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-table.component.ts
@@ -10,8 +10,10 @@ import { map } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { StudentResultsFilterService } from '../student-results-filter.service';
-import { createScorableClaimOrdering } from '../../../shared/ordering/orderings';
 import { StudentPipe } from '../../../shared/format/student.pipe';
+import { of } from "rxjs/observable/of";
+import { OrderingService } from "../../../shared/ordering/ordering.service";
+import { Assessment } from "../../../assessments/model/assessment.model";
 
 @Component({
   selector: 'student-history-table',
@@ -51,24 +53,29 @@ export class StudentHistoryTableComponent implements OnInit {
               private instructionalResourcesService: InstructionalResourcesService,
               private translateService: TranslateService,
               private studentResultsFilterService: StudentResultsFilterService,
-              private studentPipe: StudentPipe) {
+              private studentPipe: StudentPipe,
+              private orderingService: OrderingService) {
   }
 
   ngOnInit(): void {
     this.studentResultsFilterService.filterChange.subscribe(() => {
       delete this.selectedCardRowIndex;
     });
-    this.columns = [
-      new Column({ id: 'date', field: 'exam.date' }),
-      new Column({ id: 'assessment', field: 'assessment.label' }),
-      new Column({ id: 'school-year', field: 'exam.schoolYear' }),
-      new Column({ id: 'school', field: 'exam.school.name' }),
-      new Column({ id: 'enrolled-grade', field: 'exam.enrolledGrade' }),
-      new Column({ id: 'status', commonHeader: true, field: 'exam.administrativeCondition', overall: true }),
-      new Column({ id: 'performance', field: 'exam.level', overall: true }),
-      new Column({ id: 'score', commonHeader: true, field: 'exam.score', overall: true }),
-      ...this.getClaimColumns()
-    ];
+
+    this.getClaimColumns(this.exams[ 0 ].assessment)
+      .subscribe(claimColumns => {
+        this.columns = [
+          new Column({ id: 'date', field: 'exam.date' }),
+          new Column({ id: 'assessment', field: 'assessment.label' }),
+          new Column({ id: 'school-year', field: 'exam.schoolYear' }),
+          new Column({ id: 'school', field: 'exam.school.name' }),
+          new Column({ id: 'enrolled-grade', field: 'exam.enrolledGrade' }),
+          new Column({ id: 'status', commonHeader: true, field: 'exam.administrativeCondition', overall: true }),
+          new Column({ id: 'performance', field: 'exam.level', overall: true }),
+          new Column({ id: 'score', commonHeader: true, field: 'exam.score', overall: true }),
+          ...claimColumns
+        ];
+      });
   }
 
   get exams(): StudentHistoryExamWrapper[] {
@@ -135,18 +142,22 @@ export class StudentHistoryTableComponent implements OnInit {
 
     this.updateSelectedCardRowIndex();
 
-    // build the columns based off the selected assessment since it impacts the claim columns used
-    this.columns = [
-      new Column({ id: 'date', field: 'exam.date' }),
-      new Column({ id: 'assessment', field: 'assessment.label' }),
-      new Column({ id: 'school-year', field: 'exam.schoolYear' }),
-      new Column({ id: 'school', field: 'exam.school.name' }),
-      new Column({ id: 'enrolled-grade', field: 'exam.enrolledGrade' }),
-      new Column({ id: 'status', commonHeader: true, field: 'exam.administrativeCondition', overall: true }),
-      new Column({ id: 'performance', field: 'exam.level', overall: true }),
-      new Column({ id: 'score', commonHeader: true, field: 'exam.score', overall: true }),
-      ...this.getClaimColumns()
-    ];
+    this.getClaimColumns(event.assessment)
+      .subscribe(claimColumns => {
+        // build the columns based off the selected assessment since it impacts the claim columns used
+        this.columns = [
+          new Column({ id: 'date', field: 'exam.date' }),
+          new Column({ id: 'assessment', field: 'assessment.label' }),
+          new Column({ id: 'school-year', field: 'exam.schoolYear' }),
+          new Column({ id: 'school', field: 'exam.school.name' }),
+          new Column({ id: 'enrolled-grade', field: 'exam.enrolledGrade' }),
+          new Column({ id: 'status', commonHeader: true, field: 'exam.administrativeCondition', overall: true }),
+          new Column({ id: 'performance', field: 'exam.level', overall: true }),
+          new Column({ id: 'score', commonHeader: true, field: 'exam.score', overall: true }),
+          ...claimColumns
+        ];
+      });
+
   }
 
   loadInstructionalResources(studentHistoryExam: StudentHistoryExamWrapper): void {
@@ -189,23 +200,28 @@ export class StudentHistoryTableComponent implements OnInit {
     return this.exams !== undefined && this.exams.length && this.exams[ 0 ].assessment.claimCodes !== undefined;
   }
 
-  private getClaimColumns(): Column[] {
+  private getClaimColumns(assessment: Assessment): Observable<Column[]> {
     if (!this.hasClaimColumns()) {
-      return [];
+      return of([]);
     }
 
-    return this.exams[ 0 ].assessment.claimCodes
-      .map((claim: string, index: number) =>
-        new Column({
+    const columns: Column[] = assessment.claimCodes
+      .map((claim: string, index: number) => {
+        return new Column({
           id: 'claim',
           field: `exam.claimScores.${index}.level`,
           claim: claim,
           index: index
-        })
-      )
-      .sort(createScorableClaimOrdering(this.exams[ 0 ].assessment.subject)
-        .on((column: Column) => column.claim)
-        .compare);
+        });
+      });
+
+    return this.orderingService
+      .getScorableClaimOrdering(assessment.subject, assessment.type)
+      .pipe(
+        map(ordering =>
+          columns.sort(ordering.on((column: Column) => column.claim).compare)
+        )
+      );
   }
 
 }

--- a/webapp/src/main/webapp/src/app/subject/subject.service.ts
+++ b/webapp/src/main/webapp/src/app/subject/subject.service.ts
@@ -82,10 +82,6 @@ export class SubjectService {
     };
   }
 
-  getScorableClaimsBySubject(): Observable<Map<string, string[]>> {
-    return of(ScorableClaimsBySubject);
-  }
-
   getOrganizationalClaimsBySubject(): Observable<Map<string, string[]>> {
     return of(OrganizationalClaimsBySubject);
   }


### PR DESCRIPTION
Our existing orderings.ts was providing a lot of hard-coded subject/claim/etc-scoped orderings that need to be provided by the back-end API to support configurable subjects.

This PR introduces an OrderingService that provides observable orderings and refactors consumers to subscribe and sort.