### PR TITLE
make route handling consistent for admin services

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/embargo/embargo.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/embargo/embargo.service.ts
@@ -6,8 +6,9 @@ import { OrganizationType } from "./organization-type.enum";
 import { DataService } from "../../shared/data/data.service";
 import { ResponseContentType } from "@angular/http";
 import { map } from 'rxjs/operators';
+import { AdminServiceRoute } from '../../shared/service-route';
 
-const ResourceContext = '/admin-service/embargoes';
+const ResourceContext = `${AdminServiceRoute}/embargoes`;
 
 /**
  * Service responsible for managing organization embargo settings
@@ -28,7 +29,7 @@ export class EmbargoService {
       .pipe(
         map((sourceEmbargoes: any[]) => {
           return sourceEmbargoes.reduce((embargoesByOrganizationType, sourceEmbargo) => {
-            const embargo = this.toEmbargo(sourceEmbargo),
+            const embargo = EmbargoService.toEmbargo(sourceEmbargo),
               type = embargo.organization.type;
 
             embargoesByOrganizationType.set(type, (embargoesByOrganizationType.get(type) || []).concat(embargo));
@@ -60,7 +61,7 @@ export class EmbargoService {
    * @param source the API embargo model
    * @returns {Embargo} a UI embargo model
    */
-  private toEmbargo(source: any): Embargo {
+  private static toEmbargo(source: any): Embargo {
     return {
       organization: {
         id: source.organizationId,

--- a/webapp/src/main/webapp/src/app/admin/groups/groups.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/groups/groups.service.ts
@@ -11,7 +11,7 @@ import { DataService } from "../../shared/data/data.service";
 import { map } from 'rxjs/operators';
 import { AdminServiceRoute } from '../../shared/service-route';
 
-const ServiceRoute = AdminServiceRoute;
+const ResourceContext = `${AdminServiceRoute}/groups`;
 const ALL = 'ALL';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class GroupService {
 
   getFilterOptions(): Observable<GroupFilterOptions> {
     return this.dataService
-      .get(`${ServiceRoute}/groups/filters`)
+      .get(`${ResourceContext}/filters`)
       .pipe(
         map(this.mapFilterOptionsFromApi.bind(this))
       );
@@ -30,14 +30,14 @@ export class GroupService {
 
   getGroups(query: GroupQuery): Observable<Group[]> {
     return this.dataService
-      .get(`${ServiceRoute}/groups`, { search: this.mapQueryToParams(query) })
+      .get(`${ResourceContext}`, { search: this.mapQueryToParams(query) })
       .pipe(
-        map(groups => groups.map(this.mapGroupFromApi))
+        map(groups => groups.map(GroupService.mapGroupFromApi))
       );
   }
 
   delete(group: Group): Observable<any> {
-    return this.dataService.delete(`${ServiceRoute}/groups/${group.id}`);
+    return this.dataService.delete(`${ResourceContext}/${group.id}`);
   }
 
   private mapQueryToParams(query: GroupQuery) {
@@ -55,7 +55,7 @@ export class GroupService {
     return params;
   }
 
-  private mapGroupFromApi(apiModel): Group {
+  private static mapGroupFromApi(apiModel): Group {
     let uiModel = new Group();
     uiModel.id = apiModel.id;
     uiModel.schoolYear = apiModel.schoolYear;
@@ -81,10 +81,10 @@ export class GroupService {
     uiModel.schoolYears = apiModel.schoolYears || [];
     uiModel.subjects = (apiModel.subjects && apiModel.subjects.map(subject => subject.toUpperCase())) || [];
 
-    return this.adaptFilterOptions(uiModel);
+    return GroupService.adaptFilterOptions(uiModel);
   }
 
-  private adaptFilterOptions(filterOptions: GroupFilterOptions): GroupFilterOptions {
+  private static adaptFilterOptions(filterOptions: GroupFilterOptions): GroupFilterOptions {
     if (filterOptions.schoolYears.length == 0) {
       filterOptions.schoolYears = [ new Date().getFullYear() ];
     }

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/assessment.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/assessment.service.ts
@@ -6,7 +6,7 @@ import { DataService } from '../../shared/data/data.service';
 import { map } from 'rxjs/operators';
 import { AdminServiceRoute } from '../../shared/service-route';
 
-const ServiceRoute = AdminServiceRoute;
+const ResourceContext = `${AdminServiceRoute}/assessments`;
 
 /**
  * This service is responsible for interacting with assessments.
@@ -18,7 +18,7 @@ export class AssessmentService {
   }
 
   find(query: AssessmentQuery): Observable<Assessment[]> {
-    return this.dataService.get(`${ServiceRoute}/assessments`, { params: <any>query }).pipe(
+    return this.dataService.get(`${ResourceContext}`, { params: <any>query }).pipe(
       map(serverAssessments => serverAssessments.map(serverAssessment => {
         const assessment = new Assessment();
         assessment.id = serverAssessment.id;

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/instructional-resource.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/instructional-resource.service.ts
@@ -5,7 +5,7 @@ import { DataService } from '../../shared/data/data.service';
 import { map } from 'rxjs/operators';
 import { AdminServiceRoute } from '../../shared/service-route';
 
-const ServiceRoute = AdminServiceRoute;
+const ResourceContext = `${AdminServiceRoute}/instructional-resources`;
 
 /**
  * This service is responsible for interacting with instructional resources.
@@ -22,7 +22,7 @@ export class InstructionalResourceService {
    * @returns {Observable<InstructionalResource[]>} The user's instructional resources
    */
   findAll(): Observable<InstructionalResource[]> {
-    return this.dataService.get(`${ServiceRoute}/instructional-resources`).pipe(
+    return this.dataService.get(`${ResourceContext}`).pipe(
       map(InstructionalResourceService.mapResourcesFromApi)
     );
   }
@@ -34,7 +34,7 @@ export class InstructionalResourceService {
    * @returns {Observable<InstructionalResource>} The created instructional resource
    */
   create(resource: InstructionalResource): Observable<InstructionalResource> {
-    return this.dataService.post(`${ServiceRoute}/instructional-resources`, resource).pipe(
+    return this.dataService.post(`${ResourceContext}`, resource).pipe(
       map(InstructionalResourceService.mapResourceFromApi)
     );
   }
@@ -46,7 +46,7 @@ export class InstructionalResourceService {
    * @returns {Observable<InstructionalResource>} The updated instructional resource
    */
   update(resource: InstructionalResource): Observable<InstructionalResource> {
-    return this.dataService.put(`${ServiceRoute}/instructional-resources`, this.toServerFormat(resource)).pipe(
+    return this.dataService.put(`${ResourceContext}`, InstructionalResourceService.toServerFormat(resource)).pipe(
       map(InstructionalResourceService.mapResourceFromApi)
     );
   }
@@ -58,14 +58,14 @@ export class InstructionalResourceService {
    * @returns {Observable<any>} Empty if the action was successful
    */
   delete(resource: InstructionalResource): Observable<any> {
-    return this.dataService.delete(`${ServiceRoute}/instructional-resources`, { params: <any>this.toServerFormat(resource) });
+    return this.dataService.delete(`${ResourceContext}`, { params: <any>InstructionalResourceService.toServerFormat(resource) });
   }
 
   private static mapResourcesFromApi(serverResources) {
     return serverResources.map(serverResource => InstructionalResourceService.mapResourceFromApi(serverResource));
   }
 
-  private toServerFormat(resource: InstructionalResource): InstructionalResource {
+  private static toServerFormat(resource: InstructionalResource): InstructionalResource {
     resource.assessmentType = AssessmentType[resource.assessmentType] ? AssessmentType[resource.assessmentType] : resource.assessmentType;
     return resource;
   }

--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/organization.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/organization.service.ts
@@ -6,7 +6,8 @@ import { DataService } from "../../shared/data/data.service";
 import { map } from 'rxjs/operators';
 import { AdminServiceRoute } from '../../shared/service-route';
 
-const ServiceRoute = AdminServiceRoute;
+const ResourceContext = `${AdminServiceRoute}/organizations`;
+
 
 /**
  * This service is responsible for interacting with organizations.
@@ -24,7 +25,7 @@ export class OrganizationService {
    * @returns {Observable<Organization[]>}  The matching organizations
    */
   find(query: OrganizationQuery): Observable<Organization[]> {
-    return this.dataService.get(`${ServiceRoute}/organizations`, { params: query })
+    return this.dataService.get(`${ResourceContext}`, { params: query })
       .pipe(
         map(OrganizationService.mapOrganizationsFromApi)
       );


### PR DESCRIPTION
When i was debugging an issue i noticed that the admin services were slightly different in their route handling, and the use of `static` helper methods. This makes absolutely no real change except to make things consistent.