### PR TITLE
Fix display of longitudinal data that may be missing values for years.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/query-forms/longitudinal-cohort-form.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/query-forms/longitudinal-cohort-form.component.ts
@@ -19,6 +19,8 @@ import { Utils } from "../../shared/support/support";
 import { AggregateReportType } from "../aggregate-report-form-settings";
 import { SubjectService } from '../../subject/subject.service';
 
+const DisallowedDimensions = ['StudentEnrolledGrade'];
+
 @Component({
   selector: 'longitudinal-cohort-form',
   templateUrl: './longitudinal-cohort-form.component.html'
@@ -55,6 +57,15 @@ export class LongitudinalCohortFormComponent extends MultiOrganizationQueryFormC
     super(columnOrderableItemProvider, notificationService, optionMapper, organizationService, reportService, subjectService, requestMapper, route, router, subgroupMapper, tableDataService);
     this.settings.reportType = AggregateReportType.LongitudinalCohort;
     this.settings.assessmentType = 'sum';
+    console.log("subjects", this.settings.subjects);
+
+    //Strip disallowed dimension types
+    this.filteredOptions.dimensionTypes = this.filteredOptions.dimensionTypes
+      .filter(({value}) => DisallowedDimensions.indexOf(value) < 0);
+    if (this.settings.dimensionTypes) {
+      this.settings.dimensionTypes = this.settings.dimensionTypes
+        .filter(value => DisallowedDimensions.indexOf(value) < 0);
+    }
 
     this.assessmentDefinition = this.assessmentDefinitionService.get(this.settings.assessmentType, this.settings.reportType);
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/query-forms/longitudinal-cohort-form.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/query-forms/longitudinal-cohort-form.component.ts
@@ -19,6 +19,11 @@ import { Utils } from "../../shared/support/support";
 import { AggregateReportType } from "../aggregate-report-form-settings";
 import { SubjectService } from '../../subject/subject.service';
 
+/**
+ * Disable StudentEnrolledGrade as a longitudinal dimension type
+ * because the value varies year-over-year.
+ * @type {[string]}
+ */
 const DisallowedDimensions = ['StudentEnrolledGrade'];
 
 @Component({

--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
@@ -243,7 +243,9 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
         const enabledOptions = options.filter(x => !x.disabled);
         let updatedValues: any[] = this._value;
         if (updatedValues) {
-          updatedValues = enabledOptions.filter(option => this._value.includes(option.value));
+          updatedValues = enabledOptions
+            .map(option => option.value)
+            .filter(value => this._value.includes(value));
         }
 
         //Optionally allow no selection


### PR DESCRIPTION
This PR sets the x-index for longitudinal data based upon school year rather than table data row.

We weren't accounting for data rows that only exist for a single year:
Student Enrollment Grade 7 only exists for 2017
Student Enrollment Grade 8 only exists for 2018

I think this problem may just be related to "Student Enrollment Grade" where the subgroup changes year-over-year.  This wouldn't be an issue for "Gender: Female" which will be the same subgroup year-over-year.  It also wouldn't be an issue if we defined "Student Enrollment Grade" using some kind of value that doesn't change year-over-year like "on-grade" or "assessment grade minus one" but that would start to get messy.

This was leading to a datapoint array like 
`[2018_value]` 
for the enrollment grade 8 series which was displayed at x-axis 0 (2017)

This change injects "missing" values into the datapoint array so the value instead looks like 
`[{}, 2018_value]`
for the enrollment grade 8 series which now displays at x-axis 1 (2018)

![image](https://user-images.githubusercontent.com/617828/42348830-bf122f44-805f-11e8-9032-a7db011aa2d0.png)
