### PR TITLE
makes lodash imports tree-shakeable

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.ts
+++ b/webapp/src/main/webapp/src/app/admin/instructional-resource/update-instructional-resource.modal.ts
@@ -1,10 +1,10 @@
-import { Component, EventEmitter, OnDestroy } from "@angular/core";
-import { InstructionalResource } from "./model/instructional-resource.model";
-import { BsModalRef } from "ngx-bootstrap";
-import { InstructionalResourceService } from "./instructional-resource.service";
-import * as _ from "lodash";
-import { NavigationStart, Router } from "@angular/router";
-import { Subscription } from "rxjs";
+import { Component, EventEmitter, OnDestroy } from '@angular/core';
+import { InstructionalResource } from './model/instructional-resource.model';
+import { BsModalRef } from 'ngx-bootstrap';
+import { InstructionalResourceService } from './instructional-resource.service';
+import { clone } from 'lodash';
+import { NavigationStart, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 /**
@@ -15,13 +15,12 @@ import { filter } from 'rxjs/operators';
   templateUrl: './update-instructional-resource.modal.html'
 })
 export class UpdateInstructionalResourceModal implements OnDestroy {
-
   get resource(): InstructionalResource {
     return this._resource;
   }
 
   set resource(value: InstructionalResource) {
-    this._resource = _.clone(value);
+    this._resource = clone(value);
   }
 
   unableToModify: boolean = false;
@@ -30,14 +29,16 @@ export class UpdateInstructionalResourceModal implements OnDestroy {
   private _resource: InstructionalResource = new InstructionalResource();
   private _subscription: Subscription;
 
-  constructor(private modal: BsModalRef,
-              private resourceService: InstructionalResourceService,
-              private router: Router) {
-    this._subscription = router.events.pipe(
-      filter(e => e instanceof NavigationStart)
-    ).subscribe(() => {
-      this.cancel();
-    });
+  constructor(
+    private modal: BsModalRef,
+    private resourceService: InstructionalResourceService,
+    private router: Router
+  ) {
+    this._subscription = router.events
+      .pipe(filter(e => e instanceof NavigationStart))
+      .subscribe(() => {
+        this.cancel();
+      });
   }
 
   ngOnDestroy(): void {
@@ -50,13 +51,13 @@ export class UpdateInstructionalResourceModal implements OnDestroy {
 
   update() {
     this.resourceService.update(this.resource).subscribe(
-      (updatedResource) => {
+      updatedResource => {
         this.modal.hide();
         this.updated.emit(updatedResource);
       },
       () => {
         this.unableToModify = true;
-      });
+      }
+    );
   }
-
 }

--- a/webapp/src/main/webapp/src/app/assessments/filters/select-assessments/select-assessments.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/filters/select-assessments/select-assessments.component.ts
@@ -1,15 +1,14 @@
-import { Component, EventEmitter, Input, Output } from "@angular/core";
-import { Assessment } from "../../model/assessment.model";
-import * as _ from "lodash";
-import { ColorService } from "../../../shared/color.service";
-import { GradeCode } from "../../../shared/enum/grade-code.enum";
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Assessment } from '../../model/assessment.model';
+import { uniq } from 'lodash';
+import { ColorService } from '../../../shared/color.service';
+import { GradeCode } from '../../../shared/enum/grade-code.enum';
 
 @Component({
   selector: 'select-assessments',
   templateUrl: './select-assessments.component.html'
 })
 export class SelectAssessmentsComponent {
-
   assessmentsByGrade: any[] = [];
 
   @Input()
@@ -23,12 +22,11 @@ export class SelectAssessmentsComponent {
   }
 
   @Output()
-  selectedAssessmentsChanged: EventEmitter<Assessment> = new EventEmitter()
+  selectedAssessmentsChanged: EventEmitter<Assessment> = new EventEmitter();
 
   private _assessments: Assessment[];
 
-  constructor(public colorService: ColorService) {
-  }
+  constructor(public colorService: ColorService) {}
 
   getGradeIdx(gradeCode: string): number {
     return GradeCode.getIndex(gradeCode);
@@ -36,7 +34,7 @@ export class SelectAssessmentsComponent {
 
   toggleSelectedAssessment(assessment: Assessment) {
     if (assessment.selected) {
-      this.deselectAssessment(assessment)
+      this.deselectAssessment(assessment);
     } else {
       assessment.selected = true;
       this.selectedAssessmentsChanged.emit(assessment);
@@ -46,12 +44,11 @@ export class SelectAssessmentsComponent {
   private deselectAssessment(assessment: Assessment) {
     let count = 0;
     this._assessments.forEach(asmt => {
-        if (asmt.selected) {
-          count++;
-          if (count > 1) return;
-        }
+      if (asmt.selected) {
+        count++;
+        if (count > 1) return;
       }
-    );
+    });
     if (count > 1) {
       assessment.selected = false;
       this.selectedAssessmentsChanged.emit(assessment);
@@ -59,13 +56,14 @@ export class SelectAssessmentsComponent {
   }
 
   private groupAssessmentsByGrade() {
-    let assessmentsByGrade = [];
+    const assessmentsByGrade = [];
 
-    let grades: string[] = _.uniq(this._assessments.map(assessment => assessment.grade))
-      .sort((a, b) => a.localeCompare(b));
+    const grades: string[] = uniq(
+      this._assessments.map(assessment => assessment.grade)
+    ).sort((a, b) => a.localeCompare(b));
 
     for (let grade of grades) {
-      let assessments = this._assessments.filter(x => x.grade == grade);
+      const assessments = this._assessments.filter(x => x.grade == grade);
 
       if (assessments.length > 0) {
         assessmentsByGrade.push({ grade: grade, assessments: assessments });

--- a/webapp/src/main/webapp/src/app/assessments/percentile/assessment-percentile.service.ts
+++ b/webapp/src/main/webapp/src/app/assessments/percentile/assessment-percentile.service.ts
@@ -1,21 +1,21 @@
-import { Injectable } from "@angular/core";
-import { DataService } from "../../shared/data/data.service";
-import { Observable } from "rxjs";
-import { Percentile, PercentileGroup } from "./assessment-percentile";
-import { map } from "rxjs/operators";
-import * as _ from "lodash";
-import { ReportingServiceRoute } from "../../shared/service-route";
-import { TranslateDatePipe } from "../../shared/i18n/translate-date.pipe";
+import { Injectable } from '@angular/core';
+import { DataService } from '../../shared/data/data.service';
+import { Observable } from 'rxjs';
+import { Percentile, PercentileGroup } from './assessment-percentile';
+import { map } from 'rxjs/operators';
+import { isEqual } from 'lodash';
+import { ReportingServiceRoute } from '../../shared/service-route';
+import { TranslateDatePipe } from '../../shared/i18n/translate-date.pipe';
 
 /**
  * Service responsible for retrieving assessment percentile information
  */
 @Injectable()
 export class AssessmentPercentileService {
-
-  constructor(private dataService: DataService,
-              private datePipe: TranslateDatePipe) {
-  }
+  constructor(
+    private dataService: DataService,
+    private datePipe: TranslateDatePipe
+  ) {}
 
   /**
    * Gets the percentiles for the given assessment and date range
@@ -23,11 +23,15 @@ export class AssessmentPercentileService {
    * @param {AssessmentPercentileRequest} request the request parameters
    * @returns {Observable<Percentile[]>} the percentiles selected by the request
    */
-  getPercentiles(request: AssessmentPercentileRequest): Observable<Percentile[]> {
-    return this.dataService
-      .get(`${ReportingServiceRoute}/assessment-percentiles`, {
+  getPercentiles(
+    request: AssessmentPercentileRequest
+  ): Observable<Percentile[]> {
+    return this.dataService.get(
+      `${ReportingServiceRoute}/assessment-percentiles`,
+      {
         params: this.toServerRequest(request)
-      });
+      }
+    );
   }
 
   /**
@@ -36,31 +40,39 @@ export class AssessmentPercentileService {
    * @param {AssessmentPercentileRequest} request the request parameters
    * @returns {Observable<Percentile[]>} the grouped percentiles selected by the request
    */
-  getPercentilesGroupedByRank(request: AssessmentPercentileRequest): Observable<PercentileGroup[]> {
-    return this.getPercentiles(request).pipe(map(percentiles => {
-      if (percentiles.length == 0) {
-        return [];
-      }
-      const groups: PercentileGroup[] = [];
-      for (let i = 0; i < percentiles.length; i++) {
-        const previousGroup = groups[ groups.length - 1 ];
-        const percentile = percentiles[ i ];
-        const percentileRanks = percentile.scores.map(score => score.rank);
-        if (groups.length === 0
-          || !_.isEqual(previousGroup.ranks, percentileRanks)) {
-          groups.push({
-            ranks: percentileRanks,
-            percentiles: [ percentile ]
-          })
-        } else {
-          previousGroup.percentiles.push(percentile);
+  getPercentilesGroupedByRank(
+    request: AssessmentPercentileRequest
+  ): Observable<PercentileGroup[]> {
+    return this.getPercentiles(request).pipe(
+      map(percentiles => {
+        if (percentiles.length == 0) {
+          return [];
         }
-      }
-      return groups;
-    }));
+        const groups: PercentileGroup[] = [];
+        for (let i = 0; i < percentiles.length; i++) {
+          const previousGroup = groups[groups.length - 1];
+          const percentile = percentiles[i];
+          const percentileRanks = percentile.scores.map(score => score.rank);
+          if (
+            groups.length === 0 ||
+            !isEqual(previousGroup.ranks, percentileRanks)
+          ) {
+            groups.push({
+              ranks: percentileRanks,
+              percentiles: [percentile]
+            });
+          } else {
+            previousGroup.percentiles.push(percentile);
+          }
+        }
+        return groups;
+      })
+    );
   }
 
-  private toServerRequest(request: AssessmentPercentileRequest): AssessmentPercentileServerRequest {
+  private toServerRequest(
+    request: AssessmentPercentileRequest
+  ): AssessmentPercentileServerRequest {
     return {
       assessmentId: request.assessmentId,
       startDate: this.formatAsLocalDate(request.from),
@@ -71,14 +83,12 @@ export class AssessmentPercentileService {
   private formatAsLocalDate(date: Date): string {
     return this.datePipe.transform(date, 'yyyy-MM-dd');
   }
-
 }
 
 /**
  * Client API for making an assessment percentile request
  */
 export interface AssessmentPercentileRequest {
-
   /**
    * The assessment entity ID
    */
@@ -99,7 +109,6 @@ export interface AssessmentPercentileRequest {
  * Server API for making an assessment percentile request
  */
 interface AssessmentPercentileServerRequest {
-
   /**
    * The assessment entity ID
    */
@@ -114,5 +123,4 @@ interface AssessmentPercentileServerRequest {
    * The end date of the date range in yyyy-MM-dd format
    */
   endDate: string;
-
 }

--- a/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/group-dashboard/group-dashboard.component.ts
@@ -6,13 +6,16 @@ import { GroupService } from '../../groups/group.service';
 import { GroupDashboardService } from './group-dashboard.service';
 import { ExamFilterOptionsService } from '../../assessments/filters/exam-filters/exam-filter-options.service';
 import { ExamFilterOptions } from '../../assessments/model/exam-filter-options.model';
-import { forkJoin ,  of } from 'rxjs';
-import { AssessmentCardEvent, GroupCard } from './group-assessment-card.component';
+import { forkJoin, of } from 'rxjs';
+import {
+  AssessmentCardEvent,
+  GroupCard
+} from './group-assessment-card.component';
 import { GroupReportDownloadComponent } from '../../report/group-report-download.component';
 import { byString } from '@kourge/ordering/comparator';
 import { ordering } from '@kourge/ordering';
 import { UserGroupService } from '../../user-group/user-group.service';
-import * as _ from 'lodash';
+import { chunk } from 'lodash';
 import { map, mergeMap } from 'rxjs/operators';
 import { SubjectService } from '../../subject/subject.service';
 import { SubjectDefinition } from '../../subject/subject';
@@ -22,7 +25,6 @@ import { SubjectDefinition } from '../../subject/subject';
   templateUrl: './group-dashboard.component.html'
 })
 export class GroupDashboardComponent implements OnInit {
-
   measuredAssessments: MeasuredAssessment[] = [];
   filterOptions: ExamFilterOptions = new ExamFilterOptions();
   groups: Group[];
@@ -38,14 +40,15 @@ export class GroupDashboardComponent implements OnInit {
   private _previousRouteParameters: any;
   private _subjectDefinitions: SubjectDefinition[];
 
-  constructor(private route: ActivatedRoute,
-              private router: Router,
-              private groupService: GroupService,
-              private userGroupService: UserGroupService,
-              private groupDashboardService: GroupDashboardService,
-              private filterOptionsService: ExamFilterOptionsService,
-              private subjectService: SubjectService) {
-  }
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private groupService: GroupService,
+    private userGroupService: UserGroupService,
+    private groupDashboardService: GroupDashboardService,
+    private filterOptionsService: ExamFilterOptionsService,
+    private subjectService: SubjectService
+  ) {}
 
   ngOnInit() {
     forkJoin(
@@ -53,7 +56,7 @@ export class GroupDashboardComponent implements OnInit {
       this.filterOptionsService.getExamFilterOptions(),
       this.groupService.getGroups(),
       this.userGroupService.safelyGetUserGroupsAsGroups()
-    ).subscribe(([ subjectDefinitions, filterOptions, groups, userGroups ]) => {
+    ).subscribe(([subjectDefinitions, filterOptions, groups, userGroups]) => {
       this._subjectDefinitions = subjectDefinitions;
       this.filterOptions = filterOptions;
       this.groups = groups
@@ -66,62 +69,89 @@ export class GroupDashboardComponent implements OnInit {
   }
 
   private subscribeToRouteChanges(): void {
-    this.route.params.pipe(
-      mergeMap(parameters => {
-        const { groupId, userGroupId, schoolYear, subject } = parameters;
-        const previousParameters = this._previousRouteParameters;
+    this.route.params
+      .pipe(
+        mergeMap(parameters => {
+          const { groupId, userGroupId, schoolYear, subject } = parameters;
+          const previousParameters = this._previousRouteParameters;
 
-        const reload = previousParameters == null
-          || previousParameters.schoolYear != schoolYear
-          || (previousParameters.groupId != null && previousParameters.groupId != groupId)
-          || (previousParameters.userGroupId != null && previousParameters.userGroupId != userGroupId);
+          const reload =
+            previousParameters == null ||
+            previousParameters.schoolYear != schoolYear ||
+            (previousParameters.groupId != null &&
+              previousParameters.groupId != groupId) ||
+            (previousParameters.userGroupId != null &&
+              previousParameters.userGroupId != userGroupId);
 
-        const defaultsParametersRequired = isNaN(Number(schoolYear)) || schoolYear === '';
+          const defaultsParametersRequired =
+            isNaN(Number(schoolYear)) || schoolYear === '';
 
-        this._previousRouteParameters = parameters;
+          this._previousRouteParameters = parameters;
 
-        // exit early if we don't need to re fetch the assessment data or we need to update route with default parameters
-        if (!reload || defaultsParametersRequired) {
-          return of({ ...parameters, reload, defaultsParametersRequired });
+          // exit early if we don't need to re fetch the assessment data or we need to update route with default parameters
+          if (!reload || defaultsParametersRequired) {
+            return of({ ...parameters, reload, defaultsParametersRequired });
+          }
+
+          return forkJoin(
+            groupId != null
+              ? this.groupService.getGroup(groupId)
+              : this.userGroupService.getUserGroupAsGroup(userGroupId),
+            this.groupDashboardService.getAvailableMeasuredAssessments(<any>(
+              parameters
+            ))
+          ).pipe(
+            map(
+              ([group, measuredAssessments]) =>
+                <any>{
+                  ...parameters,
+                  group,
+                  measuredAssessments,
+                  reload,
+                  defaultsParametersRequired
+                }
+            )
+          );
+        })
+      )
+      .subscribe(resolvedParameters => {
+        const {
+          defaultsParametersRequired,
+          reload,
+          group,
+          schoolYear,
+          subject,
+          measuredAssessments
+        } = resolvedParameters;
+        // exit method. Default parameters will be handled outside the method and will reload the page
+        if (defaultsParametersRequired) {
+          return;
         }
-
-        return forkJoin(
-          groupId != null
-            ? this.groupService.getGroup(groupId)
-            : this.userGroupService.getUserGroupAsGroup(userGroupId),
-          this.groupDashboardService.getAvailableMeasuredAssessments(<any>parameters)
-        ).pipe(
-          map(([ group, measuredAssessments ]) => <any>{ ...parameters, group, measuredAssessments, reload, defaultsParametersRequired })
-        );
-      })
-    ).subscribe(resolvedParameters => {
-      const { defaultsParametersRequired, reload, group, schoolYear, subject, measuredAssessments } = resolvedParameters;
-      // exit method. Default parameters will be handled outside the method and will reload the page
-      if (defaultsParametersRequired) {
-        return;
-      }
-      if (reload) {
-        this.group = group;
-        this.schoolYear = Number.parseInt(schoolYear) || undefined;
-        this.updateMeasuredAssessments(measuredAssessments);
-      }
-      if (this.subjects && this.subjects.includes(subject)) {
-        this.subject = subject;
-      } else {
-        delete this.subject;
-        this.updateRoute(true);
-      }
-      this.updateRows();
-      this.loadingMeasuredAssessments = false;
-    });
+        if (reload) {
+          this.group = group;
+          this.schoolYear = Number.parseInt(schoolYear) || undefined;
+          this.updateMeasuredAssessments(measuredAssessments);
+        }
+        if (this.subjects && this.subjects.includes(subject)) {
+          this.subject = subject;
+        } else {
+          delete this.subject;
+          this.updateRoute(true);
+        }
+        this.updateRows();
+        this.loadingMeasuredAssessments = false;
+      });
   }
 
   private updateRouteWithDefaultFilters(): void {
     const { schoolYear } = this.route.snapshot.params;
     const schoolYearNumber = Number(schoolYear);
     let update = false;
-    if (isNaN(schoolYearNumber) || this.filterOptions.schoolYears.indexOf(schoolYearNumber) < 0) {
-      this.schoolYear = this.filterOptions.schoolYears[ 0 ];
+    if (
+      isNaN(schoolYearNumber) ||
+      this.filterOptions.schoolYears.indexOf(schoolYearNumber) < 0
+    ) {
+      this.schoolYear = this.filterOptions.schoolYears[0];
       update = true;
     }
     if (update) {
@@ -142,23 +172,29 @@ export class GroupDashboardComponent implements OnInit {
   }
 
   groupEquals(a: Group, b: Group): boolean {
-    return a === b || (
-      a != null
-      && b != null
-      && a.id === b.id
-    );
+    return a === b || (a != null && b != null && a.id === b.id);
   }
 
   updateRows(): void {
     const filteredCards = this.measuredAssessments
-      .filter(measuredAssessment => this.subject == null || measuredAssessment.assessment.subject === this.subject)
-      .map(measuredAssessment => <GroupCard>{
-        group: this.group,
-        measuredAssessment: measuredAssessment,
-        performanceLevels: this._subjectDefinitions.find(definition => definition.subject === measuredAssessment.assessment.subject
-          && definition.assessmentType === measuredAssessment.assessment.type).performanceLevels
-      });
-    this.rows = _.chunk(filteredCards, this.itemsPerRow);
+      .filter(
+        measuredAssessment =>
+          this.subject == null ||
+          measuredAssessment.assessment.subject === this.subject
+      )
+      .map(
+        measuredAssessment =>
+          <GroupCard>{
+            group: this.group,
+            measuredAssessment: measuredAssessment,
+            performanceLevels: this._subjectDefinitions.find(
+              definition =>
+                definition.subject === measuredAssessment.assessment.subject &&
+                definition.assessmentType === measuredAssessment.assessment.type
+            ).performanceLevels
+          }
+      );
+    this.rows = chunk(filteredCards, this.itemsPerRow);
   }
 
   get viewAssessmentsButtonEnabled(): boolean {
@@ -190,33 +226,40 @@ export class GroupDashboardComponent implements OnInit {
   updateRoute(replaceUrl: boolean = false): void {
     this.loadingMeasuredAssessments = true;
     this.selectedAssessments = [];
-    this.router.navigate([ this.stateAsNavigationParameters ], { replaceUrl });
+    this.router.navigate([this.stateAsNavigationParameters], { replaceUrl });
   }
 
   updateMeasuredAssessments(assessments: MeasuredAssessment[]): void {
-    this.measuredAssessments = assessments
-      .sort(ordering(byString).on<MeasuredAssessment>(x => x.assessment.label).compare);
+    this.measuredAssessments = assessments.sort(
+      ordering(byString).on<MeasuredAssessment>(x => x.assessment.label).compare
+    );
 
-    const assessmentSubjects = new Set(assessments.map(x => x.assessment.subject));
-    this.subjects = this.filterOptions.subjects
-      .filter(subject => assessmentSubjects.has(subject));
-
+    const assessmentSubjects = new Set(
+      assessments.map(x => x.assessment.subject)
+    );
+    this.subjects = this.filterOptions.subjects.filter(subject =>
+      assessmentSubjects.has(subject)
+    );
   }
 
   viewAssessments(): void {
     const parameters: any = {
       ...this.stateAsNavigationParameters,
-      assessmentIds: this.selectedAssessments
-        .map(measuredAssessment => measuredAssessment.assessment.id)
+      assessmentIds: this.selectedAssessments.map(
+        measuredAssessment => measuredAssessment.assessment.id
+      )
     };
-    this.router.navigate([ 'group-exams', parameters ]);
+    this.router.navigate(['group-exams', parameters]);
   }
 
   onCardSelection(event: AssessmentCardEvent) {
     this.selectedAssessments = event.selected
       ? this.selectedAssessments.concat(event.measuredAssessment)
-      : this.selectedAssessments
-        .filter(measuredAssessment => measuredAssessment.assessment.id !== event.measuredAssessment.assessment.id);
+      : this.selectedAssessments.filter(
+          measuredAssessment =>
+            measuredAssessment.assessment.id !==
+            event.measuredAssessment.assessment.id
+        );
   }
 
   /**
@@ -227,5 +270,4 @@ export class GroupDashboardComponent implements OnInit {
   initializeDownloader(downloader: GroupReportDownloadComponent): void {
     downloader.options.schoolYear = this.schoolYear;
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/datatable/datatable-service.ts
+++ b/webapp/src/main/webapp/src/app/shared/datatable/datatable-service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AggregateReportItem } from '../../aggregate-report/results/aggregate-report-item';
 import { Table } from 'primeng/table';
-import * as _ from 'lodash';
+import { get } from 'lodash';
 import { BaseColumn } from './base-column.model';
 
 @Injectable()
@@ -10,13 +10,25 @@ export class DataTableService {
    * Calculate the index for each row at which it differs from the data in the previous row.
    * This is used to display a tree-like structure which hides repetitive data in the left-most columns.
    */
-  calculateTreeColumns(rows: any[], dataTable: Table, allColumns: BaseColumn[], identityColumns: string[]): number[] {
+  calculateTreeColumns(
+    rows: any[],
+    dataTable: Table,
+    allColumns: BaseColumn[],
+    identityColumns: string[]
+  ): number[] {
     const treeColumns = [];
     const pageSize: number = dataTable.rows;
     let previousItem: AggregateReportItem;
     rows.forEach((currentItem: AggregateReportItem, index: number) => {
-      treeColumns.push(!previousItem || (index % pageSize == 0)
-        ? 0 : this.indexOfFirstUniqueColumnValue(allColumns, identityColumns, previousItem, currentItem)
+      treeColumns.push(
+        !previousItem || index % pageSize == 0
+          ? 0
+          : this.indexOfFirstUniqueColumnValue(
+              allColumns,
+              identityColumns,
+              previousItem,
+              currentItem
+            )
       );
       previousItem = currentItem;
     });
@@ -32,10 +44,15 @@ export class DataTableService {
    * @param currentItem   The current row
    * @returns {number}  The differentiating column of the currentItem
    */
-  private indexOfFirstUniqueColumnValue(allColumns: BaseColumn[], identityColumns: string[], previousItem: any, currentItem: any): number {
+  private indexOfFirstUniqueColumnValue(
+    allColumns: BaseColumn[],
+    identityColumns: string[],
+    previousItem: any,
+    currentItem: any
+  ): number {
     let index: number;
     for (index = 0; index < identityColumns.length - 1; index++) {
-      const column: BaseColumn = allColumns[ index ];
+      const column: BaseColumn = allColumns[index];
       if (column.id === 'organization') {
         const previousOrg = previousItem.organization;
         const currentOrg = currentItem.organization;
@@ -43,8 +60,8 @@ export class DataTableService {
           break;
         }
       } else {
-        const previousValue = _.get(previousItem, column.field); // TODO would be nice if this was based on "sortField" as opposed to field
-        const currentValue = _.get(currentItem, column.field);
+        const previousValue = get(previousItem, column.field); // TODO would be nice if this was based on "sortField" as opposed to field
+        const currentValue = get(currentItem, column.field);
         if (previousValue !== currentValue) {
           break;
         }

--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-group.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Forms } from './forms';
 import { AbstractControlValueAccessor } from './abstract-control-value-accessor';
-import * as _ from 'lodash';
+import { isEqual } from 'lodash';
 import { Utils } from '../support/support';
 import { Option } from './option';
 
@@ -20,7 +20,6 @@ const DefaultButtonStyles = 'btn-primary';
  * Holds the internal button selection state
  */
 interface State {
-
   /**
    * True when the all option is selected
    */
@@ -71,7 +70,6 @@ class Radio implements InputController {
  * Makes the button group behave as a range selector
  */
 class Range implements InputController {
-
   onButtonClick(context: SBButtonGroup, state: State, option: Option): void {
     const { selectedOptions } = state;
     if (selectedOptions.has(option)) {
@@ -101,7 +99,7 @@ class Range implements InputController {
     });
     if (firstIndex != null && lastIndex != null && firstIndex !== lastIndex) {
       for (let i = firstIndex + 1; i < lastIndex; i++) {
-        selectedOptions.add(options[ i ]);
+        selectedOptions.add(options[i]);
       }
     }
   }
@@ -114,10 +112,18 @@ class Range implements InputController {
    * @param {Option[]} options
    * @param {Option} option
    */
-  private unfill(selectedOptions: Set<Option>, options: Option[], option: Option): void {
+  private unfill(
+    selectedOptions: Set<Option>,
+    options: Option[],
+    option: Option
+  ): void {
     const index = options.indexOf(option);
-    const leftOptionSelected = options.slice(0, index).find(option => selectedOptions.has(option));
-    const rightOptionSelected = options.slice(index + 1).find(option => selectedOptions.has(option));
+    const leftOptionSelected = options
+      .slice(0, index)
+      .find(option => selectedOptions.has(option));
+    const rightOptionSelected = options
+      .slice(index + 1)
+      .find(option => selectedOptions.has(option));
     if (leftOptionSelected != null && rightOptionSelected != null) {
       selectedOptions.clear();
       selectedOptions.add(option);
@@ -125,7 +131,7 @@ class Range implements InputController {
   }
 }
 
-const ControllerByInputType: { [ inputType: string ]: InputController } = {
+const ControllerByInputType: { [inputType: string]: InputController } = {
   checkbox: new Checkbox(),
   radio: new Radio(),
   range: new Range()
@@ -138,56 +144,81 @@ const ControllerByInputType: { [ inputType: string ]: InputController } = {
   selector: 'sb-button-group',
   template: `
     <ng-template #button let-option let-isAllOption="isAllOption">
-      <label class="btn"
-             [ngClass]="computeStylesInternal(buttonStyles, { 
-                 active: isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option), 
-                 disabled: option.disabled 
-             })">
-        <input type="checkbox"
-               [attr.checked]="isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option)"
-               [name]="name"
-               [disabled]="option.disabled"
-               (click)="isAllOption ? onAllOptionClickInternal() : onOptionClickInternal(option)"
-               angulartics2On="click"
-               angularticsAction="{{analyticsEvent}}"
-               angularticsCategory="{{analyticsCategory}}"
-               [angularticsProperties]="isAllOption ? allOptionAnalyticsProperties : option.analyticsProperties">
-        {{option.text}}
+      <label
+        class="btn"
+        [ngClass]="
+          computeStylesInternal(buttonStyles, {
+            active: isAllOption
+              ? stateInternal.selectedAllOption
+              : stateInternal.selectedOptions.has(option),
+            disabled: option.disabled
+          })
+        "
+      >
+        <input
+          type="checkbox"
+          [attr.checked]="
+            isAllOption
+              ? stateInternal.selectedAllOption
+              : stateInternal.selectedOptions.has(option)
+          "
+          [name]="name"
+          [disabled]="option.disabled"
+          (click)="
+            isAllOption
+              ? onAllOptionClickInternal()
+              : onOptionClickInternal(option)
+          "
+          angulartics2On="click"
+          angularticsAction="{{ analyticsEvent }}"
+          angularticsCategory="{{ analyticsCategory }}"
+          [angularticsProperties]="
+            isAllOption
+              ? allOptionAnalyticsProperties
+              : option.analyticsProperties
+          "
+        />
+        {{ option.text }}
       </label>
     </ng-template>
 
-    <div *ngIf="initializedInternal"
-         data-toggle="buttons"
-         class="toggle-group"
-         [ngClass]="computeStylesInternal(buttonGroupStyles, {
-           'vertical': vertical,
-           'all-option': allOptionEnabled,
-           'nested-btn-group': allOptionEnabled || vertical
-         })">
-
+    <div
+      *ngIf="initializedInternal"
+      data-toggle="buttons"
+      class="toggle-group"
+      [ngClass]="
+        computeStylesInternal(buttonGroupStyles, {
+          vertical: vertical,
+          'all-option': allOptionEnabled,
+          'nested-btn-group': allOptionEnabled || vertical
+        })
+      "
+    >
       <ng-container *ngIf="allOptionEnabled">
-        <ng-container *ngTemplateOutlet="button; context:{
-          $implicit: { text: ('common.buttons.all' | translate) },
-          isAllOption: true
-        }"></ng-container>
+        <ng-container
+          *ngTemplateOutlet="
+            button;
+            context: {
+              $implicit: { text: 'common.buttons.all' | translate },
+              isAllOption: true
+            }
+          "
+        ></ng-container>
       </ng-container>
 
-      <div class="btn-group"
-           [ngClass]="buttonGroupStyles">
-
+      <div class="btn-group" [ngClass]="buttonGroupStyles">
         <ng-container *ngFor="let option of options">
-          <ng-container *ngTemplateOutlet="button; context:{$implicit:option}"></ng-container>
+          <ng-container
+            *ngTemplateOutlet="button; context: { $implicit: option }"
+          ></ng-container>
         </ng-container>
-
       </div>
     </div>
   `,
-  providers: [
-    Forms.valueAccessor(SBButtonGroup)
-  ]
+  providers: [Forms.valueAccessor(SBButtonGroup)]
 })
-export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implements OnInit {
-
+export class SBButtonGroup extends AbstractControlValueAccessor<any[]>
+  implements OnInit {
   @Input()
   public vertical: boolean = false;
 
@@ -235,7 +266,7 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
 
   @Input()
   set type(value: InputType) {
-    const controller = ControllerByInputType[ value ];
+    const controller = ControllerByInputType[value];
     if (controller == null) {
       this.throwError(`Unknown input type: "${value}"`);
     }
@@ -263,7 +294,10 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
         }
 
         //Optionally allow no selection
-        if (!this.effectiveNoneStateEnabled && (!updatedValues || updatedValues.length === 0)) {
+        if (
+          !this.effectiveNoneStateEnabled &&
+          (!updatedValues || updatedValues.length === 0)
+        ) {
           updatedValues = this.parseInputValues(this._initialValues);
         }
 
@@ -336,7 +370,6 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
    * All button click handler
    */
   onAllOptionClickInternal(): void {
-
     const state = this._state,
       options = this._options;
 
@@ -365,7 +398,6 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
    * @param {Option} option
    */
   onOptionClickInternal(option: Option): void {
-
     const state = this._state,
       options = this._options;
 
@@ -396,11 +428,16 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
    * @param {Option[]} options
    */
   private updateValue(state, options: Option[]): void {
-    const values = state.selectedAllOption && this._allOptionReturnsUndefined
-      ? undefined
-      : options
-        .filter(option => !option.disabled && (state.selectedAllOption || state.selectedOptions.has(option)))
-        .map(option => option.value);
+    const values =
+      state.selectedAllOption && this._allOptionReturnsUndefined
+        ? undefined
+        : options
+            .filter(
+              option =>
+                !option.disabled &&
+                (state.selectedAllOption || state.selectedOptions.has(option))
+            )
+            .map(option => option.value);
 
     this.setValueAndNotifyChanges(values);
   }
@@ -419,12 +456,15 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
     if (options.length < 2) {
       this.throwError('at least two options are required');
     }
-    return options.map(option => <Option>{
-      value: option.value,
-      text: option.text ? option.text : option.value,
-      analyticsProperties: option.analyticsProperties,
-      disabled: option.disabled
-    });
+    return options.map(
+      option =>
+        <Option>{
+          value: option.value,
+          text: option.text ? option.text : option.value,
+          analyticsProperties: option.analyticsProperties,
+          disabled: option.disabled
+        }
+    );
   }
 
   /**
@@ -460,8 +500,12 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
   private computeState(options: Option[], values: any[]): State {
     if (this.allOptionEnabled) {
       let enabledOptions = options.filter(x => !x.disabled);
-      const effectiveOptions = enabledOptions.filter(option => values.includes(option.value));
-      const effectivelySelectedAllOption = values.length === enabledOptions.length || enabledOptions.length === effectiveOptions.length;
+      const effectiveOptions = enabledOptions.filter(option =>
+        values.includes(option.value)
+      );
+      const effectivelySelectedAllOption =
+        values.length === enabledOptions.length ||
+        enabledOptions.length === effectiveOptions.length;
       return {
         selectedAllOption: effectivelySelectedAllOption,
         selectedOptions: effectivelySelectedAllOption
@@ -471,12 +515,14 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
     }
     return {
       selectedAllOption: false,
-      selectedOptions: new Set(options.filter(option => values.includes(option.value)))
+      selectedOptions: new Set(
+        options.filter(option => values.includes(option.value))
+      )
     };
   }
 
   private setValueAndNotifyChanges(value: any) {
-    if (!_.isEqual(this._value, value)) {
+    if (!isEqual(this._value, value)) {
       this._value = value;
       this._onChangeCallback(value);
     }
@@ -485,5 +531,4 @@ export class SBButtonGroup extends AbstractControlValueAccessor<any[]> implement
   private throwError(message: string): void {
     throw new Error(`${this.constructor.name} ${message}`);
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-typeahead-group.ts
@@ -1,10 +1,17 @@
-import { Component, EventEmitter, Input, Output, OnInit, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import { Forms } from './forms';
 import { AbstractControlValueAccessor } from './abstract-control-value-accessor';
-import * as _ from 'lodash';
+import { isEqual } from 'lodash';
 import { Utils } from '../support/support';
 import { Option } from './option';
-import {AutoComplete} from "primeng/primeng";
+import { AutoComplete } from 'primeng/primeng';
 
 /**
  * Holds the internal button selection state
@@ -34,66 +41,86 @@ const DefaultButtonStyles = 'btn-primary';
   selector: 'sb-typeahead-group',
   template: `
     <ng-template #button let-option let-isAllOption="isAllOption">
-      <label class="btn"
-             [ngClass]="computeStylesInternal(buttonStyles, { 
-                 active: isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option), 
-                 disabled: option.disabled 
-             })"> 
-        <input type="checkbox"
-               [attr.checked]="isAllOption ? stateInternal.selectedAllOption : stateInternal.selectedOptions.has(option)"
-               [name]="name"
-               [disabled]="option.disabled"
-               (click)="onAllOptionClickInternal()">
-        {{option.text}}
+      <label
+        class="btn"
+        [ngClass]="
+          computeStylesInternal(buttonStyles, {
+            active: isAllOption
+              ? stateInternal.selectedAllOption
+              : stateInternal.selectedOptions.has(option),
+            disabled: option.disabled
+          })
+        "
+      >
+        <input
+          type="checkbox"
+          [attr.checked]="
+            isAllOption
+              ? stateInternal.selectedAllOption
+              : stateInternal.selectedOptions.has(option)
+          "
+          [name]="name"
+          [disabled]="option.disabled"
+          (click)="onAllOptionClickInternal()"
+        />
+        {{ option.text }}
       </label>
     </ng-template>
 
-    <div *ngIf="initializedInternal"
-         data-toggle="buttons"
-         class="typeahead-group all-option btn-group-sm vertical nested-btn-group">
+    <div
+      *ngIf="initializedInternal"
+      data-toggle="buttons"
+      class="typeahead-group all-option btn-group-sm vertical nested-btn-group"
+    >
+      <ng-container
+        *ngTemplateOutlet="
+          button;
+          context: {
+            $implicit: { text: 'common.buttons.all' | translate },
+            isAllOption: true
+          }
+        "
+      ></ng-container>
 
-      <ng-container *ngTemplateOutlet="button; context:{
-        $implicit: { text: ('common.buttons.all' | translate) },
-        isAllOption: true
-      }"></ng-container>
-
-      <div class="btn-group chips"
-           [ngClass]="buttonGroupStyles">
-
-        <p-autoComplete #autoComplete
-                        [(ngModel)]="options"
-                        [autoHighlight]="true"
-                        [suggestions]="filteredOptions"
-                        [multiple]="true"
-                        dataKey="value"
-                        (completeMethod)="search($event)"
-                        (onSelect)="optionSelected($event)"
-                        (keydown)="onKeydown($event)"
-                        styleClass="wid100"
-                        [minLength]="0" 
-                        [dropdown]="true"
-                        [placeholder]="placeholder"
-                        [scrollHeight]="'158px'"
-                        field="text" >
-        </p-autoComplete> 
+      <div class="btn-group chips" [ngClass]="buttonGroupStyles">
+        <p-autoComplete
+          #autoComplete
+          [(ngModel)]="options"
+          [autoHighlight]="true"
+          [suggestions]="filteredOptions"
+          [multiple]="true"
+          dataKey="value"
+          (completeMethod)="search($event)"
+          (onSelect)="optionSelected($event)"
+          (keydown)="onKeydown($event)"
+          styleClass="wid100"
+          [minLength]="0"
+          [dropdown]="true"
+          [placeholder]="placeholder"
+          [scrollHeight]="'158px'"
+          field="text"
+        >
+        </p-autoComplete>
         <div class="languages-container btn-group-sm">
           <ng-container *ngFor="let option of options">
-            <label class="btn btn-primary active">{{option.text}}
-              <i class="fa fa-times fa-lg pull-right"
-                 tabindex="0"
-                 (click)="removeOption(option)"
-                 (keyup.enter)="removeOption(option)"></i>
+            <label class="btn btn-primary active"
+              >{{ option.text }}
+              <i
+                class="fa fa-times fa-lg pull-right"
+                tabindex="0"
+                (click)="removeOption(option)"
+                (keyup.enter)="removeOption(option)"
+              ></i>
             </label>
           </ng-container>
         </div>
       </div>
     </div>
   `,
-  providers: [
-    Forms.valueAccessor(SBTypeaheadGroup)
-  ]
+  providers: [Forms.valueAccessor(SBTypeaheadGroup)]
 })
-export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implements OnInit {
+export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]>
+  implements OnInit {
   private _options: Option[];
   private _initialOptions: Option[] = [];
   private _initialValues: any[];
@@ -124,14 +151,17 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
   public property: string;
 
   @Output()
-  optionsEvent = new EventEmitter <Option[]>();
+  optionsEvent = new EventEmitter<Option[]>();
 
   constructor() {
     super();
   }
 
   ngOnInit(): void {
-    this._initialOptions = (this.initialOptions != null && this.initialOptions.length > 0) ? this.initialOptions : [];
+    this._initialOptions =
+      this.initialOptions != null && this.initialOptions.length > 0
+        ? this.initialOptions
+        : [];
     this._options = this.parseInputOptions(this._initialOptions);
     this._value = this.parseInputValues(this._initialValues);
     this._state = this.computeState(this._options, this._value);
@@ -168,7 +198,7 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
   }
 
   onKeydown($event) {
-    if ($event.key === "ArrowDown" && !this.autoComplete.overlayVisible) {
+    if ($event.key === 'ArrowDown' && !this.autoComplete.overlayVisible) {
       this.autoComplete.handleDropdownClick(0);
     }
   }
@@ -220,9 +250,10 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
   search(event) {
     let query = event.query;
     this.filteredOptions = this.suggestions.filter(
-      option => option.text.toUpperCase().indexOf(query.toUpperCase()) > -1
-        && !this._options.find(o => o.value === option.value)
-    )
+      option =>
+        option.text.toUpperCase().indexOf(query.toUpperCase()) > -1 &&
+        !this._options.find(o => o.value === option.value)
+    );
   }
 
   private optionSelected(event) {
@@ -251,7 +282,7 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
    */
   private parseInputValues(values: any): any[] {
     if (values == null) {
-        return [];
+      return [];
     }
     // Make a copy of the value to avoid side effects
     return values.concat();
@@ -269,12 +300,15 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
       this.throwError('options must not be null or undefined');
     }
 
-    return options.map(option => <Option>{
-      value: option.value,
-      text: option.text ? option.text : option.value,
-      analyticsProperties: option.analyticsProperties,
-      disabled: option.disabled
-    });
+    return options.map(
+      option =>
+        <Option>{
+          value: option.value,
+          text: option.text ? option.text : option.value,
+          analyticsProperties: option.analyticsProperties,
+          disabled: option.disabled
+        }
+    );
   }
 
   /**
@@ -287,8 +321,12 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
     const values = state.selectedAllOption
       ? undefined
       : options
-        .filter(option => !option.disabled && (state.selectedAllOption || state.selectedOptions.has(option)))
-        .map(option => option.value);
+          .filter(
+            option =>
+              !option.disabled &&
+              (state.selectedAllOption || state.selectedOptions.has(option))
+          )
+          .map(option => option.value);
 
     this.setValueAndNotifyChanges(values);
   }
@@ -303,8 +341,12 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
    */
   private computeState(options: Option[], values: any[]): State {
     let enabledOptions = options.filter(x => !x.disabled);
-    const effectiveOptions = enabledOptions.filter(option => values.includes(option.value));
-    const effectivelySelectedAllOption = this.suggestions.length === enabledOptions.length || (enabledOptions.length == 0);
+    const effectiveOptions = enabledOptions.filter(option =>
+      values.includes(option.value)
+    );
+    const effectivelySelectedAllOption =
+      this.suggestions.length === enabledOptions.length ||
+      enabledOptions.length == 0;
     return {
       selectedAllOption: effectivelySelectedAllOption,
       selectedOptions: effectivelySelectedAllOption
@@ -332,7 +374,7 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
   }
 
   private setValueAndNotifyChanges(value: any) {
-    if (!_.isEqual(this._value, value)) {
+    if (!isEqual(this._value, value)) {
       this._value = value;
       this._onChangeCallback(value);
     }
@@ -341,5 +383,4 @@ export class SBTypeaheadGroup extends AbstractControlValueAccessor<any[]> implem
   private throwError(message: string): void {
     throw new Error(`${this.constructor.name} ${message}`);
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/i18n/rdw-translate-loader.ts
+++ b/webapp/src/main/webapp/src/app/shared/i18n/rdw-translate-loader.ts
@@ -1,27 +1,33 @@
-import { TranslateHttpLoader } from "@ngx-translate/http-loader";
-import * as _ from "lodash";
-import { Injectable } from "@angular/core";
-import { TranslateLoader } from "@ngx-translate/core";
-import { Observable ,  forkJoin ,  of } from "rxjs";
-import { EmbeddedLanguages } from "./language-settings";
-import { HttpClient } from "@angular/common/http";
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { merge, set, get } from 'lodash';
+import { Injectable } from '@angular/core';
+import { TranslateLoader } from '@ngx-translate/core';
+import { Observable, forkJoin, of } from 'rxjs';
+import { EmbeddedLanguages } from './language-settings';
+import { HttpClient } from '@angular/common/http';
 import { catchError, map } from 'rxjs/operators';
-import { SubjectService } from "../../subject/subject.service";
-import { Utils } from "../support/support";
+import { SubjectService } from '../../subject/subject.service';
+import { Utils } from '../support/support';
 
 const EmptyObservable = of({});
-const AssessmentTypes: string[] = ["iab", "ica", "sum"];
+const AssessmentTypes: string[] = ['iab', 'ica', 'sum'];
 
 @Injectable()
 export class RdwTranslateLoader implements TranslateLoader {
-
   private clientTranslationsLoader;
   private serverTranslationsLoader;
 
-  constructor(http: HttpClient,
-              private subjectService: SubjectService) {
-    this.clientTranslationsLoader = new TranslateHttpLoader(http, '/assets/i18n/', '.json');
-    this.serverTranslationsLoader = new TranslateHttpLoader(http, '/api/translations/', '');
+  constructor(http: HttpClient, private subjectService: SubjectService) {
+    this.clientTranslationsLoader = new TranslateHttpLoader(
+      http,
+      '/assets/i18n/',
+      '.json'
+    );
+    this.serverTranslationsLoader = new TranslateHttpLoader(
+      http,
+      '/api/translations/',
+      ''
+    );
   }
 
   getTranslation(languageCode: string): Observable<any> {
@@ -30,12 +36,15 @@ export class RdwTranslateLoader implements TranslateLoader {
       this.getServerTranslations(languageCode),
       this.subjectService.getSubjectCodes()
     ).pipe(
-      map(([ clientTranslations, serverTranslations, subjects ]) => {
-        const asmtTranslations = this.createSubjectTranslations(subjects, serverTranslations);
-        return _.merge(clientTranslations, asmtTranslations, serverTranslations);
+      map(([clientTranslations, serverTranslations, subjects]) => {
+        const asmtTranslations = this.createSubjectTranslations(
+          subjects,
+          serverTranslations
+        );
+        return merge(clientTranslations, asmtTranslations, serverTranslations);
       })
     );
-  };
+  }
 
   private getClientTranslations(languageCode: string): Observable<any> {
     return EmbeddedLanguages.indexOf(languageCode) != -1
@@ -44,10 +53,9 @@ export class RdwTranslateLoader implements TranslateLoader {
   }
 
   private getServerTranslations(languageCode: string): Observable<any> {
-    return this.serverTranslationsLoader.getTranslation(languageCode)
-      .pipe(
-        catchError(() => EmptyObservable)
-      );
+    return this.serverTranslationsLoader
+      .getTranslation(languageCode)
+      .pipe(catchError(() => EmptyObservable));
   }
 
   /**
@@ -60,21 +68,31 @@ export class RdwTranslateLoader implements TranslateLoader {
    * @param serverTranslations  The backend-provided translations
    * @returns {any} A translation payload containing combined assessment type labels
    */
-  private createSubjectTranslations(subjects: string[], serverTranslations: any): any {
+  private createSubjectTranslations(
+    subjects: string[],
+    serverTranslations: any
+  ): any {
     const subjectTranslations: any = {};
     for (let assessmentType of AssessmentTypes) {
       const labels: string[] = [];
       for (let subject of subjects) {
-        const label = _.get(serverTranslations, `subject.${subject}.asmt-type.${assessmentType}.name`);
-        if (Utils.isNullOrUndefined(label) || labels.indexOf(label) >= 0) continue;
+        const label = get(
+          serverTranslations,
+          `subject.${subject}.asmt-type.${assessmentType}.name`
+        );
+        if (Utils.isNullOrUndefined(label) || labels.indexOf(label) >= 0)
+          continue;
 
         labels.push(label);
       }
 
-      _.set(subjectTranslations, `common.assessment-type.${assessmentType}.short-name`, labels.join("/"));
+      set(
+        subjectTranslations,
+        `common.assessment-type.${assessmentType}.short-name`,
+        labels.join('/')
+      );
     }
 
     return subjectTranslations;
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/layout/sb-breadcrumbs.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/layout/sb-breadcrumbs.component.ts
@@ -1,7 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ActivatedRoute, NavigationEnd, PRIMARY_OUTLET, Router } from '@angular/router';
-import * as _ from 'lodash';
+import {
+  ActivatedRoute,
+  NavigationEnd,
+  PRIMARY_OUTLET,
+  Router
+} from '@angular/router';
+import { isEqual } from 'lodash';
 import { TranslateService } from '@ngx-translate/core';
 import { Utils } from '../support/support';
 import { filter } from 'rxjs/operators';
@@ -28,7 +33,6 @@ export interface BreadcrumbOptions {
  * Represents a breadcrumb in the navigation path
  */
 export interface Breadcrumb {
-
   /**
    * Display name of the path segment
    */
@@ -51,12 +55,22 @@ export interface Breadcrumb {
         <ul class="breadcrumb">
           <li>
             <a routerLink="/">
-              <i class="fa fa-home"></i> <span class="sr-only">{{ 'common-ngx.breadcrumbs.home-sr' | translate }}</span>
+              <i class="fa fa-home"></i>
+              <span class="sr-only">{{
+                'common-ngx.breadcrumbs.home-sr' | translate
+              }}</span>
             </a>
           </li>
-          <li *ngFor="let crumb of breadcrumbs; let last = last;" [ngClass]="{'active': last }">
-            <a *ngIf="!last" [routerLink]="crumb.routerLinkParameters">{{ crumb.text }}</a>
-            <span *ngIf="last" [routerLink]="crumb.routerLinkParameters">{{ crumb.text }}</span>
+          <li
+            *ngFor="let crumb of breadcrumbs; let last = last"
+            [ngClass]="{ active: last }"
+          >
+            <a *ngIf="!last" [routerLink]="crumb.routerLinkParameters">{{
+              crumb.text
+            }}</a>
+            <span *ngIf="last" [routerLink]="crumb.routerLinkParameters">{{
+              crumb.text
+            }}</span>
           </li>
         </ul>
       </div>
@@ -64,24 +78,24 @@ export interface Breadcrumb {
   `
 })
 export class SbBreadcrumbs implements OnInit {
-
   private _breadcrumbs: Breadcrumb[] = [];
 
-  constructor(private router: Router,
-              private activatedRoute: ActivatedRoute,
-              private title: Title,
-              private translateService: TranslateService) {
-  }
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private title: Title,
+    private translateService: TranslateService
+  ) {}
 
   ngOnInit(): void {
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe(() => {
-      this.breadcrumbs = this.createBreadcrumbs(this.activatedRoute.root);
-    });
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.breadcrumbs = this.createBreadcrumbs(this.activatedRoute.root);
+      });
     this.translateService.onLangChange.subscribe(() => {
       this.breadcrumbs = this.createBreadcrumbs(this.activatedRoute.root);
-    })
+    });
   }
 
   get breadcrumbs(): Breadcrumb[] {
@@ -95,8 +109,11 @@ export class SbBreadcrumbs implements OnInit {
     }
   }
 
-  private createBreadcrumbs(route: ActivatedRoute, routerLinkParameters: any[] = [], breadcrumbs: Breadcrumb[] = []): Breadcrumb[] {
-
+  private createBreadcrumbs(
+    route: ActivatedRoute,
+    routerLinkParameters: any[] = [],
+    breadcrumbs: Breadcrumb[] = []
+  ): Breadcrumb[] {
     const children: ActivatedRoute[] = route.children;
     if (children.length === 0) {
       return breadcrumbs;
@@ -113,15 +130,22 @@ export class SbBreadcrumbs implements OnInit {
         return this.createBreadcrumbs(child, routerLinkParameters, breadcrumbs);
       }
 
-      const breadcrumbOptions: BreadcrumbOptions = route.data[ BreadCrumbsRouteDataKey ];
+      const breadcrumbOptions: BreadcrumbOptions =
+        route.data[BreadCrumbsRouteDataKey];
 
       route.url.forEach(segment => {
         routerLinkParameters.push(segment.path);
         routerLinkParameters.push(segment.parameters);
       });
 
-      const breadcrumb = this.createBreadcrumb(breadcrumbOptions, route.data, routerLinkParameters.concat());
-      const existing = breadcrumbs.find(existing => _.isEqual(existing.routerLinkParameters, breadcrumb.routerLinkParameters));
+      const breadcrumb = this.createBreadcrumb(
+        breadcrumbOptions,
+        route.data,
+        routerLinkParameters.concat()
+      );
+      const existing = breadcrumbs.find(existing =>
+        isEqual(existing.routerLinkParameters, breadcrumb.routerLinkParameters)
+      );
 
       if (existing) {
         existing.text = breadcrumb.text;
@@ -133,13 +157,20 @@ export class SbBreadcrumbs implements OnInit {
     }
   }
 
-  private createBreadcrumb(options: BreadcrumbOptions, routeData: any, routerLinkParameters: any[]): Breadcrumb {
+  private createBreadcrumb(
+    options: BreadcrumbOptions,
+    routeData: any,
+    routerLinkParameters: any[]
+  ): Breadcrumb {
     if (options.translate) {
       let text: string;
       if (options.translateResolve) {
         if (options.transform) {
-          text = this.translateService.instant(options.translate,
-            { value: options.transform(Utils.getPropertyValue(options.translateResolve, routeData)) });
+          text = this.translateService.instant(options.translate, {
+            value: options.transform(
+              Utils.getPropertyValue(options.translateResolve, routeData)
+            )
+          });
         } else {
           text = Utils.getPropertyValue(options.translateResolve, routeData);
         }
@@ -150,15 +181,17 @@ export class SbBreadcrumbs implements OnInit {
       return {
         text: text,
         routerLinkParameters: routerLinkParameters
-      }
+      };
     }
     if (options.resolve) {
       return {
         text: Utils.getPropertyValue(options.resolve, routeData),
         routerLinkParameters: routerLinkParameters
-      }
+      };
     }
-    throw new Error('Invalid route breadcrumb options. You must provide a "translate" or "resolve" property.');
+    throw new Error(
+      'Invalid route breadcrumb options. You must provide a "translate" or "resolve" property.'
+    );
   }
 
   private createTitle(breadcrumbs: any[]): string {
@@ -166,8 +199,9 @@ export class SbBreadcrumbs implements OnInit {
       .concat()
       .reverse()
       .map(breadcrumb => breadcrumb.text)
-      .concat(this.translateService.instant('common-ngx.breadcrumbs.window-title'))
+      .concat(
+        this.translateService.instant('common-ngx.breadcrumbs.window-title')
+      )
       .join(BreadCrumbsTitleDelimiter);
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/notification/notification.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/notification/notification.component.ts
@@ -1,7 +1,7 @@
-import { Component } from "@angular/core";
-import { NotificationService } from "./notification.service";
-import { Notification } from "./notification.model";
-import * as _ from "lodash";
+import { Component } from '@angular/core';
+import { NotificationService } from './notification.service';
+import { Notification } from './notification.model';
+import { remove, isEqual } from 'lodash';
 
 /**
  * This component is responsible for displaying user notifications.
@@ -11,11 +11,12 @@ import * as _ from "lodash";
   templateUrl: 'notification.component.html'
 })
 export class NotificationComponent {
-
   public notifications: Notification[] = [];
 
   constructor(private notificationService: NotificationService) {
-    notificationService.onNotification.subscribe(this.onNotification.bind(this));
+    notificationService.onNotification.subscribe(
+      this.onNotification.bind(this)
+    );
   }
 
   /**
@@ -23,11 +24,11 @@ export class NotificationComponent {
    *
    * @param notification The dismissed notification
    */
-  public onDismissed(notification) {
-    let idx: number = this.notifications.indexOf(notification);
-    if (idx < 0) return;
-
-    this.notifications.splice(idx, 1);
+  public onDismissed(notification: Notification): void {
+    const index: number = this.notifications.indexOf(notification);
+    if (index !== -1) {
+      this.notifications.splice(index, 1);
+    }
   }
 
   /**
@@ -35,11 +36,10 @@ export class NotificationComponent {
    *
    * @param notification A notification
    */
-  private onNotification(notification) {
+  private onNotification(notification: Notification): void {
     // if the same message is being generated again then remove it so a new one can be added and the dismiss time extended
-    _.remove(this.notifications, x => _.isEqual(x, notification));
+    remove(this.notifications, x => isEqual(x, notification));
 
     this.notifications.push(notification);
   }
-
 }

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import { isEqual, isEmpty } from 'lodash';
 
 /**
  * Expands support from string and Array to type Object as well
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
  * @param value The value to test
  */
 export function isNullOrEmpty(value: any): boolean {
-  return value == null || _.isEmpty(value);
+  return value == null || isEmpty(value);
 }
 
 export function isEqualSet(a: any[], b: any[]): boolean {
@@ -16,7 +16,7 @@ export function isEqualSet(a: any[], b: any[]): boolean {
     (a != null &&
       b != null &&
       a.length === b.length &&
-      _.isEqual(a.slice().sort(), b.slice().sort()))
+      isEqual(a.slice().sort(), b.slice().sort()))
   );
 }
 
@@ -27,7 +27,7 @@ export class Utils {
       (a != null &&
         b != null &&
         a.length === b.length &&
-        _.isEqual(a.concat().sort(), b.concat().sort()))
+        isEqual(a.concat().sort(), b.concat().sort()))
     );
   }
 

--- a/webapp/src/main/webapp/src/app/student/results/student-results.component.ts
+++ b/webapp/src/main/webapp/src/app/student/results/student-results.component.ts
@@ -13,19 +13,18 @@ import { ReportingEmbargoService } from '../../shared/embargo/reporting-embargo.
 import { ApplicationSettingsService } from '../../app-settings.service';
 import { AssessmentTypeOrdering } from '../../shared/ordering/orderings';
 import { FilterBy } from '../../assessments/model/filter-by.model';
-import * as _ from 'lodash';
+import { union } from 'lodash';
 import { StudentResultsFilterService } from './student-results-filter.service';
 import { Student } from '../model/student.model';
 import { StudentPipe } from '../../shared/format/student.pipe';
-import { OrderingService } from "../../shared/ordering/ordering.service";
-import { Ordering } from "@kourge/ordering";
+import { OrderingService } from '../../shared/ordering/ordering.service';
+import { Ordering } from '@kourge/ordering';
 
 @Component({
   selector: 'student-results',
   templateUrl: './student-results.component.html'
 })
 export class StudentResultsComponent implements OnInit {
-
   examHistory: StudentExamHistory;
   sections: Section[] = [];
   filterState: StudentResultsFilterState;
@@ -37,46 +36,51 @@ export class StudentResultsComponent implements OnInit {
 
   private _subjectOrdering: Ordering<string>;
 
-  constructor(private colorService: ColorService,
-              private csvExportService: CsvExportService,
-              private route: ActivatedRoute,
-              private router: Router,
-              private angulartics2: Angulartics2,
-              private applicationSettingsService: ApplicationSettingsService,
-              private examFilterService: ExamFilterService,
-              private embargoService: ReportingEmbargoService,
-              private studentResultsFilterService: StudentResultsFilterService,
-              private studentPipe: StudentPipe,
-              private orderingService: OrderingService) {
-  }
+  constructor(
+    private colorService: ColorService,
+    private csvExportService: CsvExportService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private angulartics2: Angulartics2,
+    private applicationSettingsService: ApplicationSettingsService,
+    private examFilterService: ExamFilterService,
+    private embargoService: ReportingEmbargoService,
+    private studentResultsFilterService: StudentResultsFilterService,
+    private studentPipe: StudentPipe,
+    private orderingService: OrderingService
+  ) {}
 
   ngOnInit(): void {
-
     const { examHistory } = this.route.snapshot.data;
     if (examHistory) {
-      this.orderingService.getSubjectOrdering()
-        .subscribe(subjectOrdering => {
-          this.examHistory = examHistory;
-          this._subjectOrdering = subjectOrdering;
+      this.orderingService.getSubjectOrdering().subscribe(subjectOrdering => {
+        this.examHistory = examHistory;
+        this._subjectOrdering = subjectOrdering;
 
-          const { exams } = examHistory;
-          this.filterState = this.createFilterState(exams);
-          this.filterOptions.hasSummative = exams.some(wrapper => wrapper.assessment.isSummative);
-          this.filterOptions.hasInterim = exams.some(wrapper => wrapper.assessment.isInterim);
-          this.advancedFilters.onChanges.subscribe(property => this.onAdvancedFilterChange());
-          this.sections = this.createSections(exams);
+        const { exams } = examHistory;
+        this.filterState = this.createFilterState(exams);
+        this.filterOptions.hasSummative = exams.some(
+          wrapper => wrapper.assessment.isSummative
+        );
+        this.filterOptions.hasInterim = exams.some(
+          wrapper => wrapper.assessment.isInterim
+        );
+        this.advancedFilters.onChanges.subscribe(property =>
+          this.onAdvancedFilterChange()
+        );
+        this.sections = this.createSections(exams);
 
-          this.subscribeToRouteChanges();
-          this.updateRouteWithDefaultFilters();
+        this.subscribeToRouteChanges();
+        this.updateRouteWithDefaultFilters();
 
-          this.applicationSettingsService.getSettings().subscribe(settings => {
-            this.minimumItemDataYear = settings.minItemDataYear;
-          });
-
-          this.embargoService.isEmbargoed().subscribe(embargoed => {
-            this.exportDisabled = embargoed;
-          });
+        this.applicationSettingsService.getSettings().subscribe(settings => {
+          this.minimumItemDataYear = settings.minItemDataYear;
         });
+
+        this.embargoService.isEmbargoed().subscribe(embargoed => {
+          this.exportDisabled = embargoed;
+        });
+      });
     }
   }
 
@@ -94,7 +98,7 @@ export class StudentResultsComponent implements OnInit {
   private updateRouteWithDefaultFilters(): void {
     const { historySchoolYear } = this.route.snapshot.params;
     if (historySchoolYear == null) {
-      this.filterState.schoolYear = this.filterState.schoolYears[ 0 ];
+      this.filterState.schoolYear = this.filterState.schoolYears[0];
       this.updateRoute(true);
     }
   }
@@ -111,7 +115,6 @@ export class StudentResultsComponent implements OnInit {
   }
 
   exportCsv(): void {
-
     this.angulartics2.eventTrack.next({
       action: 'Export Student Exam History',
       properties: {
@@ -126,12 +129,14 @@ export class StudentResultsComponent implements OnInit {
         return exams;
       }, []),
       () => this.examHistory.student,
-      `${student.lastName ? student.lastName + '-' : ''}${student.firstName ? student.firstName + '-' : ''}${student.ssid}-${new Date().toDateString()}`
+      `${student.lastName ? student.lastName + '-' : ''}${
+        student.firstName ? student.firstName + '-' : ''
+      }${student.ssid}-${new Date().toDateString()}`
     );
   }
 
   getAssessmentTypeColor(assessmentType: string): string {
-    const index = [ 'ica', 'iab', 'sum' ].indexOf(assessmentType);
+    const index = ['ica', 'iab', 'sum'].indexOf(assessmentType);
     const totalAssessmentTypes = 3;
     const colorIndex = index >= 0 ? index + 1 : totalAssessmentTypes;
     return this.colorService.getColor(colorIndex);
@@ -142,13 +147,16 @@ export class StudentResultsComponent implements OnInit {
    */
   private applyFilter(): void {
     this.studentResultsFilterService.filterChanged();
-    const examsFilteredByYearAndSubject = this.examHistory.exams
-      .filter(wrapper => {
+    const examsFilteredByYearAndSubject = this.examHistory.exams.filter(
+      wrapper => {
         const { schoolYear, subject, assessmentType } = this.filterState;
-        return (schoolYear == null || schoolYear === wrapper.exam.schoolYear)
-          && (subject == null || subject === wrapper.assessment.subject)
-          && (assessmentType == null || assessmentType === wrapper.assessment.type);
-      });
+        return (
+          (schoolYear == null || schoolYear === wrapper.exam.schoolYear) &&
+          (subject == null || subject === wrapper.assessment.subject) &&
+          (assessmentType == null || assessmentType === wrapper.assessment.type)
+        );
+      }
+    );
 
     const filteredExams = this.examFilterService.filterItems(
       wrapper => wrapper.assessment,
@@ -159,7 +167,9 @@ export class StudentResultsComponent implements OnInit {
 
     this.hasResults = filteredExams.length !== 0;
     this.sections.forEach(section => {
-      section.filteredExams = section.exams.filter(exam => filteredExams.find(x => x.exam.id === exam.exam.id));
+      section.filteredExams = section.exams.filter(exam =>
+        filteredExams.find(x => x.exam.id === exam.exam.id)
+      );
     });
   }
 
@@ -179,35 +189,42 @@ export class StudentResultsComponent implements OnInit {
     }
 
     // this is needed since the route can be for a group (/groups/1/students/2 or directly to the student (/students/2)
-    const navigationExtras = this.route.parent && this.route.parent.parent.snapshot.url.length > 0
-      ? { relativeTo: this.route.parent.parent, replaceUrl }
-      : { replaceUrl };
+    const navigationExtras =
+      this.route.parent && this.route.parent.parent.snapshot.url.length > 0
+        ? { relativeTo: this.route.parent.parent, replaceUrl }
+        : { replaceUrl };
 
-    this.router.navigate([
-      'students',
-      this.examHistory.student.id,
-      parameters
-    ], navigationExtras);
+    this.router.navigate(
+      ['students', this.examHistory.student.id, parameters],
+      navigationExtras
+    );
   }
 
   private createSections(exams: StudentHistoryExamWrapper[]): Section[] {
-    return exams.reduce((sections, wrapper) => {
-      const { type, subject } = wrapper.assessment;
-      const section = sections.find(section => section.subjectCode === subject);
-      if (section) {
-        section.exams.push(wrapper);
-      } else {
-        sections.push({
-          assessmentTypeCode: type,
-          assessmentTypeColor: this.getAssessmentTypeColor(type),
-          subjectCode: subject,
-          exams: [ wrapper ],
-          filteredExams: [],
-          collapsed: false
-        });
-      }
-      return sections;
-    }, []).sort(this._subjectOrdering.on<Section>(section => section.subjectCode).compare);
+    return exams
+      .reduce((sections, wrapper) => {
+        const { type, subject } = wrapper.assessment;
+        const section = sections.find(
+          section => section.subjectCode === subject
+        );
+        if (section) {
+          section.exams.push(wrapper);
+        } else {
+          sections.push({
+            assessmentTypeCode: type,
+            assessmentTypeColor: this.getAssessmentTypeColor(type),
+            subjectCode: subject,
+            exams: [wrapper],
+            filteredExams: [],
+            collapsed: false
+          });
+        }
+        return sections;
+      }, [])
+      .sort(
+        this._subjectOrdering.on<Section>(section => section.subjectCode)
+          .compare
+      );
   }
 
   /**
@@ -216,14 +233,18 @@ export class StudentResultsComponent implements OnInit {
    * @param exams       The available exams
    * @param params      The route params
    */
-  private createFilterState(exams: StudentHistoryExamWrapper[]): StudentResultsFilterState {
-
-    const filterState: StudentResultsFilterState = exams.reduce((filterState, wrapper: StudentHistoryExamWrapper) => {
+  private createFilterState(
+    exams: StudentHistoryExamWrapper[]
+  ): StudentResultsFilterState {
+    const filterState: StudentResultsFilterState = exams.reduce(
+      (filterState, wrapper: StudentHistoryExamWrapper) => {
         const { schoolYear } = wrapper.exam;
-        filterState.schoolYears = _.union(filterState.schoolYears, [ schoolYear ]);
+        filterState.schoolYears = union(filterState.schoolYears, [schoolYear]);
         const { subject, type } = wrapper.assessment;
-        filterState.subjects = _.union(filterState.subjects, [ subject ]);
-        filterState.assessmentTypes = _.union(filterState.assessmentTypes, [ type ]);
+        filterState.subjects = union(filterState.subjects, [subject]);
+        filterState.assessmentTypes = union(filterState.assessmentTypes, [
+          type
+        ]);
         return filterState;
       },
       {
@@ -243,7 +264,10 @@ export class StudentResultsComponent implements OnInit {
   private updateFilterState(parameters: any): void {
     const { historySchoolYear, subject, assessmentType } = parameters;
     const filterState = this.filterState;
-    filterState.schoolYear = historySchoolYear != null ? Number.parseInt(historySchoolYear) : undefined;
+    filterState.schoolYear =
+      historySchoolYear != null
+        ? Number.parseInt(historySchoolYear)
+        : undefined;
     filterState.subject = subject;
     filterState.assessmentType = assessmentType;
   }
@@ -256,11 +280,10 @@ export class StudentResultsComponent implements OnInit {
   initializeDownloader(downloader: StudentReportDownloadComponent): void {
     downloader.options.schoolYear = this.filterState.schoolYear
       ? this.filterState.schoolYear
-      : this.filterState.schoolYears[ 0 ];
+      : this.filterState.schoolYears[0];
     downloader.options.subject = this.filterState.subject;
     downloader.options.assessmentType = this.filterState.assessmentType;
   }
-
 }
 
 /**


### PR DESCRIPTION
This theoretically this should improve build time/size

The metrics don't reflect this though x l

before:
```
chunk {0} runtime.a5dd35324ddfd942bef1.js (runtime) 1.41 kB [entry] [rendered]
chunk {1} main.a75c5a6ee078bfdb2dc9.js (main) 4.13 MB [initial] [rendered]
chunk {2} polyfills.6f4d9fc89549c9b39ff0.js (polyfills) 99 kB [initial] [rendered]
chunk {3} styles.4d9c2c4eea880bdc8750.css (styles) 649 kB [initial] [rendered]
chunk {scripts} scripts.fdb6bbe90b2b083d2cd8.js (scripts) 93.9 kB [entry] [rendered]
```

after:
```
chunk {0} runtime.a5dd35324ddfd942bef1.js (runtime) 1.41 kB [entry] [rendered]
chunk {1} main.a76fe214900461bae36c.js (main) 4.11 MB [initial] [rendered]
chunk {2} polyfills.6f4d9fc89549c9b39ff0.js (polyfills) 99 kB [initial] [rendered]
chunk {3} styles.4d9c2c4eea880bdc8750.css (styles) 649 kB [initial] [rendered]
chunk {scripts} scripts.fdb6bbe90b2b083d2cd8.js (scripts) 93.9 kB [entry] [rendered]
```