### PR TITLE
Clearing out the state when select All is called.

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
@@ -326,6 +326,7 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
     // in a deselection of all options buttons
     state.selectedOptions.clear();
     this._options = [];
+    this._initialOptions = [];
     this.updateValue(state, options);
     this.optionsEvent.emit(this.options);
   }


### PR DESCRIPTION
some state needed resetting when the clear button (All) was clicked.

Otherwise, part of the issue was that the state is kept independently from report type to report type (Yearly Report, Claim Report, etc). This is the same behavior as the rest of the controls there. 