### PR TITLE
Fix for header sorting. We're not actually using lazy loading here an…

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table.component.html
@@ -6,7 +6,6 @@
          [virtualScroll]="true"
          [totalRecords]="table.rows.length"
          scrollHeight="500px"
-         [lazy]="true"
          [virtualRowHeight]="37"
          [rowTrackBy]="rowTrackBy"
          [alwaysShowPaginator]="false"


### PR DESCRIPTION
…yway.

Using lazy loading for this library requires the API to support it, but we confused the p-table by specifying that we were using lazy loading.