### PR TITLE
Fix for RP-63 where if a language was selected then unselected …

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
@@ -300,8 +300,6 @@ export class AggregateReportSummary {
         });
       }
       if (!equalSize(optionFilters.section504s, settingFilters.section504s)) {
-        console.log("optionFilters.section504s:", optionFilters.section504s);
-        console.log("settingFilters.section504s:", settingFilters.section504s);
         filterRows.push({
           label: translate('aggregate-report-form.field.504-label'),
           values: inline(orAll(

--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
@@ -300,6 +300,8 @@ export class AggregateReportSummary {
         });
       }
       if (!equalSize(optionFilters.section504s, settingFilters.section504s)) {
+        console.log("optionFilters.section504s:", optionFilters.section504s);
+        console.log("settingFilters.section504s:", settingFilters.section504s);
         filterRows.push({
           label: translate('aggregate-report-form.field.504-label'),
           values: inline(orAll(
@@ -309,7 +311,8 @@ export class AggregateReportSummary {
           ))
         });
       }
-      if (!equalSize(optionFilters.languages, settingFilters.languages)) {
+      if ((!equalSize(optionFilters.languages, settingFilters.languages)) &&
+        (settingFilters.languages.length > 0)) {
         filterRows.push({
           label: translate('aggregate-report-form.field.language-label'),
           values: inline(orAll(


### PR DESCRIPTION
…then unselected the Advanced Filters section report summary showed "Languages: None" instead of having that section disappear.

https://jira.fairwaytech.com/browse/RP-63