### PR TITLE
Adding autocomplete/typeahead multiselection widget

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filter-form-options.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filter-form-options.ts
@@ -10,5 +10,6 @@ export interface SubgroupFilterFormOptions {
   englishLanguageAcquisitionStatuses: Option[];
   migrantStatuses: Option[];
   section504s: Option[];
+  languages: Option[];
 
 }

--- a/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filters.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filters.component.html
@@ -96,6 +96,48 @@
   <fieldset>
     <div class="row">
       <div class="col-md-6">
+        <label for="language-subgroup-filter"
+               info-button
+               title="Primary Language"></label>
+               <!--title="{{'aggregate-report-form.field.elas-label' | translate}}"-->
+               <!--content="{{'aggregate-report-form.field.elas-info' | translate}}"></label>-->
+      </div>
+      <div class="col-md-6 toggle-group btn-group-sm vertical all-option nested-btn-group" >
+        <!--TODO: We are mocking the suggestions - these should be seeded from the db -->
+        <sb-typeahead-group id="language-subgroup-filter"
+                            placeholder="Enter a language code"
+                            [suggestions]="[
+                                        {
+                                          text: 'ENG (English)',
+                                          value: 'eng'
+                                        }, {
+                                          text: 'SPA (Spanish)',
+                                          value: 'spa'
+                                        }, {
+                                          text: 'PUN (Punjabi)',
+                                          value: 'pun'
+                                        }, {
+                                          text: 'ITA (Italian)',
+                                            value: 'ita'
+                                        }, {
+                                        text: 'FRA (French)',
+                                        value: 'fra'
+                                        }, {
+                                        text: 'JPN (Japanese)',
+                                        value: 'jpn'
+                                        }]"
+                           [(ngModel)]="settings.languages"
+                           [ngModelOptions]="{standalone: true}"
+                           name="languageCodes"
+                           (change)="onSettingChangeInternal()"></sb-typeahead-group>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<div class="well">
+  <fieldset>
+    <div class="row">
+      <div class="col-md-6">
         <label for="504-subgroup-filter"
                info-button
                title="{{'aggregate-report-form.field.504-label' | translate}}"

--- a/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filters.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/subgroup/subgroup-filters.ts
@@ -42,6 +42,10 @@ export interface SubgroupFilters {
    */
   section504s: string[];
 
+  /**
+   * Language  filter
+   */
+  languages: string[];
 }
 
 const leftDifference = (a: { [ key: string ]: any }, b: { [ key: string ]: any }): { [ key: string ]: any } => {
@@ -64,7 +68,8 @@ export class SubgroupFilterSupport {
       limitedEnglishProficiencies: [],
       englishLanguageAcquisitionStatuses: [],
       migrantStatuses: [],
-      section504s: []
+      section504s: [],
+      languages: []
     };
   }
 

--- a/webapp/src/main/webapp/src/app/shared/form/rdw-form.module.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/rdw-form.module.ts
@@ -10,11 +10,14 @@ import { TranslateModule } from "@ngx-translate/core";
 import { SBButtonGroup } from './sb-button-group';
 import { SBRadioGroup } from './sb-radio-group';
 import { InformationButtonComponent } from './information-button.component';
+import { SBTypeaheadGroup } from "./sb-typeahead-group";
+import { AutoCompleteModule } from "primeng/primeng";
 
 @NgModule({
   declarations: [
     SBTypeahead,
     SBButtonTypeahead,
+    SBTypeaheadGroup,
     SBCheckboxGroup,
     SBButtonGroup,
     SBRadioGroup,
@@ -24,6 +27,7 @@ import { InformationButtonComponent } from './information-button.component';
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
+    AutoCompleteModule,
     PopoverModule.forRoot(),
     TypeaheadModule.forRoot(),
     TranslateModule.forRoot(),
@@ -35,6 +39,7 @@ import { InformationButtonComponent } from './information-button.component';
     SBCheckboxGroup,
     SBButtonGroup,
     SBRadioGroup,
+    SBTypeaheadGroup,
     InformationButtonComponent
   ]
 })

--- a/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
@@ -1,0 +1,309 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Forms } from './forms';
+import { AbstractControlValueAccessor } from './abstract-control-value-accessor';
+import * as _ from 'lodash';
+import { Utils } from '../support/support';
+import { Option } from './option';
+
+/**
+ * Holds the internal button selection state
+ */
+interface State {
+  /**
+   * True when the all option is selected
+   */
+  selectedAllOption: boolean;
+
+  /**
+   * Holds all selected option buttons
+   */
+  selectedOptions: Set<Option>;
+}
+
+/**
+ * Default component styles
+ */
+const DefaultButtonGroupStyles = 'btn-group-sm';
+const DefaultButtonStyles = 'btn-primary';
+
+/**
+ * A group of one or more selections made via a typeahead/autocomplete input field
+ */
+@Component({
+  selector: 'sb-typeahead-group',
+  template: `
+    <ng-template #button let-option let-isAllOption="isAllOption">
+      <label class="btn"
+             [ngClass]="computeStylesInternal(buttonStyles, { 
+                 active: isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option), 
+                 disabled: option.disabled 
+             })"> 
+        <input type="checkbox"
+               [attr.checked]="isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option)"
+               [name]="name"
+               [disabled]="option.disabled"
+               (click)="onAllOptionClickInternal()">
+        {{option.text}}
+      </label>
+    </ng-template>
+
+    <div *ngIf="initializedInternal"
+         data-toggle="buttons"
+         class="typeahead-group all-option btn-group-sm vertical nested-btn-group">
+
+      <ng-container *ngTemplateOutlet="button; context:{
+        $implicit: { text: ('common.buttons.all' | translate) },
+        isAllOption: true
+      }"></ng-container>
+
+      <div class="btn-group chips"
+           [ngClass]="buttonGroupStyles">
+
+        <p-autoComplete #autoComplete
+                        [(ngModel)]="options"
+                        [autoHighlight]="true"
+                        [suggestions]="filteredOptions"
+                        [multiple]="true"
+                        dataKey="value"
+                        (completeMethod)="search($event)"
+                        (onFocus)="autoComplete.show()"
+                        styleClass="wid100"
+                        [minLength]="0" 
+                        [placeholder]="placeholder" 
+                        field="text" >
+        </p-autoComplete> 
+        <div class="languages-container btn-group-sm">
+          <ng-container *ngFor="let option of options">
+            <label class="btn btn-primary active">{{option.text}}
+              <i class="fa fa-times fa-lg pull-right"
+                 tabindex="0"
+                 (click)="removeOption(option)"
+                 (keyup.enter)="removeOption(option)"></i>
+            </label>
+          </ng-container>
+        </div>
+      </div>
+    </div>
+  `,
+  providers: [
+    Forms.valueAccessor(SBTypeaheadGroup)
+  ]
+})
+export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implements OnInit {
+  private _options: Option[];
+  private _initialOptions: Option[] = [];
+  private _initialValues: any[];
+  private _initialized: boolean = false;
+  private _buttonStyles: any = DefaultButtonStyles;
+  private _buttonGroupStyles: any = DefaultButtonGroupStyles;
+  private _state: State;
+
+  filteredOptions: any[];
+  @Input()
+  placeholder = '';
+  @Input()
+  suggestions: Option[];
+
+  constructor() {
+    super();
+  }
+
+  ngOnInit(): void {
+    this._options = this.parseInputOptions(this._initialOptions);
+    this._value = this.parseInputValues(this._initialValues);
+    this._state = this.computeState(this._options, this._value);
+    this._initialized = true;
+  }
+
+  get initializedInternal(): boolean {
+    return this._initialized;
+  }
+
+  get buttonGroupStyles(): any {
+    return this._buttonGroupStyles;
+  }
+
+  @Input()
+  set buttonGroupStyles(value: any) {
+    this._buttonGroupStyles = value ? value : DefaultButtonGroupStyles;
+  }
+
+  get buttonStyles(): any {
+    return this._buttonStyles;
+  }
+
+  @Input()
+  set buttonStyles(value: any) {
+    this._buttonStyles = value ? value : DefaultButtonStyles;
+  }
+
+  get stateInternal(): any {
+    return this._state;
+  }
+  get options(): Option[] {
+    return this._options;
+  }
+
+  @Input()
+  set options(options: Option[]) {
+    if (options.length) {
+      if (this._initialized) {
+        this._options = this.parseInputOptions(options);
+
+        //Only allow enabled values
+        const enabledOptions = options.filter(x => !x.disabled);
+        let updatedValues: any[] = this._value;
+        if (updatedValues) {
+          updatedValues = enabledOptions
+            .map(option => option.value)
+            .filter(value => this._value.includes(value));
+        }
+
+        if (!updatedValues || updatedValues.length === 0) {
+          updatedValues = this.parseInputValues(this._initialValues);
+        }
+
+        //Preserve "All" selection state
+        if (this._state && this._state.selectedAllOption) {
+          updatedValues = this.parseInputValues(null);
+        }
+
+        this.setValueAndNotifyChanges(updatedValues);
+        this._state = this.computeState(this._options, this._value);
+      } else {
+        this._initialOptions = options;
+      }
+    }
+  }
+
+  get value(): any {
+    return this._value;
+  }
+
+  set value(value: any) {
+    if (this._initialized) {
+      this.setValueAndNotifyChanges(this.parseInputValues(value));
+      this._state = this.computeState(this._options, this._value);
+    } else {
+      this._initialValues = value;
+    }
+  }
+
+  search(event) {
+    let query = event.query;
+    this.filteredOptions = this.suggestions.filter(
+      option => option.text.toUpperCase().indexOf(query.toUpperCase()) > -1
+        && !this._options.find(o => o.value === option.value)
+    )
+  }
+
+  removeOption(option: Option) {
+    this.options.splice(this.options.indexOf(option), 1);
+
+    if (this._options.length === 0) {
+      this.onAllOptionClickInternal();
+    }
+  }
+
+  computeStylesInternal(...styles): any {
+    return Utils.toNgClass(...styles.filter(style => style != null));
+  }
+
+  /**
+   * Normalizes and copies values
+   * This should be used to process all values provided to the value field
+   *
+   * @param values
+   * @returns {any[]}
+   */
+  private parseInputValues(values: any): any[] {
+    if (values == null) {
+        return [];
+    }
+    // Make a copy of the value to avoid side effects
+    return values.concat();
+  }
+
+  /**
+   * Normalizes, copies and makes options sensible defaults.
+   * This should be used to process all options provided to the option field
+   *
+   * @param value
+   * @returns {any[]}
+   */
+  private parseInputOptions(options: Option[]): Option[] {
+    if (options == null) {
+      this.throwError('options must not be null or undefined');
+    }
+
+    return options.map(option => <Option>{
+      value: option.value,
+      text: option.text ? option.text : option.value,
+      analyticsProperties: option.analyticsProperties,
+      disabled: option.disabled
+    });
+  }
+
+  /**
+   * This method is called after a state change initiated through user input
+   *
+   * @param {State} state
+   * @param {Option[]} options
+   */
+  private updateValue(state, options: Option[]): void {
+    const values = state.selectedAllOption
+      ? undefined
+      : options
+        .filter(option => !option.disabled && (state.selectedAllOption || state.selectedOptions.has(option)))
+        .map(option => option.value);
+
+    this.setValueAndNotifyChanges(values);
+  }
+
+  /**
+   * Initializes component state based on the component options and values
+   * This method should be called after any externally initiated update to the component options or values
+   *
+   * @param {Option[]} options
+   * @param {any[]} values
+   * @returns {State}
+   */
+  private computeState(options: Option[], values: any[]): State {
+    let enabledOptions = options.filter(x => !x.disabled);
+    const effectiveOptions = enabledOptions.filter(option => values.includes(option.value));
+    const effectivelySelectedAllOption = values.length === enabledOptions.length || enabledOptions.length === effectiveOptions.length;
+    return {
+      selectedAllOption: effectivelySelectedAllOption,
+      selectedOptions: effectivelySelectedAllOption
+        ? new Set()
+        : new Set(effectiveOptions)
+    };
+  }
+
+  /**
+   * All button click handler
+   */
+  onAllOptionClickInternal(): void {
+    const state = this._state,
+      options = this._options;
+
+    state.selectedAllOption = !state.selectedAllOption;
+
+    // Clicking the all button will always result
+    // in a deselection of all options buttons
+    state.selectedOptions.clear();
+    this._options = [];
+    this.updateValue(state, options);
+  }
+
+  private setValueAndNotifyChanges(value: any) {
+    if (!_.isEqual(this._value, value)) {
+      this._value = value;
+      this._onChangeCallback(value);
+    }
+  }
+
+  private throwError(message: string): void {
+    throw new Error(`${this.constructor.name} ${message}`);
+  }
+}

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1709,12 +1709,6 @@ tr.highlight {
   background-color: @gray-lighter;
 }
 
-.controls-container {
-  //position: fixed;
-  background-color: white;
-  z-index: 1;
-}
-
 .typeahead-group {
   .ui-autocomplete-token {
     display: none;

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -1708,3 +1708,47 @@ tr.highlight {
 .admin-tools-well {
   background-color: @gray-lighter;
 }
+
+.controls-container {
+  //position: fixed;
+  background-color: white;
+  z-index: 1;
+}
+
+.typeahead-group {
+  .ui-autocomplete-token {
+    display: none;
+  }
+
+  .chips {
+
+    p-autoComplete {
+      .ui-autocomplete-multiple-container {
+        padding: 0;
+
+        .ui-autocomplete-input-token input {
+          height: 22px;
+          width: 220px;
+          padding-left: 6px;
+          font-size: 14px;
+        }
+      }
+    }
+
+    .languages-container {
+      display: grid;
+
+      label {
+        cursor: default;
+        i {
+          line-height: 20px;
+          cursor: pointer;
+        }
+
+        &:first-child {
+          margin-top: 2px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Sample integration (with mock data of course) added to the custom aggregate reports filter selection
- We will need to create another story to integrate this component in other screens
- Still need to fetch/store the data somewhere. Right now I am returning 8 or so mocked "suggestions"
- Some code was pulled somewhat directly from the `sb-button-group.component` - particularly styling and the "all" button behavior