### PR TITLE
makes display of grouping control conditional on standard cutoff config

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report.component.html
@@ -258,7 +258,7 @@
             <span
               *ngIf="
                 effectiveReportType !== 'Claim' &&
-                assessmentDefinition.performanceLevelDisplayTypes.length > 1
+                view.subjectDefinition.overallScore.standardCutoff != null
               "
             >
               <label for="performance-level-display-type">


### PR DESCRIPTION
This will theoretically disable the score level grouping in the aggregate result page but i have not yet been able to test this locally