### PR TITLE
Task/update student ui for conf subject

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/assessment-icon.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/assessment-icon.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Assessment } from './model/assessment.model';
+import { Utils } from "../shared/support/support";
 
 export const IcaAssessmentIconsBySubject = {
   'Math': 'Math/ICA',
@@ -172,6 +173,9 @@ export class AssessmentIconComponent {
   @Input()
   styles: any;
 
+  @Output()
+  missingIcon: EventEmitter<boolean> = new EventEmitter(true);
+
   private _icon: string;
 
   get icon(): string {
@@ -191,6 +195,10 @@ export class AssessmentIconComponent {
       default:
         this._icon = AssessmentIconsByAssessmentName[ value.name ];
         break;
+    }
+
+    if (Utils.isNullOrUndefined(this._icon)) {
+      this.missingIcon.emit(true);
     }
 
   }

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.html
@@ -1,4 +1,4 @@
-<p>{{ 'item-scores.student-scores-intro-text' | translate }}</p>
+<p *ngIf="subject === 'Math' || subject === 'ELA'">{{ 'item-scores.student-scores-intro-text' | translate }}</p>
 <p-table #itemScores
          [columns]="columns"
          [value]="scores"
@@ -49,11 +49,17 @@
           [ngSwitch]="column.id"
           [hidden]="!column.visible">
 
-        <table-row-expander *ngSwitchCase="'name'"
-                            [table]="itemScores"
-                            [row]="score"
-                            [text]="score.student | studentName">
-        </table-row-expander>
+        <ng-container *ngSwitchCase="'name'">
+          <ng-container *ngIf="subject === 'Math' || subject === 'ELA'; else textOnly">
+            <table-row-expander *ngSwitchCase="'name'"
+                                [table]="itemScores"
+                                [row]="score"
+                                [text]="score.student | studentName"></table-row-expander>
+          </ng-container>
+          <ng-template #textOnly>
+            {{score.student | studentName}}
+          </ng-template>
+        </ng-container>
 
         <div *ngSwitchCase="'date'">
           {{ score.date | date }}

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.spec.ts
@@ -5,7 +5,6 @@ import { Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { AssessmentItem } from "../../model/assessment-item.model";
 import { CommonModule } from "../../../shared/common.module";
 import { TestModule } from "../../../../test/test.module";
-import { RdwFormatModule } from '../../../shared/format/rdw-format.module';
 
 describe('ItemScoresComponent', () => {
   let mockScoreService: any;

--- a/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-scores/item-scores.component.ts
@@ -16,6 +16,9 @@ export class ItemScoresComponent implements OnInit {
   @Input()
   item: AssessmentItem;
 
+  @Input()
+  subject: string;
+
   /**
    * The exam results for this item.
    */

--- a/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-tab.component.html
@@ -3,6 +3,7 @@
        heading="{{ 'item-tab.student-scores' | translate }}">
     <div class="tab-content well">
       <item-scores [item]="item"
+                   [subject]="subject"
                    [exams]="exams"
                    [includeResponse]="includeResponseInStudentScores"
                    [includeWritingTraitScores]="includeWritingTraitScores">
@@ -15,7 +16,8 @@
       <item-writing-trait-scores [responsesAssessmentItem]="responsesAssessmentItem"></item-writing-trait-scores>
     </div>
   </tab>
-  <tab *ngIf="showItemDetails" (select)="selectTab('Item Viewer')"
+  <tab *ngIf="showItemDetails && (subject === 'ELA' || subject === 'Math')"
+       (select)="selectTab('Item Viewer')"
        heading="{{'item-viewer.title' | translate }}">
     <div class="tab-content well">
       <item-viewer *ngIf="loadItemViewer"
@@ -25,7 +27,7 @@
                    [position]="position"></item-viewer>
     </div>
   </tab>
-  <tab *ngIf="showItemDetails" (select)="selectTab('Rubric Exemplar')"
+  <tab *ngIf="showItemDetails && (subject === 'ELA' || subject === 'Math')" (select)="selectTab('Rubric Exemplar')"
        heading="{{ 'item-exemplar.title' | translate }}">
     <div class="tab-content well">
       <item-exemplar *ngIf="loadExemplar" [item]="item"></item-exemplar>

--- a/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/results-by-student/results-by-student.component.html
@@ -30,7 +30,7 @@
         <span *ngSwitchCase="'level'"
               info-button
               title="{{'common.results.assessment-exam-columns.' + assessment.type + '.performance' | translate}}"
-              content="{{'common.results.assessment-exam-columns.' + assessment.type + '.performance-info' | translate}}">
+              content="{{('subject.' + assessment.subject + '.' + assessment.type + '.performance-info') | translate}}">
         </span>
 
         <span *ngSwitchCase="'claim'">

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.html
@@ -8,12 +8,14 @@
   </div>
 
   <div class="row">
-    <div class="col-xs-4">
+    <div class="col-xs-4"
+         [hidden]="!hasIcon">
       <div class="icon-wrapper">
-        <assessment-icon [assessment]="measuredAssessment.assessment"></assessment-icon>
+        <assessment-icon [assessment]="measuredAssessment.assessment"
+                         (missingIcon)="hasIcon = !$event"></assessment-icon>
       </div>
     </div>
-    <div class="col-xs-8">
+    <div [ngClass]="hasIcon ? 'col-xs-8' : 'col-xs-12'">
       <div class="label"
            [ngClass]="getGradeColor()">
         {{'common.assessment-grade-short-label.' + measuredAssessment.assessment.grade | translate}}

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-assessment-card.component.ts
@@ -31,6 +31,7 @@ export class GroupAssessmentCardComponent implements OnInit {
   percents: number[] = [];
   dataWidths: number[] = [];
   selected = false;
+  hasIcon: boolean = true;
 
   constructor(public colorService: ColorService, private examCalculator: ExamStatisticsCalculator) {
   }

--- a/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
@@ -8,12 +8,14 @@
   </div>
 
   <div class="row">
-    <div class="col-xs-4">
+    <div class="col-xs-4"
+         [hidden]="!hasIcon">
       <div class="icon-wrapper">
-        <assessment-icon [assessment]="latestExam.assessment"></assessment-icon>
+        <assessment-icon [assessment]="latestExam.assessment"
+                         (missingIcon)="hasIcon = !$event"></assessment-icon>
       </div>
     </div>
-    <div class="col-xs-8">
+    <div [ngClass]="hasIcon ? 'col-xs-8' : 'col-xs-12'">
       <div class="label"
            [ngClass]="getGradeColor()">
         {{'common.assessment-grade-short-label.' + latestExam.assessment.grade | translate}}

--- a/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
+++ b/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.html
@@ -28,7 +28,7 @@
   </div>
   <div *ngIf="level > 0"
        class="distribution mt-sm"
-       [ngClass]="colorService.getPerformanceLevelColorsByAssessmentTypeCode(latestExam.assessment.type, level)">
+       [ngClass]="'subject.' + latestExam.assessment.subject + '.asmt-type.' + latestExam.assessment.type + '.level.' + level + '.color' | translate">
     {{'subject.' + latestExam.assessment.subject + '.asmt-type.'+ latestExam.assessment.type + '.level.' + level + '.name' | translate}}
   </div>
   <div *ngIf="!level"

--- a/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/student-dashboard/student-assessment-card.component.ts
@@ -18,6 +18,7 @@ export class StudentAssessmentCardComponent implements OnInit {
 
   level: number;
   resultCount: number;
+  hasIcon: boolean = true;
 
   constructor(public colorService: ColorService) {
   }

--- a/webapp/src/main/webapp/src/app/student/results/tables/student-history-table.component.html
+++ b/webapp/src/main/webapp/src/app/student/results/tables/student-history-table.component.html
@@ -69,7 +69,7 @@
             <span *ngSwitchCase="'performance'"
                   info-button
                   title="{{('common.results.assessment-exam-columns.' + assessmentType + '.performance') | translate}}"
-                  content="{{('common.results.assessment-exam-columns.' + assessmentType + '.performance-info') | translate}}">
+                  content="{{('subject.' + subject + '.' + assessmentType + '.performance-info') | translate}}">
             </span>
 
             <span *ngSwitchCase="'claim'">

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -646,16 +646,13 @@
         "date": "Date",
         "grade": "Enrolled Grade",
         "iab": {
-          "performance": "Reporting Category",
-          "performance-info": "Student scores on each Interim Assessment Block are assigned to one of three reporting categories (Below Standard, Near Standard, Above Standard).  The standard is based on the minimum scale score for the 'Met Standard' achievement level on the Interim Comprehensive and summative assessments (the score that separates Levels 2 and 3).  See the Interpretive Guide for more information on how placement into the reporting categories is determined."
+          "performance": "Reporting Category"
         },
         "ica": {
-          "performance": "Achievement Level",
-          "performance-info": "Student scores on the Summative and Interim Comprehensive assessments are assigned to one of four achievement levels (Standard Not Met, Standard Nearly Met, Standard Met, and Standard Exceeded) based on the scale score."
+          "performance": "Achievement Level"
         },
         "sum": {
-          "performance": "Achievement Level",
-          "performance-info": "Student scores on the Summative and Interim Comprehensive assessments are assigned to one of four achievement levels (Standard Not Met, Standard Nearly Met, Standard Met, and Standard Exceeded) based on the scale score."
+          "performance": "Achievement Level"
         },
         "name": "Student",
         "school": "School",


### PR DESCRIPTION
Disable the IRIS expando on student name as well as the item viewer, and rubric/exemplar tab on results-by-student if this isn't an IRIS-aware Math or ELA subject
![image](https://user-images.githubusercontent.com/617828/42001330-88517930-7a18-11e8-99a1-580f21043d64.png)

student history with a mock subject
![image](https://user-images.githubusercontent.com/617828/42001415-c014dbfa-7a18-11e8-8d8d-6aa1eff72124.png)

pull column description text from the subject XML
![image](https://user-images.githubusercontent.com/617828/42001446-d82bbf60-7a18-11e8-8b2e-2b012d625e61.png)

Update student responses with item viewer changes as above
![image](https://user-images.githubusercontent.com/617828/42001615-5d88d6ac-7a19-11e8-82e2-416cb2aedacd.png)

