### PR TITLE
RP-33, fix angular unit tests

### DIFF
--- a/webapp/src/main/webapp/README.md
+++ b/webapp/src/main/webapp/README.md
@@ -7,7 +7,19 @@ ng build
 ```
 #!bash
 ng test
+
+# or, disable watching to run them once
+ng test --watch=false
 ```
+
+To run a single set of tests, i modify the test.ts file. Change the regex for the context
+from the checked-in value to the test suite you want to focus on, e.g.:
+```
+// const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /organization-grouping\.service\.spec\.ts$/);
+```
+Then run tests as usual.
+
 ### Run ###
 ```
 #!bash

--- a/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.spec.ts
+++ b/webapp/src/main/webapp/src/app/assessments/items/item-exemplar/item-exemplar.component.spec.ts
@@ -46,15 +46,15 @@ describe('ItemExemplarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  //TODO: Investigate/fix intermittent unit test failure
-  // it('should display not found when item scoring guide is empty', () => {
-  //   component.ngOnInit();
-  //   expect(component.notFound).toBeTruthy();
-  //   expect(component.errorLoading).toBeFalsy();
-  //   expect(component.model.answerKeyValue).toBeUndefined();
-  //   expect(component.model.exemplars).toEqual([]);
-  //   expect(component.model.rubrics).toEqual([]);
-  // });
+  it('should display not found when item scoring guide is empty', () => {
+    mockItemScoringGuide.itemScoringGuide.answerKeyValue = undefined;
+    component.ngOnInit();
+    expect(component.notFound).toBeTruthy();
+    expect(component.errorLoading).toBeFalsy();
+    expect(component.model.answerKeyValue).toBeUndefined();
+    expect(component.model.exemplars).toEqual([]);
+    expect(component.model.rubrics).toEqual([]);
+  });
 
   it('should display answer key when item scoring guide has answer key', () => {
     mockItemScoringGuide.itemScoringGuide.answerKeyValue = "Answer";

--- a/webapp/src/main/webapp/src/app/organization-export/organization-grouping.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/organization-export/organization-grouping.service.spec.ts
@@ -1,20 +1,25 @@
 import { OrganizationMapper } from "./organization/organization.mapper";
 import { OrganizationGroupingService } from "./organization-grouping.service";
+import { UserOrganizations } from "./organization/user-organizations";
 
 describe('OrganizationGroupingService', () => {
 
   let mapper = new OrganizationMapper();
   let service: OrganizationGroupingService = new OrganizationGroupingService(mapper);
-  let organizations = mapper.createUserOrganizations([
-    { id: 1, name: 'School 1', schoolGroupId: 1, districtId: 1 },
-    { id: 2, name: 'School 2', schoolGroupId: 1, districtId: 1 },
-    { id: 3, name: 'School 3', schoolGroupId: 2, districtId: 1 }
-  ], [
-    { id: 1, name: 'School Group 1', districtId: 1 },
-    { id: 2, name: 'School Group 2', districtId: 1 }
-  ], [
-    { id: 1, name: 'District 1' }
-  ]);
+  let organizations: UserOrganizations;
+
+  beforeEach(() => {
+    organizations = mapper.createUserOrganizations([
+      { id: 1, name: 'School 1', schoolGroupId: 1, districtId: 1 },
+      { id: 2, name: 'School 2', schoolGroupId: 1, districtId: 1 },
+      { id: 3, name: 'School 3', schoolGroupId: 2, districtId: 1 }
+    ], [
+      { id: 1, name: 'School Group 1', districtId: 1 },
+      { id: 2, name: 'School Group 2', districtId: 1 }
+    ], [
+      { id: 1, name: 'District 1' }
+    ]);
+  });
 
   it('should return one school when one school of multi-school group/district', () => {
     expect(service.groupSelectedOrganizationIdsByType([
@@ -27,32 +32,30 @@ describe('OrganizationGroupingService', () => {
     });
   });
 
-  //TODO: Investigate/fix intermittent unit test failures here
-  // it('should return school group when all schools of group are selected', () => {
-  //   expect(service.groupSelectedOrganizationIdsByType([
-  //       organizations.schoolsById.get(1),
-  //       organizations.schoolsById.get(2)
-  //     ], organizations
-  //   )).toEqual({
-  //     districtIds: [],
-  //     schoolGroupIds: [ 1 ],
-  //     schoolIds: []
-  //   });
-  // });
+  it('should return school group when all schools of group are selected', () => {
+    expect(service.groupSelectedOrganizationIdsByType([
+        organizations.schoolsById.get(1),
+        organizations.schoolsById.get(2)
+      ], organizations
+    )).toEqual({
+      districtIds: [],
+      schoolGroupIds: [ 1 ],
+      schoolIds: []
+    });
+  });
 
-  //TODO: Investigate/fix intermittent unit test failures here
-  // it('should return district when all schools of the district are selected', () => {
-  //   expect(service.groupSelectedOrganizationIdsByType([
-  //       organizations.schoolsById.get(1),
-  //       organizations.schoolsById.get(2),
-  //       organizations.schoolsById.get(3),
-  //     ], organizations
-  //   )).toEqual({
-  //     districtIds: [ 1 ],
-  //     schoolGroupIds: [],
-  //     schoolIds: []
-  //   });
-  // });
+  it('should return district when all schools of the district are selected', () => {
+    expect(service.groupSelectedOrganizationIdsByType([
+        organizations.schoolsById.get(1),
+        organizations.schoolsById.get(2),
+        organizations.schoolsById.get(3),
+      ], organizations
+    )).toEqual({
+      districtIds: [ 1 ],
+      schoolGroupIds: [],
+      schoolIds: []
+    });
+  });
 
   it('should handle multi-school export without district permissions', () => {
     organizations = new OrganizationMapper().createUserOrganizations([
@@ -74,5 +77,3 @@ describe('OrganizationGroupingService', () => {
   });
 
 });
-
-

--- a/webapp/src/main/webapp/src/app/organization-export/organization-grouping.service.ts
+++ b/webapp/src/main/webapp/src/app/organization-export/organization-grouping.service.ts
@@ -47,7 +47,7 @@ export class OrganizationGroupingService {
    * Adds the given organization's ID to the appropriate ID collection in the given grouped organization ID holder.
    *
    * @param {Organization} organization the organization to add
-   * @param {GroupedOrganizationIds} groupedOrganizationIds the ID collection holder to add the organization ID to
+   * @param {GroupedOrganizationIds} ids the ID collection holder to add the organization ID to
    */
   private groupOrganization(organization: Organization, ids: GroupedOrganizationIds) {
     switch (organization.type) {

--- a/webapp/src/main/webapp/src/app/shared/security/authentication.service.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/security/authentication.service.spec.ts
@@ -13,19 +13,19 @@ import { Location } from "@angular/common";
 import { WindowRefService } from "../core/window-ref.service";
 import { SBStorage, StorageService, StorageType } from "../core/storage.service";
 
-let mockWindow = {
-  location: {
-    href: 'https://awsqa/groups',
-    pathname: '/groups'
-  }
-};
-
-
 describe('AuthenticationService', () => {
   let storageService: MockStorageService;
+  let mockWindow: any;
 
   beforeEach(() => {
     storageService = new MockStorageService();
+
+    mockWindow = {
+      location: {
+        href: 'https://awsqa/groups',
+        pathname: '/groups'
+      }
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -47,16 +47,15 @@ describe('AuthenticationService', () => {
       expect(service).toBeTruthy();
     }));
 
-  //TODO: Investigate/fix intermittent unit test failure
-  // it('should record the browser location on authentication failure',
-  //   inject([ AuthenticationService, Router ], (service: AuthenticationService, router: Router) => {
-  //
-  //     service.navigateToAuthenticationExpiredRoute();
-  //
-  //     expect(storageService.getStorage).toHaveBeenCalledWith(StorageType.Session);
-  //     expect(service.urlWhenSessionExpired).toBe("https://awsqa/groups");
-  //     expect(router.navigate).toHaveBeenCalledWith([ "session-expired" ]);
-  //   }));
+  it('should record the browser location on authentication failure',
+    inject([ AuthenticationService, Router ], (service: AuthenticationService, router: Router) => {
+
+      service.navigateToAuthenticationExpiredRoute();
+
+      expect(storageService.getStorage).toHaveBeenCalledWith(StorageType.Session);
+      expect(service.urlWhenSessionExpired).toBe("https://awsqa/groups");
+      expect(router.navigate).toHaveBeenCalledWith([ "session-expired" ]);
+    }));
 
   it('should never record the browser location of session-expired',
     inject([ AuthenticationService, Router ], (service: AuthenticationService, router: Router) => {


### PR DESCRIPTION
The general problem is tests that don't fully set up, relying on shared mocks, etc. Fix was just to put the appropriate setup in a beforeEach, or otherwise setup properly.