### PR TITLE
RP-31, add targetReport to backend data model and repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-104"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-394"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-105"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-395"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
@@ -13,6 +13,7 @@ public class SubjectDefinition {
     private int performanceLevelCount;
     private Integer performanceLevelStandardCutoff;
     private Integer claimScorePerformanceLevelCount;
+    private boolean targetReport;
     private List<String> scorableClaims;
 
     public String getAsmtTypeCode() {
@@ -35,6 +36,10 @@ public class SubjectDefinition {
         return claimScorePerformanceLevelCount;
     }
 
+    public boolean isTargetReport() {
+        return targetReport;
+    }
+
     public List<String> getScorableClaims() {
         return scorableClaims == null ? ImmutableList.of() : scorableClaims;
     }
@@ -53,6 +58,7 @@ public class SubjectDefinition {
         private int performanceLevelCount;
         private Integer performanceLevelStandardCutoff;
         private Integer claimScorePerformanceLevelCount;
+        private boolean targetReport;
         private List<String> scorableClaims;
 
         public SubjectDefinition build() {
@@ -62,6 +68,7 @@ public class SubjectDefinition {
             definition.performanceLevelCount = performanceLevelCount;
             definition.performanceLevelStandardCutoff = performanceLevelStandardCutoff;
             definition.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            definition.targetReport = targetReport;
             definition.scorableClaims = scorableClaims;
             return definition;
         }
@@ -72,6 +79,7 @@ public class SubjectDefinition {
             performanceLevelCount = definition.performanceLevelCount;
             performanceLevelStandardCutoff = definition.performanceLevelStandardCutoff;
             claimScorePerformanceLevelCount = definition.claimScorePerformanceLevelCount;
+            targetReport = definition.targetReport;
             scorableClaims = definition.scorableClaims;
             return this;
         }
@@ -98,6 +106,11 @@ public class SubjectDefinition {
 
         public Builder claimScorePerformanceLevelCount(final Integer claimScorePerformanceLevelCount) {
             this.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            return this;
+        }
+
+        public Builder targetReport(final boolean targetReport) {
+            this.targetReport = targetReport;
             return this;
         }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
@@ -37,6 +37,7 @@ public class JdbcSubjectDefinitionRepository implements SubjectDefinitionReposit
                         .performanceLevelCount(row.getInt("performance_level_count"))
                         .performanceLevelStandardCutoff(getNullable(row, row.getInt("performance_level_standard_cutoff")))
                         .claimScorePerformanceLevelCount(getNullable(row, row.getInt("claim_score_performance_level_count")))
+                        .targetReport(row.getBoolean("target_report"))
                         .build()
         );
     }

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -139,7 +139,8 @@ sql:
         s.code as subject_code,
         sat.performance_level_count,
         sat.performance_level_standard_cutoff,
-        sat.claim_score_performance_level_count
+        sat.claim_score_performance_level_count,
+        sat.target_report
       FROM subject_asmt_type sat
         JOIN asmt_type at ON at.id = sat.asmt_type_id
         JOIN subject s ON s.id = sat.subject_id

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
@@ -36,9 +36,18 @@ public class JdbcSubjectDefinitionRepositoryIT {
                 .performanceLevelStandardCutoff(3)
                 .claimScorePerformanceLevelCount(3)
                 .build();
+        final SubjectDefinition mathSumDefinition = SubjectDefinition.builder()
+                .asmtTypeCode("sum")
+                .subjectCode("Math")
+                .performanceLevelCount(4)
+                .performanceLevelStandardCutoff(3)
+                .claimScorePerformanceLevelCount(3)
+                .targetReport(true)
+                .build();
         assertThat(definitions)
                 .usingRecursiveFieldByFieldElementComparator()
-                .contains(elaIcaDefinition);
+                .contains(elaIcaDefinition)
+                .contains(mathSumDefinition);
     }
 
 

--- a/reporting-service/src/test/resources/integration-test-data.sql
+++ b/reporting-service/src/test/resources/integration-test-data.sql
@@ -3,8 +3,8 @@ insert into ethnicity VALUES (-29,'ethnicity-29'),(-28,'ethnicity-28'),(-27, 'et
 insert into subject (id, code, updated, update_import_id, migrate_id) values
   (-1, 'NEW', now(), -1, -1);
 
-insert into subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) values
-  (1, -1, 6, 3, 6);
+insert into subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) values
+  (1, -1, 6, 3, 6, 0);
 
 insert into subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) values
   (-1, -1, 1, 'claim1', 1, 1),


### PR DESCRIPTION
This adds the targetReport flag to the backend data model. Which isn't really that useful but doesn't hurt anything and nibbles away at the work for this JIRA.