### PR TITLE
Remove graph border radius from PDF graphs

### DIFF
--- a/report-processor/src/main/resources/templates/fragments.html
+++ b/report-processor/src/main/resources/templates/fragments.html
@@ -240,12 +240,6 @@
             height: 2rem;
             border-right: 1px solid white;
         }
-        .graph .bar:nth-child(3) {
-            border-radius: 0.5rem 0 0 0.5rem;
-        }
-        .graph .bar:last-child {
-            border-radius: 0 0.5rem 0.5rem 0;
-        }
         .graph .bar .bound {
             left: auto;
             right: 0;


### PR DESCRIPTION
With the corner border radius, wkhtmltopdf seems to do some funky antialiasing on the bars at the left and right edges of the graph, which makes them appear about a pixel or two shorter than the bars in the middle.

![image](https://user-images.githubusercontent.com/617828/42289127-ae927d92-7f72-11e8-860b-bf872d543a58.png)

![image](https://user-images.githubusercontent.com/617828/42289104-8f75261c-7f72-11e8-9964-f639df053a4d.png)

After removing the corner border radius the bars are drawn with a uniform height:

![image](https://user-images.githubusercontent.com/617828/42289155-cf5bc7ae-7f72-11e8-8f46-50d23a5d2d46.png)

![image](https://user-images.githubusercontent.com/617828/42289150-c2a70384-7f72-11e8-9aa0-6b53b701af2d.png)
