### PR TITLE
Remove session filtering from the target report.

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.html
@@ -240,7 +240,6 @@
                          [statistics]="statistics"
                          [exams]="exams"
                          [studentsTested]="statistics.total"
-                         [sessions]="sessions"
                          [filterBy]="filterBy"
                          [subjectDefinition]="subjectDefinition"></target-report>
         </ng-container>

--- a/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/assessment-results.component.ts
@@ -339,11 +339,6 @@ export class AssessmentResultsComponent implements OnInit {
 
   toggleSession(session): void {
     session.filter = !session.filter;
-
-    if (this.showTargetReport) {
-      this.targetReport.sessions = this.sessions;
-    }
-
     this.updateExamSessions();
   }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
@@ -86,12 +86,6 @@ export class TargetReportComponent implements OnInit, ExportResults {
 
   schoolYear: number;
 
-  @Input()
-  set sessions(value: any) {
-    this._sessions = value;
-    this.updateTargetScoreExamFilters();
-  }
-
   /**
    * Exam filters applied, if any.
    */
@@ -143,7 +137,6 @@ export class TargetReportComponent implements OnInit, ExportResults {
 
   allSubgroups: any[] = [];
 
-  private _sessions: any[];
   private _filterBy: FilterBy;
   private _filterBySubscription: Subscription;
   private _orderingByIdentityField: { [ key: string ]: Ordering<AggregateTargetScoreRow> } = {};
@@ -390,11 +383,8 @@ export class TargetReportComponent implements OnInit, ExportResults {
       return [];
     }
 
-    const exams: TargetScoreExam[] = <TargetScoreExam[]>this.examFilterService
+    return <TargetScoreExam[]>this.examFilterService
       .filterExams(this.originalTargetScoreExams, this.assessment, this._filterBy);
-
-    // this is only for Groups so always filter by sessions
-    return exams.filter(x => this._sessions.some(y => y.filter && y.id === x.session));
   }
 
   private createAllSubgroups(settings: any): any[] {


### PR DESCRIPTION
Since we no longer allow session filtering in Summative reports, we need to remove session filtering from the target report as well.