### PR TITLE
minimal changes for reporting to work with configurable subjects schema change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-108"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-411"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-413"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -1,10 +1,12 @@
 sql:
   claim:
+    # TODO - deal with ALT scores and remove "WHERE scs.score_type_id=3"
     findAll: >-
       SELECT scs.id, scs.code, s.code as subject_code, at.code as asmt_type_code
       FROM subject_score scs
         JOIN subject s ON scs.subject_id = s.id
         JOIN asmt_type at ON at.id = scs.asmt_type_id
+      WHERE scs.score_type_id=3
       ORDER BY scs.display_order
 
   translation:

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -2,7 +2,7 @@ sql:
   claim:
     findAll: >-
       SELECT scs.id, scs.code, s.code as subject_code, at.code as asmt_type_code
-      FROM subject_claim_score scs
+      FROM subject_score scs
         JOIN subject s ON scs.subject_id = s.id
         JOIN asmt_type at ON at.id = scs.asmt_type_id
       ORDER BY scs.display_order

--- a/reporting-service/src/test/resources/integration-test-data.sql
+++ b/reporting-service/src/test/resources/integration-test-data.sql
@@ -3,16 +3,16 @@ insert into ethnicity VALUES (-29,'ethnicity-29'),(-28,'ethnicity-28'),(-27, 'et
 insert into subject (id, code, updated, update_import_id, migrate_id) values
   (-1, 'NEW', now(), -1, -1);
 
-insert into subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) values
-  (1, -1, 6, 3, 6, 0);
+insert into subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, printed_report) values
+  (1, -1, 6, 3, 6, 0, 0);
 
-insert into subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) values
-  (-1, -1, 1, 'claim1', 1, 1),
-  (-2, -1, 1, 'claim2', 2, 2),
-  (-3, -1, 1, 'claim3', 3, 3),
-  (-4, -1, 1, 'claim4', 4, 4),
-  (-5, -1, 1, 'claim5', 5, 5),
-  (-6, -1, 1, 'claim6', 6, 6);
+insert into subject_score (id, subject_id, asmt_type_id, score_type_id, code, display_order, data_order) values
+  (-1, -1, 1, 3, 'claim1', 1, 1),
+  (-2, -1, 1, 3, 'claim2', 2, 2),
+  (-3, -1, 1, 3, 'claim3', 3, 3),
+  (-4, -1, 1, 3, 'claim4', 4, 4),
+  (-5, -1, 1, 3, 'claim5', 5, 5),
+  (-6, -1, 1, 3, 'claim6', 6, 6);
 
 insert into school_group (id, natural_id, name) values
   (-10, 'schoolGroup1', 'schoolGroup1'),


### PR DESCRIPTION
Because most of the configurable subject changes to reporting are additive, there were just a couple tweaks to keep things running.

@esotrope, this (obviously) doesn't make all the changes we'll need to get the configurable subject changes into the UI and backing API calls.