### PR TITLE
remove propdeps

### DIFF
--- a/admin-service/build.gradle
+++ b/admin-service/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
     runtime 'org.springframework.boot:spring-boot-devtools'
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/aggregate-service/build.gradle
+++ b/aggregate-service/build.gradle
@@ -5,8 +5,6 @@ createDockerfile {
 }
 
 dependencies {
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     compile 'com.amazon.redshift:redshift-jdbc42-no-awssdk:1.2.8.1005'
 
     // fixes java 8 time marshaling

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,11 @@ buildscript {
     repositories {
         mavenLocal()
         jcenter()
-        maven { url 'http://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath("com.bmuschko:gradle-docker-plugin:3.6.2")
         classpath("io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE")
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.18.RELEASE")
-        classpath('org.springframework.build.gradle:propdeps-plugin:0.0.7')
     }
 }
 
@@ -23,7 +21,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-107"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-108"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-411"
 String dockerPrefix = "smarterbalanced"
 
@@ -32,9 +30,6 @@ allprojects {
     version = '1.4.0-SNAPSHOT'
 
     apply plugin: 'idea'
-    apply plugin: 'propdeps'
-    apply plugin: 'propdeps-maven'
-    apply plugin: 'propdeps-idea'
     apply plugin: "com.jfrog.artifactory"
 
     if (project.hasProperty("buildNumber")) {
@@ -92,6 +87,9 @@ subprojects {
     }
 
     dependencies {
+        // handy for creating metadata with @ConfigurationProperties
+        compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
+
         compile "org.slf4j:slf4j-api"
 
         testCompile 'junit:junit'

--- a/common-web/build.gradle
+++ b/common-web/build.gradle
@@ -7,11 +7,11 @@ bootRun.enabled = false
 
 dependencies {
     compile project(':rdw-reporting-common')
+    compile 'io.jsonwebtoken:jjwt'
+    compile 'org.springframework:spring-messaging'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-security'
-    compile 'io.jsonwebtoken:jjwt'
-    provided 'org.springframework:spring-messaging'
 
     testCompile project(path: ':rdw-reporting-common', configuration: 'tests')
     testCompile('org.springframework.boot:spring-boot-starter-test') {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -19,8 +19,6 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'com.healthmarketscience.sqlbuilder:sqlbuilder:2.1.7'
 
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     testCompile('org.springframework.boot:spring-boot-starter-test') {
         exclude(module: 'commons-logging')
     }

--- a/report-processor/build.gradle
+++ b/report-processor/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-cache'
     compile 'org.springframework.boot:spring-boot-starter-security'

--- a/reporting-service/build.gradle
+++ b/reporting-service/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
     runtime 'org.springframework.boot:spring-boot-devtools'
     compile 'org.springframework.cloud:spring-cloud-starter-aws'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
     runtime 'org.springframework.boot:spring-boot-devtools'
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'


### PR DESCRIPTION
Similar to change in common: Dave had trouble with the repo for propdeps not being available. Since we don't really use the optional and provided features, it seems prudent to stop trying to get it. Note that we do pull in the spring boot spring-boot-configuration-processor using optional, so i switched that to compileOnly which is morally equivalent. I also pulled that common dependency into the root build file since every module was repeating it. And we did use `provided` in common-web but i can't quite figure out why since i *think* the reason it was provided is because the service using common-web is pulling it in, and that means `compile` is the same as `provided` in that situation.  Maybe @wtritch will correct me if i'm wrong.