### PR TITLE
dont' include longitudinal and target report types if summative is no…

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.service.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-options.service.ts
@@ -36,7 +36,9 @@ export class AggregateReportOptionsService {
         dimensionTypes: serverOptions.dimensionTypes.concat(),
         interimAdministrationConditions: serverOptions.interimAdministrationConditions.concat(),
         queryTypes: [ 'Basic', 'FilteredSubgroup' ],
-        reportTypes: [ AggregateReportType.GeneralPopulation, AggregateReportType.LongitudinalCohort, AggregateReportType.Claim, AggregateReportType.Target ],
+        reportTypes: serverOptions.assessmentTypes.some(x => x.value == 'sum')
+          ? [ AggregateReportType.GeneralPopulation, AggregateReportType.LongitudinalCohort, AggregateReportType.Claim, AggregateReportType.Target ]
+          : [ AggregateReportType.GeneralPopulation, AggregateReportType.Claim ],
         schoolYears: serverOptions.schoolYears.concat(),
         statewideReporter: serverOptions.statewideReporter,
         subjects: serverOptions.subjects.concat(),

--- a/webapp/src/main/webapp/src/app/aggregate-report/query-forms/aggregate-query-form-container.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/query-forms/aggregate-query-form-container.component.html
@@ -62,19 +62,23 @@
       </div>
     </div>
 
-    <general-population-form [hidden]="reportType !== 'GeneralPopulation'"
+    <general-population-form *ngIf="hasGeneralPopulationReport"
+                             [hidden]="reportType !== 'GeneralPopulation'"
                              (navItemChange)="setNavItems('GeneralPopulation', $event)"
                              [submitAction]="submitActionsByReportType['GeneralPopulation']"></general-population-form>
 
-    <longitudinal-cohort-form [hidden]="reportType !== 'LongitudinalCohort'"
+    <longitudinal-cohort-form *ngIf="hasLongitudinalReport"
+                              [hidden]="reportType !== 'LongitudinalCohort'"
                               (navItemChange)="setNavItems('LongitudinalCohort', $event)"
                               [submitAction]="submitActionsByReportType['LongitudinalCohort']"></longitudinal-cohort-form>
 
-    <claim-report-form [hidden]="reportType !== 'Claim'"
-                              (navItemChange)="setNavItems('Claim', $event)"
-                              [submitAction]="submitActionsByReportType['Claim']"></claim-report-form>
+    <claim-report-form *ngIf="hasClaimReport"
+                       [hidden]="reportType !== 'Claim'"
+                       (navItemChange)="setNavItems('Claim', $event)"
+                       [submitAction]="submitActionsByReportType['Claim']"></claim-report-form>
 
-    <target-report-form [hidden]="reportType !== 'Target'"
+    <target-report-form *ngIf="hasTargetReport"
+                        [hidden]="reportType !== 'Target'"
                         (navItemChange)="setNavItems('Target', $event)"
                         [submitAction]="submitActionsByReportType['Target']"></target-report-form>
   </div>

--- a/webapp/src/main/webapp/src/app/aggregate-report/query-forms/aggregate-query-form-container.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/query-forms/aggregate-query-form-container.component.ts
@@ -57,4 +57,25 @@ export class AggregateQueryFormContainerComponent {
   submitQuery($event): void {
     this.submitActionsByReportType[this.reportType].emit($event);
   }
+
+  get hasGeneralPopulationReport(): boolean {
+    return this.hasReportType(AggregateReportType.GeneralPopulation)
+  }
+
+  get hasLongitudinalReport(): boolean {
+    return this.hasReportType(AggregateReportType.LongitudinalCohort)
+  }
+
+  get hasClaimReport(): boolean {
+    return this.hasReportType(AggregateReportType.Claim)
+  }
+
+  get hasTargetReport(): boolean {
+    return this.hasReportType(AggregateReportType.Target)
+  }
+
+  private hasReportType(type: AggregateReportType): boolean {
+    return this.filteredOptions.reportTypes.some(x => x.value == type);
+  }
+
 }


### PR DESCRIPTION
…t an assessment type

with summative not include in the configuration options, it looks like this.

![image](https://user-images.githubusercontent.com/341584/41797339-866788a6-761e-11e8-9c0a-9101347f1465.png)
