### PR TITLE
RP-135, honor subject flag when batch generating ISR's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-109"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-414"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-110"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-417"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -292,6 +292,7 @@ sql:
           join student st on st.id = e.student_id
           join asmt a on e.asmt_id = a.id
           join subject su on a.subject_id=su.id
+          join subject_asmt_type sat on a.subject_id=sat.subject_id and a.type_id=sat.asmt_type_id
           join school s on e.school_id = s.id
           join school isch on st.inferred_school_id = isch.id
 

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
@@ -48,7 +48,7 @@ public class JdbcSubjectDefinitionRepositoryIT {
                 .performanceLevelStandardCutoff(3)
                 .claimScorePerformanceLevelCount(3)
                 .targetReport(true)
-                .printedReport(false)
+                .printedReport(true)
                 .scorableClaims(newArrayList("1", "SOCK_2", "3"))
                 .build();
 

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -14,6 +14,7 @@ sql:
        AND ${sql.reportProcessor.snippet.studentExamPermissionWithEmbargo}
 
   exam:
+    # this is used to query for IABs for report generation
     findAllIabsByStudentIdsAndQueryParamsUnknownPermissions: >-
       SELECT
         d.name AS district_name,
@@ -27,7 +28,7 @@ sql:
       ${sql.reportProcessor.snippet.percentileLeftJoin}
       WHERE e.student_id in (:student_ids)
         AND (:school_year is null or e.school_year=:school_year)
-        AND (:subject_code is null or su.code=:subject_code)
+        AND (:subject_code is null or su.code=:subject_code) AND sat.printed_report=1
         AND (:grade_id is null or a.grade_id=:grade_id)
         AND a.type_id = 2
         AND ${sql.reportProcessor.snippet.schoolFilter}
@@ -35,6 +36,7 @@ sql:
       ORDER BY e.completed_at DESC,
         i.performance_task_writing_type DESC
 
+    # this is used to query for IABs for report generation
     findAllIabsByStudentIdsAndQueryParamsGroupPermissions: >-
       SELECT
         d.name AS district_name,
@@ -50,7 +52,7 @@ sql:
       WHERE e.student_id in (:student_ids)
         AND $[groupFilterPlaceholder]
         AND (:school_year is null or e.school_year=:school_year)
-        AND (:subject_code is null or su.code=:subject_code)
+        AND (:subject_code is null or su.code=:subject_code) AND sat.printed_report=1
         AND (:grade_id is null or a.grade_id=:grade_id)
         AND a.type_id=2
         AND ${sql.reportProcessor.snippet.schoolFilter}
@@ -58,6 +60,7 @@ sql:
       ORDER BY e.completed_at DESC,
               i.performance_task_writing_type DESC
 
+    # this is used to query for results for report generation
     findAllIcasOrSummativesByStudentIdsAndQueryParamsUnknownPermissions: >-
       SELECT
         d.name AS district_name,
@@ -81,13 +84,14 @@ sql:
       ) as wt on wt.exam_id = e.id
       WHERE e.student_id in (:student_ids)
         AND (:school_year is null or e.school_year=:school_year)
-        AND (:subject_code is null or su.code=:subject_code)
+        AND (:subject_code is null or su.code=:subject_code) AND sat.printed_report=1
         AND (:grade_id is null or a.grade_id=:grade_id)
         AND a.type_id=:type_id
         AND ${sql.reportProcessor.snippet.schoolFilter}
         AND ${sql.reportProcessor.snippet.studentExamPermissionWithEmbargo}
       ORDER BY e.completed_at asc
 
+    # this is used to query for results for report generation
     findAllIcasOrSummativesByStudentIdsAndQueryParamsGroupPermissions: >-
       SELECT
         d.name AS district_name,
@@ -112,7 +116,7 @@ sql:
       $[groupJoinPlaceholder]
       WHERE e.student_id in (:student_ids)
         AND $[groupFilterPlaceholder]
-        AND (:subject_code is null or su.code=:subject_code)
+        AND (:subject_code is null or su.code=:subject_code) AND sat.printed_report=1
         AND (:school_year is null or e.school_year=:school_year)
         AND (:grade_id is null or a.grade_id=:grade_id)
         AND a.type_id=:type_id

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/repository/JdbcIcaSummativeReportRepositoryIT.java
@@ -84,7 +84,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
                 .schoolId(-10L)
                 .schoolYear(1997)
                 .queryPermissionType(Individual)
-                .subjectCode("sub")
+                .subjectCode("Math")
                 .gradeId(-1)
                 .assessmentTypeCode("sum")
                 .build();
@@ -97,7 +97,7 @@ public class JdbcIcaSummativeReportRepositoryIT {
         assertThat(reports.get(-1L)).isNullOrEmpty();
 
         assertThat(reports.get(-2L)).hasSize(1);
-        assertThat(getFirstBySubject(reports.get(-2L), "sub").getAssessment().getSubjectCode()).isEqualTo("sub");
+        assertThat(getFirstBySubject(reports.get(-2L), "Math").getAssessment().getSubjectCode()).isEqualTo("Math");
     }
 
     @Test
@@ -114,10 +114,11 @@ public class JdbcIcaSummativeReportRepositoryIT {
                 of(-1L, -2L),
                 examQueryParams);
 
+        // there is 1 student with results
         assertThat(reports).hasSize(1);
-        assertThat(reports.get(-2L)).hasSize(2);
+        // there are 2 exams for the student but "sub" doesn't support ISR's
+        assertThat(reports.get(-2L)).hasSize(1);
         assertThat(getFirstBySubject(reports.get(-2L), "Math").getAssessment().getSubjectCode()).isEqualTo("Math");
-        assertThat(getFirstBySubject(reports.get(-2L), "sub").getAssessment().getSubjectCode()).isEqualTo("sub");
     }
 
     @Test
@@ -202,10 +203,11 @@ public class JdbcIcaSummativeReportRepositoryIT {
                 of(-1L, -2L),
                 examQueryParams);
 
+        // only 1 student has exams matching query
         assertThat(reports).hasSize(1);
-        assertThat(reports.get(-2L)).hasSize(2);
+        // there are 2 exams but "sub" doesn't support printed reports
+        assertThat(reports.get(-2L)).hasSize(1);
         assertThat(getFirstBySubject(reports.get(-2L), "Math").getAssessment().getSubjectCode()).isEqualTo("Math");
-        assertThat(getFirstBySubject(reports.get(-2L), "sub").getAssessment().getSubjectCode()).isEqualTo("sub");
     }
 
     @Test

--- a/report-processor/src/test/resources/integration-test-data.sql
+++ b/report-processor/src/test/resources/integration-test-data.sql
@@ -30,6 +30,9 @@ insert into school_year (year) values
 insert into subject (id, code, update_import_id, migrate_id) values
   (-1, 'sub', -1, -1);
 
+insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report) VALUES
+  (-1, 3, 4, 3, 3, 0, 0);
+
 insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, inferred_school_id, update_import_id, updated, migrate_id) values
   (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -10, -1, '1997-07-18 20:14:34.000000', -1),
   (-2, 'student2_ssid', 'student2_lastName', 'student2_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -12, -1, '1997-07-18 20:14:34.000000', -1),

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/TestData.java
@@ -206,6 +206,7 @@ public final class TestData {
                 .schoolYear(1997)
                 .subjectCode(MATH)
                 .targetReportEnabled(true)
+                .printedReportEnabled(true)
                 .claimCodes(newArrayList("sum_claim1", "sum_claim2", "sum_claim3"))
                 .altScoreCodes(newArrayList("sum_alt1"));
     }


### PR DESCRIPTION
Some of the changes were actually due to a bug in the schema migration where the printed_report flag was not set properly for all Smarter Balanced assessments.