### PR TITLE
Sandbox Configuration

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/admin.module.ts
+++ b/webapp/src/main/webapp/src/app/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { GroupsModule } from './groups/groups.module';
 import { FileFormatModule } from './groups/import/fileformat/file-format.module';
 import { InstructionalResourceModule } from './instructional-resource/instructional-resource.module';
 import { EmbargoModule } from './embargo/embargo.module';
+import { SandboxModule } from './sandbox/sandbox.module';
 import { CommonModule } from '../shared/common.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { IngestPipelineModule } from './ingest-pipeline/ingest-pipeline.module';
@@ -18,7 +19,8 @@ import { IngestPipelineModule } from './ingest-pipeline/ingest-pipeline.module';
     IngestPipelineModule,
     InstructionalResourceModule,
     EmbargoModule,
-    FileFormatModule
+    FileFormatModule,
+    SandboxModule
   ],
   exports: [
     GroupImportModule,

--- a/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.html
@@ -195,7 +195,7 @@
     </form>
   </div>
   <div class="mt-md" style="height: 40px">
-    <a class="btn btn-default pull-right mr-xs" routerLink="/sandbox">{{
+    <a class="btn btn-default pull-right mr-xs" routerLink="/sandboxes">{{
       'common.action.cancel' | translate
     }}</a>
     <button

--- a/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.html
@@ -1,0 +1,210 @@
+<page-heading>
+  <ng-template #heading>
+    <h2>{{ 'sandbox-config.new-sandbox.header' | translate }}</h2>
+  </ng-template>
+</page-heading>
+
+<div class="well sandbox-config">
+  <div class="well-body mt-sm">
+    <form class="form-group" [formGroup]="sandboxForm">
+      <div class="row mb-xs">
+        <div class="col-md-4">
+          <label>{{ 'sandbox-config.fields.label' | translate }}</label>
+        </div>
+        <div class="col-md-8">
+          <input
+            type="text"
+            class="form-control"
+            name="label"
+            formControlName="label"
+          />
+        </div>
+      </div>
+      <div class="row mb-xs">
+        <div class="col-md-4">
+          <label>{{ 'sandbox-config.fields.description' | translate }}</label>
+        </div>
+        <div class="col-md-8">
+          <textarea
+            class="form-control"
+            name="description"
+            formControlName="description"
+          >
+          </textarea>
+        </div>
+      </div>
+      <div class="row mb-sm">
+        <div class="col-md-4">
+          <label>{{ 'sandbox-config.fields.data-template' | translate }}</label>
+        </div>
+        <div class="col-md-8">
+          <select class="form-control" formControlName="template">
+            <option [value]="null">{{
+              'sandbox-config.fields.select-template' | translate
+            }}</option>
+            <option
+              *ngFor="let dataTemplate of dataTemplates"
+              [ngValue]="dataTemplate"
+            >
+              {{ dataTemplate.label }}
+            </option>
+          </select>
+        </div>
+      </div>
+      <p-accordion [multiple]="true">
+        <p-accordionTab
+          header="{{
+            'sandbox-config.fields.configuration-properties' | translate
+          }}"
+        >
+          <p-table
+            #configurationPropertiesDataTable
+            [value]="configurationProperties"
+            dataKey="key"
+            [scrollable]="true"
+            scrollHeight="400px"
+            [globalFilterFields]="['key', 'value']"
+            styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+            [paginator]="true"
+            [rows]="20"
+          >
+            <ng-template pTemplate="caption">
+              <div>
+                <i class="fa fa-search"></i>
+                <input
+                  type="text"
+                  class="form-control"
+                  pInputText
+                  size="50"
+                  placeholder="{{ 'sandbox-config.fields.search' | translate }}"
+                  (input)="
+                    configurationPropertiesDataTable.filterGlobal(
+                      $event.target.value,
+                      'contains'
+                    )
+                  "
+                />
+              </div>
+            </ng-template>
+            <ng-template pTemplate="header">
+              <tr>
+                <th>Key</th>
+                <th>Value</th>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-property let-i="rowIndex">
+              <tr
+                [ngClass]="{
+                  modified: property.value !== property.originalValue
+                }"
+              >
+                <td [title]="property.key">{{ property.key }}</td>
+                <td>
+                  <div class="col-md-11">
+                    <input
+                      type="text"
+                      [value]="property.value"
+                      [formControlName]="i"
+                      class="property-input"
+                      (change)="updateConfigurationProperty(property, i)"
+                    />
+                  </div>
+                  <div class="col-md-1">
+                    <i
+                      class="fa fa-refresh fa-2x"
+                      *ngIf="property.value !== property.originalValue"
+                      (click)="property.value = property.originalValue"
+                    ></i>
+                  </div>
+                </td>
+              </tr>
+            </ng-template>
+          </p-table>
+        </p-accordionTab>
+        <p-accordionTab
+          header="{{
+            'sandbox-config.fields.localization-overrides' | translate
+          }}"
+          formArrayName="localizationOverrides"
+        >
+          <p-table
+            #localizationDataTable
+            [value]="localizationOverrides"
+            dataKey="key"
+            [scrollable]="true"
+            scrollHeight="400px"
+            [globalFilterFields]="['key', 'value']"
+            styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+            [paginator]="true"
+            [rows]="20"
+          >
+            <ng-template pTemplate="caption">
+              <div>
+                <i class="fa fa-search"></i>
+                <input
+                  type="text"
+                  class="form-control"
+                  pInputText
+                  size="50"
+                  placeholder="{{ 'sandbox-config.fields.search' | translate }}"
+                  (input)="
+                    localizationDataTable.filterGlobal(
+                      $event.target.value,
+                      'contains'
+                    )
+                  "
+                />
+              </div>
+            </ng-template>
+            <ng-template pTemplate="header">
+              <tr>
+                <th>Key</th>
+                <th>Value</th>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-overrides let-i="rowIndex">
+              <tr
+                [ngClass]="{
+                  modified: overrides.value !== overrides.originalValue
+                }"
+              >
+                <td [title]="overrides.key">{{ overrides.key }}</td>
+                <td>
+                  <div class="col-md-11">
+                    <input
+                      type="text"
+                      [value]="overrides.value"
+                      [formControlName]="i"
+                      class="property-input"
+                      (change)="updateOverride(overrides, i)"
+                    />
+                  </div>
+                  <div class="col-md-1">
+                    <i
+                      class="fa fa-refresh fa-2x"
+                      *ngIf="overrides.value !== overrides.originalValue"
+                      (click)="overrides.value = overrides.originalValue"
+                    ></i>
+                  </div>
+                </td>
+              </tr>
+            </ng-template>
+          </p-table>
+        </p-accordionTab>
+      </p-accordion>
+    </form>
+  </div>
+  <div class="mt-md" style="height: 40px">
+    <a class="btn btn-default pull-right mr-xs" routerLink="/sandbox">{{
+      'common.action.cancel' | translate
+    }}</a>
+    <button
+      type="button"
+      class="btn btn-primary pull-right mr-xs"
+      (click)="onSubmit()"
+      [disabled]="sandboxForm.invalid"
+    >
+      {{ 'common.action.save' | translate }}
+    </button>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
@@ -1,0 +1,95 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { DataTemplate } from './sandbox-configuration';
+import { SandboxService } from './sandbox.service';
+import {
+  FormBuilder,
+  FormGroup,
+  FormArray,
+  Validators,
+  FormControl
+} from '@angular/forms';
+import { RdwTranslateLoader } from '../../shared/i18n/rdw-translate-loader';
+import { SandboxConfigurationProperty } from './sandbox-configuration-property';
+
+@Component({
+  selector: 'new-sandbox',
+  templateUrl: './new-sandbox.component.html'
+})
+export class NewSandboxConfigurationComponent {
+  dataTemplates: DataTemplate[];
+  sandboxForm: FormGroup;
+  // Contains the full list of localization overrides, with default values
+  localizationOverrides: SandboxConfigurationProperty[] = [];
+  // Contains the full list of configuration properties, with default values
+  configurationProperties: SandboxConfigurationProperty[] = [];
+  // An array containing localization overrides that have been modified
+  modifiedLocalizationOverrides: SandboxConfigurationProperty[] = [];
+  // An array containing configuration properties that have been modified
+  modifiedConfigurationProperties: SandboxConfigurationProperty[] = [];
+
+  constructor(
+    private service: SandboxService,
+    private formBuilder: FormBuilder,
+    private translationLoader: RdwTranslateLoader,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.sandboxForm = this.formBuilder.group({
+      label: [null, Validators.required],
+      description: [null],
+      template: [null, Validators.required],
+      configurationProperties: this.formBuilder.array([]),
+      localizationOverrides: this.formBuilder.array([])
+    });
+
+    this.service
+      .getAvailableDataTemplates()
+      .subscribe(templates => (this.dataTemplates = templates));
+
+    this.translationLoader
+      .getFlattenedTranslations('en')
+      .subscribe(translations => {
+        let locationOverrideFormArray = <FormArray>(
+          this.sandboxForm.controls['localizationOverrides']
+        );
+        for (let key in translations) {
+          // check also if property is not inherited from prototype
+          if (translations.hasOwnProperty(key)) {
+            let value = translations[key];
+            this.localizationOverrides.push(
+              new SandboxConfigurationProperty(key, value)
+            );
+            locationOverrideFormArray.controls.push(new FormControl(value));
+          }
+        }
+      });
+  }
+
+  onSubmit(): void {
+    let newSandbox = {
+      ...this.sandboxForm.value,
+      localizationOverrides: this.modifiedLocalizationOverrides
+    };
+    this.service.create(newSandbox);
+    this.router.navigate(['sandbox']);
+  }
+
+  updateOverride(override: SandboxConfigurationProperty, index: number): void {
+    const overrides = <FormArray>(
+      this.sandboxForm.controls['localizationOverrides']
+    );
+    const newVal = overrides.controls[index].value;
+
+    if (this.modifiedLocalizationOverrides.indexOf(override) > -1) {
+      let existingOverride = this.modifiedLocalizationOverrides[
+        this.modifiedLocalizationOverrides.indexOf(override)
+      ];
+      existingOverride.value = newVal;
+    } else {
+      override.value = newVal;
+      this.modifiedLocalizationOverrides.push(override);
+    }
+  }
+}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
@@ -23,10 +23,6 @@ export class NewSandboxConfigurationComponent {
   localizationOverrides: SandboxConfigurationProperty[] = [];
   // Contains the full list of configuration properties, with default values
   configurationProperties: SandboxConfigurationProperty[] = [];
-  // An array containing localization overrides that have been modified
-  modifiedLocalizationOverrides: SandboxConfigurationProperty[] = [];
-  // An array containing configuration properties that have been modified
-  modifiedConfigurationProperties: SandboxConfigurationProperty[] = [];
 
   constructor(
     private service: SandboxService,
@@ -69,14 +65,17 @@ export class NewSandboxConfigurationComponent {
 
   onSubmit(): void {
     //TODO: This key should be generated in the database. Remove this once the backend is in place
-    let randomKey = Math.floor(Math.random() * 9999999) + 1000000;
-    let newSandbox = {
+    const randomCode = Math.floor(Math.random() * 9999999) + 1000000;
+    const modifiedLocalizationOverrides = this.localizationOverrides.filter(
+      override => override.originalValue !== override.value
+    );
+    const newSandbox = {
       ...this.sandboxForm.value,
-      key: randomKey,
-      localizationOverrides: this.modifiedLocalizationOverrides
+      code: randomCode,
+      localizationOverrides: modifiedLocalizationOverrides
     };
     this.service.create(newSandbox);
-    this.router.navigate(['sandbox']);
+    this.router.navigate(['sandboxes']);
   }
 
   updateOverride(override: SandboxConfigurationProperty, index: number): void {
@@ -85,14 +84,14 @@ export class NewSandboxConfigurationComponent {
     );
     const newVal = overrides.controls[index].value;
 
-    if (this.modifiedLocalizationOverrides.indexOf(override) > -1) {
-      let existingOverride = this.modifiedLocalizationOverrides[
-        this.modifiedLocalizationOverrides.indexOf(override)
+    if (this.localizationOverrides.indexOf(override) > -1) {
+      let existingOverride = this.localizationOverrides[
+        this.localizationOverrides.indexOf(override)
       ];
       existingOverride.value = newVal;
     } else {
       override.value = newVal;
-      this.modifiedLocalizationOverrides.push(override);
+      this.localizationOverrides.push(override);
     }
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/new-sandbox.component.ts
@@ -68,8 +68,11 @@ export class NewSandboxConfigurationComponent {
   }
 
   onSubmit(): void {
+    //TODO: This key should be generated in the database. Remove this once the backend is in place
+    let randomKey = Math.floor(Math.random() * 9999999) + 1000000;
     let newSandbox = {
       ...this.sandboxForm.value,
+      key: randomKey,
       localizationOverrides: this.modifiedLocalizationOverrides
     };
     this.service.create(newSandbox);

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration-property.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration-property.ts
@@ -1,0 +1,11 @@
+export class SandboxConfigurationProperty {
+  key: string;
+  originalValue: string;
+  value: string;
+
+  constructor(key, value, originalVal = value) {
+    this.key = key;
+    this.value = value;
+    this.originalValue = originalVal;
+  }
+}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration.ts
@@ -7,7 +7,7 @@ export interface SandboxConfiguration {
   /**
    * The unique (generated) key for the sandbox
    */
-  key: string;
+  code: string;
 
   /**
    * A human readable label, name, or description of the sandbox

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-configuration.ts
@@ -1,0 +1,48 @@
+/**
+ * Holds information regarding an RDW sandbox configuration
+ */
+import { SandboxConfigurationProperty } from './sandbox-configuration-property';
+
+export interface SandboxConfiguration {
+  /**
+   * The unique (generated) key for the sandbox
+   */
+  key: string;
+
+  /**
+   * A human readable label, name, or description of the sandbox
+   */
+  label: string;
+
+  /**
+   * Optional additional description of the sandbox configuration
+   */
+  description?: string;
+
+  /**
+   * The data template initially used to create the sandbox
+   */
+  template: DataTemplate;
+
+  /**
+   * The map containing text/i18n overrides
+   */
+  localizationOverrides?: SandboxConfigurationProperty[];
+
+  /**
+   * The map containing key/value pairings of configuration properties
+   */
+  configurationProperties?: SandboxConfigurationProperty[];
+}
+
+export interface DataTemplate {
+  /**
+   * The unique key for a given data template
+   */
+  key: string;
+
+  /**
+   * A more human-readable label for a data template
+   */
+  label: string;
+}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.html
@@ -1,7 +1,7 @@
 <div class="sandbox-container pt-md pb-md" *ngIf="!editMode">
   <div class="sandbox-header">
     <h2>
-      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.key }})</span>
+      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.code }})</span>
     </h2>
     <i class="fa fa-edit fa-2x pull-right" (click)="editMode = !editMode"></i>
     <h4>{{ sandbox.description }}</h4>
@@ -12,7 +12,7 @@
 <div class="sandbox-container pt-md pb-md" *ngIf="editMode">
   <div class="sandbox-header">
     <h2>
-      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.key }})</span>
+      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.code }})</span>
     </h2>
     <!-- Actions -->
     <div class="mb-sm pull-right">

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.html
@@ -1,0 +1,386 @@
+<div class="sandbox-container pt-md pb-md" *ngIf="!editMode">
+  <div class="sandbox-header">
+    <h2>
+      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.key }})</span>
+    </h2>
+    <i class="fa fa-edit fa-2x pull-right" (click)="editMode = !editMode"></i>
+    <h4>{{ sandbox.description }}</h4>
+    <h5>{{ sandbox.template.label }}</h5>
+  </div>
+</div>
+
+<div class="sandbox-container pt-md pb-md" *ngIf="editMode">
+  <div class="sandbox-header">
+    <h2>
+      {{ sandbox.label }} <span class="sandbox-key">({{ sandbox.key }})</span>
+    </h2>
+    <!-- Actions -->
+    <div class="mb-sm pull-right">
+      <button class="btn btn-primary mr-xs" (click)="onSubmit()">
+        {{ 'common.action.save' | translate }}
+      </button>
+      <button class="btn btn-default mr-xs" (click)="editMode = false">
+        {{ 'common.action.cancel' | translate }}
+      </button>
+      <p-menu #menu [popup]="true" [model]="menuItems"></p-menu>
+      <button
+        type="button"
+        pButton
+        class="btn btn-primary btn-outlined"
+        label="Show"
+        (click)="menu.toggle($event)"
+      >
+        <i class="fa fa-list fa-xl"></i>
+      </button>
+    </div>
+  </div>
+  <!-- Edit -->
+  <form class="form-group" [formGroup]="sandboxForm">
+    <div class="row mb-xs">
+      <div class="col-md-4">
+        <label>{{ 'sandbox-config.fields.label' | translate }}</label>
+      </div>
+      <div class="col-md-8">
+        <input
+          type="text"
+          class="form-control"
+          name="label"
+          formControlName="label"
+        />
+      </div>
+    </div>
+    <div class="row mb-xs">
+      <div class="col-md-4">
+        <label>{{ 'sandbox-config.fields.description' | translate }}</label>
+      </div>
+      <div class="col-md-8">
+        <textarea
+          class="form-control"
+          name="description"
+          formControlName="description"
+        >
+        </textarea>
+      </div>
+    </div>
+    <div class="row mb-sm">
+      <div class="col-md-4">
+        <label>{{ 'sandbox-config.fields.data-template' | translate }}</label>
+      </div>
+      <div class="col-md-8">{{ sandbox.template.label }}</div>
+    </div>
+
+    <p-accordion [multiple]="true">
+      <p-accordionTab
+        header="{{
+          'sandbox-config.fields.configuration-properties' | translate
+        }}"
+      >
+        <p-table
+          #configurationPropertiesDataTable
+          [value]="configurationProperties"
+          dataKey="key"
+          [scrollable]="true"
+          scrollHeight="400px"
+          [globalFilterFields]="['key', 'value']"
+          styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+          [paginator]="true"
+          [rows]="20"
+        >
+          <ng-template pTemplate="caption">
+            <div>
+              <i class="fa fa-search"></i>
+              <input
+                type="text"
+                class="form-control"
+                pInputText
+                size="50"
+                placeholder="{{ 'sandbox-config.fields.search' | translate }}"
+                (input)="
+                  configurationPropertiesDataTable.filterGlobal(
+                    $event.target.value,
+                    'contains'
+                  )
+                "
+              />
+            </div>
+          </ng-template>
+          <ng-template pTemplate="header">
+            <tr>
+              <th>Key</th>
+              <th>Value</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-property let-i="rowIndex">
+            <tr
+              [ngClass]="{
+                modified: property.value !== property.originalValue
+              }"
+            >
+              <td [title]="property.key">{{ property.key }}</td>
+              <td>
+                <div class="col-md-11">
+                  <input
+                    type="text"
+                    [value]="property.value"
+                    [formControlName]="i"
+                    class="property-input"
+                    (change)="updateConfigurationProperty(property, i)"
+                  />
+                </div>
+                <div class="col-md-1">
+                  <i
+                    class="fa fa-refresh fa-2x"
+                    *ngIf="property.value !== property.originalValue"
+                    (click)="property.value = property.originalValue"
+                  ></i>
+                </div>
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-accordionTab>
+      <p-accordionTab
+        header="{{
+          'sandbox-config.fields.localization-overrides' | translate
+        }}"
+        formArrayName="localizationOverrides"
+      >
+        <p-table
+          #localizationDataTable
+          [value]="localizationOverrides"
+          dataKey="key"
+          [scrollable]="true"
+          scrollHeight="400px"
+          [globalFilterFields]="['key', 'value']"
+          styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+          [paginator]="true"
+          [rows]="20"
+        >
+          <ng-template pTemplate="caption">
+            <div>
+              <i class="fa fa-search"></i>
+              <input
+                type="text"
+                class="form-control"
+                pInputText
+                size="50"
+                placeholder="{{ 'sandbox-config.fields.search' | translate }}"
+                (input)="
+                  localizationDataTable.filterGlobal(
+                    $event.target.value,
+                    'contains'
+                  )
+                "
+              />
+            </div>
+          </ng-template>
+          <ng-template pTemplate="header">
+            <tr>
+              <th>Key</th>
+              <th>Value</th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-overrides let-i="rowIndex">
+            <tr
+              [ngClass]="{
+                modified: overrides.value !== overrides.originalValue
+              }"
+            >
+              <td [title]="overrides.key">{{ overrides.key }}</td>
+              <td>
+                <div class="col-md-11">
+                  <input
+                    type="text"
+                    [value]="overrides.value"
+                    [formControlName]="i"
+                    class="property-input"
+                    (change)="updateOverride(overrides, i)"
+                  />
+                </div>
+                <div class="col-md-1">
+                  <i
+                    class="fa fa-refresh fa-2x"
+                    *ngIf="overrides.value !== overrides.originalValue"
+                    (click)="overrides.value = overrides.originalValue"
+                  ></i>
+                </div>
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </p-accordionTab>
+    </p-accordion>
+  </form>
+</div>
+
+<!-- Delete Modal -->
+<div
+  bsModal
+  #deleteModal="bs-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4
+          id="dialog-static-name"
+          class="modal-title pull-left label-max-width"
+          [innerHTML]="
+            'sandbox-config.delete-modal.header' | translate: sandbox
+          "
+        ></h4>
+        <button
+          type="button"
+          class="close pull-right"
+          aria-label="Close"
+          (click)="deleteModal.hide()"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div
+        class="modal-body"
+        [innerHTML]="'sandbox-config.delete-modal.body' | translate: sandbox"
+      ></div>
+      <div class="modal-footer">
+        <ul class="pull-right list-unstyled list-inline">
+          <li>
+            <button
+              type="button"
+              class="btn btn-danger btn-sm"
+              (click)="deleteModal.hide(); onDeleteButtonClick()"
+            >
+              <i class="fa fa-trash"></i>
+              {{ 'common.action.delete' | translate }}
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              class="btn btn-default btn-sm"
+              (click)="deleteModal.hide()"
+            >
+              {{ 'common.action.cancel' | translate }}
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Archive Modal -->
+<div
+  bsModal
+  #archiveModal="bs-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4
+          id="dialog-static-name"
+          class="modal-title pull-left label-max-width"
+          [innerHTML]="
+            'sandbox-config.archive-modal.header' | translate: sandbox
+          "
+        ></h4>
+        <button
+          type="button"
+          class="close pull-right"
+          aria-label="Close"
+          (click)="archiveModal.hide()"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div
+        class="modal-body"
+        [innerHTML]="'sandbox-config.archive-modal.body' | translate: sandbox"
+      ></div>
+      <div class="modal-footer">
+        <ul class="pull-right list-unstyled list-inline">
+          <li>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              (click)="archiveModal.hide(); onArchiveButtonClick()"
+            >
+              <i class="fa fa-archive"></i>
+              {{ 'sandbox-config.archive-modal.archive' | translate }}
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              class="btn btn-default btn-sm"
+              (click)="archiveModal.hide()"
+            >
+              {{ 'common.action.cancel' | translate }}
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Reset Modal -->
+<div
+  bsModal
+  #resetModal="bs-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4
+          id="dialog-static-name"
+          class="modal-title pull-left label-max-width"
+          [innerHTML]="'sandbox-config.reset-modal.header' | translate: sandbox"
+        ></h4>
+        <button
+          type="button"
+          class="close pull-right"
+          aria-label="Close"
+          (click)="resetModal.hide()"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div
+        class="modal-body"
+        [innerHTML]="'sandbox-config.reset-modal.body' | translate: sandbox"
+      ></div>
+      <div class="modal-footer">
+        <ul class="pull-right list-unstyled list-inline">
+          <li>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              (click)="resetModal.hide(); onResetButtonClick()"
+            >
+              <i class="fa fa-refresh"></i>
+              {{ 'sandbox-config.reset-modal.reset' | translate }}
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              class="btn btn-default btn-sm"
+              (click)="resetModal.hide()"
+            >
+              {{ 'common.action.cancel' | translate }}
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild
-} from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { SandboxConfiguration } from './sandbox-configuration';
 import { SandboxConfigurationProperty } from './sandbox-configuration-property';
 import { RdwTranslateLoader } from '../../shared/i18n/rdw-translate-loader';
@@ -26,10 +19,6 @@ import { SandboxService } from './sandbox.service';
 export class SandboxConfigurationDetailsComponent implements OnInit {
   @Input()
   sandbox: SandboxConfiguration;
-  @Output()
-  delete: EventEmitter<SandboxConfiguration> = new EventEmitter<
-    SandboxConfiguration
-  >();
   @ViewChild('resetModal')
   resetModal;
   @ViewChild('archiveModal')
@@ -113,7 +102,7 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
 
   onDeleteButtonClick() {
     //TODO: Call DELETE API and emit delete event
-    this.delete.emit(this.sandbox);
+    this.service.delete(this.sandbox.key);
   }
 
   onResetButtonClick() {
@@ -121,7 +110,6 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
   }
 
   onSubmit() {
-    console.log(this.sandbox);
     let newSandbox = {
       key: this.sandbox.key,
       template: this.sandbox.template,

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
@@ -30,8 +30,6 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
   editMode = false;
   configurationProperties: SandboxConfigurationProperty[] = [];
   localizationOverrides: SandboxConfigurationProperty[] = [];
-  modifiedConfigurationProperties: SandboxConfigurationProperty[] = [];
-  modifiedLocalizationOverrides: SandboxConfigurationProperty[] = [];
   menuItems: MenuItem[];
   sandboxForm: FormGroup;
 
@@ -102,7 +100,7 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
 
   onDeleteButtonClick() {
     //TODO: Call DELETE API and emit delete event
-    this.service.delete(this.sandbox.key);
+    this.service.delete(this.sandbox.code);
   }
 
   onResetButtonClick() {
@@ -110,11 +108,14 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
   }
 
   onSubmit() {
+    const modifiedLocalizationOverrides = this.localizationOverrides.filter(
+      override => override.originalValue !== override.value
+    );
     let newSandbox = {
-      key: this.sandbox.key,
+      code: this.sandbox.code,
       template: this.sandbox.template,
       ...this.sandboxForm.value,
-      localizationOverrides: this.modifiedLocalizationOverrides
+      localizationOverrides: modifiedLocalizationOverrides
     };
     this.service.update(newSandbox);
     this.editMode = false;
@@ -126,15 +127,10 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
     );
     const newVal = overrides.controls[index].value;
 
-    if (this.modifiedLocalizationOverrides.indexOf(override) > -1) {
-      let existingOverride = this.modifiedLocalizationOverrides[
-        this.modifiedLocalizationOverrides.indexOf(override)
-      ];
-      existingOverride.value = newVal;
-    } else {
-      override.value = newVal;
-      this.modifiedLocalizationOverrides.push(override);
-    }
+    let existingOverride = this.localizationOverrides[
+      this.localizationOverrides.indexOf(override)
+    ];
+    existingOverride.value = newVal;
   }
 
   private configureMenuItems(): void {

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox-details.component.ts
@@ -1,0 +1,171 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
+import { SandboxConfiguration } from './sandbox-configuration';
+import { SandboxConfigurationProperty } from './sandbox-configuration-property';
+import { RdwTranslateLoader } from '../../shared/i18n/rdw-translate-loader';
+import { MenuItem } from 'primeng/api';
+import {
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators
+} from '@angular/forms';
+import { SandboxService } from './sandbox.service';
+
+@Component({
+  selector: 'sandbox-details-config',
+  templateUrl: './sandbox-details.component.html'
+})
+export class SandboxConfigurationDetailsComponent implements OnInit {
+  @Input()
+  sandbox: SandboxConfiguration;
+  @Output()
+  delete: EventEmitter<SandboxConfiguration> = new EventEmitter<
+    SandboxConfiguration
+  >();
+  @ViewChild('resetModal')
+  resetModal;
+  @ViewChild('archiveModal')
+  archiveModal;
+  @ViewChild('deleteModal')
+  deleteModal;
+
+  expanded = false;
+  editMode = false;
+  configurationProperties: SandboxConfigurationProperty[] = [];
+  localizationOverrides: SandboxConfigurationProperty[] = [];
+  modifiedConfigurationProperties: SandboxConfigurationProperty[] = [];
+  modifiedLocalizationOverrides: SandboxConfigurationProperty[] = [];
+  menuItems: MenuItem[];
+  sandboxForm: FormGroup;
+
+  constructor(
+    private translationLoader: RdwTranslateLoader,
+    private service: SandboxService,
+    private formBuilder: FormBuilder
+  ) {}
+
+  ngOnInit(): void {
+    this.sandboxForm = this.formBuilder.group({
+      label: [this.sandbox.label, Validators.required],
+      description: [this.sandbox.description],
+      configurationProperties: this.formBuilder.array([]),
+      localizationOverrides: this.formBuilder.array([])
+    });
+
+    this.translationLoader
+      //TODO: Get the correct language code from somewhere, do not hardcode
+      .getFlattenedTranslations('en')
+      .subscribe(translations => {
+        for (let key in translations) {
+          let locationOverrideFormArray = <FormArray>(
+            this.sandboxForm.controls['localizationOverrides']
+          );
+          if (translations.hasOwnProperty(key)) {
+            const value = translations[key];
+            const localizationOverrides =
+              this.sandbox.localizationOverrides || [];
+            const override = localizationOverrides.find(
+              override => override.key === key
+            );
+            if (override) {
+              this.localizationOverrides.push(
+                new SandboxConfigurationProperty(
+                  key,
+                  override.value,
+                  override.originalValue
+                )
+              );
+              locationOverrideFormArray.controls.push(
+                new FormControl(override.value)
+              );
+            } else {
+              this.localizationOverrides.push(
+                new SandboxConfigurationProperty(key, value)
+              );
+              locationOverrideFormArray.controls.push(new FormControl(value));
+            }
+          }
+        }
+      });
+
+    if (this.sandbox.configurationProperties) {
+      this.sandbox.configurationProperties.forEach((value, key) =>
+        this.configurationProperties.push(
+          new SandboxConfigurationProperty(key, value)
+        )
+      );
+    }
+
+    this.configureMenuItems();
+  }
+
+  onArchiveButtonClick() {
+    //TODO: Call ARCHIVE API - update UI accordingly
+  }
+
+  onDeleteButtonClick() {
+    //TODO: Call DELETE API and emit delete event
+    this.delete.emit(this.sandbox);
+  }
+
+  onResetButtonClick() {
+    //TODO: Call DATA RESET API
+  }
+
+  onSubmit() {
+    console.log(this.sandbox);
+    let newSandbox = {
+      key: this.sandbox.key,
+      template: this.sandbox.template,
+      ...this.sandboxForm.value,
+      localizationOverrides: this.modifiedLocalizationOverrides
+    };
+    this.service.update(newSandbox);
+    this.editMode = false;
+  }
+
+  updateOverride(override: SandboxConfigurationProperty, index: number): void {
+    const overrides = <FormArray>(
+      this.sandboxForm.controls['localizationOverrides']
+    );
+    const newVal = overrides.controls[index].value;
+
+    if (this.modifiedLocalizationOverrides.indexOf(override) > -1) {
+      let existingOverride = this.modifiedLocalizationOverrides[
+        this.modifiedLocalizationOverrides.indexOf(override)
+      ];
+      existingOverride.value = newVal;
+    } else {
+      override.value = newVal;
+      this.modifiedLocalizationOverrides.push(override);
+    }
+  }
+
+  private configureMenuItems(): void {
+    this.menuItems = [
+      {
+        label: 'Reset Data',
+        icon: 'fa fa-refresh',
+        command: () => this.resetModal.show()
+      },
+      {
+        label: 'Archive',
+        icon: 'fa fa-archive',
+        command: () => this.archiveModal.show()
+      },
+      {
+        label: 'Delete',
+        icon: 'fa fa-close',
+        command: () => this.deleteModal.show()
+      }
+    ];
+  }
+}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
@@ -4,7 +4,7 @@
     <a
       class="btn btn-primary pull-right"
       style="margin-top: -8px;"
-      routerLink="/sandbox/new"
+      routerLink="/sandboxes/new"
     >
       Create New Sandbox
     </a>

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
@@ -14,10 +14,7 @@
 <div class="well sandbox-config">
   <div class="well-body mt-sm">
     <div *ngFor="let sandbox of sandboxes">
-      <sandbox-details-config
-        [sandbox]="sandbox"
-        (delete)="deleteSandbox($event)"
-      ></sandbox-details-config>
+      <sandbox-details-config [sandbox]="sandbox"></sandbox-details-config>
     </div>
   </div>
 </div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.html
@@ -1,0 +1,23 @@
+<page-heading>
+  <ng-template #heading>
+    <h2>{{ 'sandbox-config.title' | translate }}</h2>
+    <a
+      class="btn btn-primary pull-right"
+      style="margin-top: -8px;"
+      routerLink="/sandbox/new"
+    >
+      Create New Sandbox
+    </a>
+  </ng-template>
+</page-heading>
+
+<div class="well sandbox-config">
+  <div class="well-body mt-sm">
+    <div *ngFor="let sandbox of sandboxes">
+      <sandbox-details-config
+        [sandbox]="sandbox"
+        (delete)="deleteSandbox($event)"
+      ></sandbox-details-config>
+    </div>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SandboxConfiguration } from './sandbox-configuration';
+import { SandboxService } from './sandbox.service';
+
+@Component({
+  selector: 'sandbox-config',
+  templateUrl: './sandbox.component.html'
+})
+export class SandboxConfigurationComponent {
+  sandboxes: SandboxConfiguration[];
+
+  constructor(private route: ActivatedRoute, private service: SandboxService) {}
+
+  ngOnInit(): void {
+    this.service.getAll().subscribe(sandboxes => (this.sandboxes = sandboxes));
+  }
+
+  saveSandbox($event: SandboxConfiguration): void {
+    // TODO: Add the save service call to actually persist the sandbox configuration on the backend
+    this.sandboxes.push($event);
+  }
+
+  deleteSandbox($event: SandboxConfiguration): void {
+    //TODO: Remove this once we have an actual DELETE API in place
+    const index: number = this.sandboxes.indexOf($event);
+    if (index !== -1) {
+      this.sandboxes.splice(index, 1);
+    }
+  }
+}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.component.ts
@@ -15,17 +15,4 @@ export class SandboxConfigurationComponent {
   ngOnInit(): void {
     this.service.getAll().subscribe(sandboxes => (this.sandboxes = sandboxes));
   }
-
-  saveSandbox($event: SandboxConfiguration): void {
-    // TODO: Add the save service call to actually persist the sandbox configuration on the backend
-    this.sandboxes.push($event);
-  }
-
-  deleteSandbox($event: SandboxConfiguration): void {
-    //TODO: Remove this once we have an actual DELETE API in place
-    const index: number = this.sandboxes.indexOf($event);
-    if (index !== -1) {
-      this.sandboxes.splice(index, 1);
-    }
-  }
 }

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.module.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.module.ts
@@ -1,0 +1,36 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SandboxConfigurationComponent } from './sandbox.component';
+import { SandboxConfigurationDetailsComponent } from './sandbox-details.component';
+import { ButtonsModule, ModalModule } from 'ngx-bootstrap';
+import { HttpClientModule } from '@angular/common/http';
+import { CommonModule } from '../../shared/common.module';
+import { SandboxService } from './sandbox.service';
+import { NewSandboxConfigurationComponent } from './new-sandbox.component';
+import { TableModule } from 'primeng/table';
+import { MenuModule } from 'primeng/menu';
+import { AccordionModule } from 'primeng/primeng';
+
+@NgModule({
+  declarations: [
+    SandboxConfigurationComponent,
+    SandboxConfigurationDetailsComponent,
+    NewSandboxConfigurationComponent
+  ],
+  imports: [
+    BrowserModule,
+    ButtonsModule.forRoot(),
+    CommonModule,
+    FormsModule,
+    MenuModule,
+    AccordionModule,
+    ReactiveFormsModule,
+    HttpClientModule,
+    TableModule,
+    ModalModule.forRoot()
+  ],
+  exports: [SandboxConfigurationComponent, NewSandboxConfigurationComponent],
+  providers: [SandboxService]
+})
+export class SandboxModule {}

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
@@ -12,17 +12,7 @@ export class SandboxService {
 
   constructor(private dataService: DataService) {
     // TODO: Remove mock object, make call to backend API to fetch sandboxes
-
     if (!this.mockData) {
-      // configProperties.set('reporting.analytics-tracking-id', '123456789');
-      // configProperties.set(
-      //   'reporting.interpretive-guide-url',
-      //   'https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf'
-      // );
-      // configProperties.set('reporting.landing-page-url', 'forward:/landing.html');
-      // configProperties.set('reporting.state.code', 'CA');
-      // configProperties.set('reporting.state.name', 'California');
-
       this.mockData = [
         {
           key: '79d05c3d',
@@ -63,6 +53,13 @@ export class SandboxService {
   update(sandbox: SandboxConfiguration): void {
     let index = this.mockData.findIndex(s => s.key === sandbox.key);
     this.mockData[index] = sandbox;
+  }
+
+  delete(sandboxKey: string): void {
+    let index = this.mockData.findIndex(s => s.key === sandboxKey);
+    if (index !== -1) {
+      this.mockData.splice(index, 1);
+    }
   }
 
   getAvailableDataTemplates(): Observable<DataTemplate[]> {

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
@@ -6,7 +6,9 @@ import { DataTemplate, SandboxConfiguration } from './sandbox-configuration';
 /**
  * Service responsible for managing organization embargo settings
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class SandboxService {
   mockData: SandboxConfiguration[];
 
@@ -15,7 +17,7 @@ export class SandboxService {
     if (!this.mockData) {
       this.mockData = [
         {
-          key: '79d05c3d',
+          code: '79d05c3d',
           label: 'A Middle School Sandbox',
           description:
             'A test sandbox for middle school students with both ELA and MATH assessments',
@@ -25,7 +27,7 @@ export class SandboxService {
           }
         },
         {
-          key: '130c9ab1',
+          code: '130c9ab1',
           label: 'A High School Sandbox',
           description:
             'A sandbox for high school students with both ELA and MATH assessments',
@@ -51,12 +53,12 @@ export class SandboxService {
   }
 
   update(sandbox: SandboxConfiguration): void {
-    let index = this.mockData.findIndex(s => s.key === sandbox.key);
+    let index = this.mockData.findIndex(s => s.code === sandbox.code);
     this.mockData[index] = sandbox;
   }
 
-  delete(sandboxKey: string): void {
-    let index = this.mockData.findIndex(s => s.key === sandboxKey);
+  delete(sandboxCode: string): void {
+    let index = this.mockData.findIndex(s => s.code === sandboxCode);
     if (index !== -1) {
       this.mockData.splice(index, 1);
     }

--- a/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox/sandbox.service.ts
@@ -1,0 +1,86 @@
+import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { DataService } from '../../shared/data/data.service';
+import { DataTemplate, SandboxConfiguration } from './sandbox-configuration';
+
+/**
+ * Service responsible for managing organization embargo settings
+ */
+@Injectable()
+export class SandboxService {
+  mockData: SandboxConfiguration[];
+
+  constructor(private dataService: DataService) {
+    // TODO: Remove mock object, make call to backend API to fetch sandboxes
+
+    if (!this.mockData) {
+      // configProperties.set('reporting.analytics-tracking-id', '123456789');
+      // configProperties.set(
+      //   'reporting.interpretive-guide-url',
+      //   'https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf'
+      // );
+      // configProperties.set('reporting.landing-page-url', 'forward:/landing.html');
+      // configProperties.set('reporting.state.code', 'CA');
+      // configProperties.set('reporting.state.name', 'California');
+
+      this.mockData = [
+        {
+          key: '79d05c3d',
+          label: 'A Middle School Sandbox',
+          description:
+            'A test sandbox for middle school students with both ELA and MATH assessments',
+          template: {
+            key: 'template1',
+            label: 'Middle School Template'
+          }
+        },
+        {
+          key: '130c9ab1',
+          label: 'A High School Sandbox',
+          description:
+            'A sandbox for high school students with both ELA and MATH assessments',
+          template: {
+            key: 'template2',
+            label: 'High School Template'
+          }
+        }
+      ];
+    }
+  }
+
+  /**
+   * Gets all sandbox configurations for the system
+   */
+  getAll(): Observable<SandboxConfiguration[]> {
+    return new Observable(observer => observer.next(this.mockData));
+  }
+
+  create(sandbox: SandboxConfiguration): void {
+    // TODO: Call SAVE API
+    this.mockData.push(sandbox);
+  }
+
+  update(sandbox: SandboxConfiguration): void {
+    let index = this.mockData.findIndex(s => s.key === sandbox.key);
+    this.mockData[index] = sandbox;
+  }
+
+  getAvailableDataTemplates(): Observable<DataTemplate[]> {
+    //TODO: Pull these from database or other repository
+    let mockDataTemplates = [
+      {
+        key: 'template0',
+        label: 'Elementary School Template'
+      },
+      {
+        key: 'template1',
+        label: 'Middle School Template'
+      },
+      {
+        key: 'template2',
+        label: 'High School Template'
+      }
+    ];
+    return new Observable(observer => observer.next(mockDataTemplates));
+  }
+}

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -152,7 +152,7 @@ export const adminRoute = {
       ]
     },
     {
-      path: 'sandbox',
+      path: 'sandboxes',
       pathMatch: 'prefix',
       data: {
         breadcrumb: { translate: 'sandbox-config.title' }

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -39,6 +39,8 @@ import { UserGroupResolve } from './user-group/user-group.resolve';
 import { AggregateQueryFormContainerComponent } from './aggregate-report/query-forms/aggregate-query-form-container.component';
 import { StudentPipe } from './shared/format/student.pipe';
 import { ingestPipelineRoutes } from './admin/ingest-pipeline/ingest-pipeline.routes';
+import { SandboxConfigurationComponent } from './admin/sandbox/sandbox.component';
+import { NewSandboxConfigurationComponent } from './admin/sandbox/new-sandbox.component';
 
 export const studentPipe = new StudentPipe();
 export const adminRoute = {
@@ -146,6 +148,37 @@ export const adminRoute = {
           pathMatch: 'prefix',
           component: EmbargoComponent,
           resolve: { embargoesByOrganizationType: EmbargoResolve }
+        }
+      ]
+    },
+    {
+      path: 'sandbox',
+      pathMatch: 'prefix',
+      data: {
+        breadcrumb: { translate: 'sandbox-config.title' }
+        //TODO: Uncomment the line below once the roles/permissions have been configured
+        // permissions: ['TENANT_ADMIN']
+      },
+      canActivate: [AuthorizationCanActivate],
+      children: [
+        {
+          path: '',
+          pathMatch: 'prefix',
+          component: SandboxConfigurationComponent
+        },
+        {
+          path: 'new',
+          pathMatch: 'prefix',
+          data: {
+            breadcrumb: { translate: 'sandbox-config.new-sandbox.header' }
+          },
+          children: [
+            {
+              path: '',
+              pathMatch: 'prefix',
+              component: NewSandboxConfigurationComponent
+            }
+          ]
         }
       ]
     }

--- a/webapp/src/main/webapp/src/app/home/admin-tools.component.html
+++ b/webapp/src/main/webapp/src/app/home/admin-tools.component.html
@@ -14,5 +14,15 @@
         </div>
       </ng-container>
     </ng-container>
+    <!-- TODO: Add hasPermission check once roles/permissions for TENANT_ADMIN have been configured -->
+    <div class="col-xs-4 mb-sm admin-tool">
+      <a routerLink="/sandbox" class="btn btn-primary btn-xs mb-xs">
+        <i class="fa fa-cog"></i>
+        {{ 'home.admin-tools.sandbox-config.button' | translate }}
+      </a>
+      <p class="small">
+        {{ 'home.admin-tools.sandbox-config.description' | translate }}
+      </p>
+    </div>
   </div>
 </div>

--- a/webapp/src/main/webapp/src/app/home/admin-tools.component.html
+++ b/webapp/src/main/webapp/src/app/home/admin-tools.component.html
@@ -16,7 +16,7 @@
     </ng-container>
     <!-- TODO: Add hasPermission check once roles/permissions for TENANT_ADMIN have been configured -->
     <div class="col-xs-4 mb-sm admin-tool">
-      <a routerLink="/sandbox" class="btn btn-primary btn-xs mb-xs">
+      <a routerLink="/sandboxes" class="btn btn-primary btn-xs mb-xs">
         <i class="fa fa-cog"></i>
         {{ 'home.admin-tools.sandbox-config.button' | translate }}
       </a>

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -857,6 +857,35 @@
     },
     "title": "Manage Embargo"
   },
+  "sandbox-config": {
+    "title": "Sandbox Configuration",
+    "new-sandbox": {
+      "header": "Create New Sandbox"
+    },
+    "delete-modal": {
+      "header": "Delete <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to delete the sandbox <strong>{{label}}</strong>?"
+    },
+    "archive-modal": {
+      "header": "Archive <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to archive the sandbox <strong>{{label}}</strong>?",
+      "archive": "Archive"
+    },
+    "reset-modal": {
+      "header": "Reset data for <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to reset the data for the the sandbox <strong>{{label}}</strong>?",
+      "reset": "Reset Data"
+    },
+    "fields": {
+      "label": "Sandbox Name / Label:",
+      "description": "Description:",
+      "data-template": "Data Template:",
+      "select-template": "-- Select Template --",
+      "configuration-properties": "Configuration Properties",
+      "localization-overrides": "Localization Overrides",
+      "search": "Search by key or value"
+    }
+  },
   "embargo-alert": {
     "message": "Summative test results in your region of administration are not yet released. These results may be viewed online but not downloaded."
   },
@@ -991,6 +1020,10 @@
       "student-groups": {
         "button": "Student Groups",
         "description": "Create and manage student groups for teachers."
+      },
+      "sandbox-config": {
+        "button": "Sandbox Configuration",
+        "description": "Manage Reporting System Sandboxes"
       },
       "titles": {
         "administrator-tools": "Administrator Tools"

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -760,6 +760,124 @@ aggregate-report-table {
   }
 }
 
+.sandbox-config {
+  .action-buttons {
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+  .property-input {
+    width: 98%;
+  }
+
+  .sandbox-container {
+    border-bottom: 1px solid @gray-light;
+    margin-top: 5px;
+
+    .sandbox-header {
+      .sandbox-key {
+        color: @gray;
+        font-size: 20px;
+      }
+
+      i {
+        cursor: pointer;
+
+        &:hover {
+          color: @teal;
+        }
+      }
+
+      h2 {
+        display: inline;
+      }
+
+      h4,
+      h5 {
+        color: @gray-darker;
+      }
+
+      button {
+        cursor: pointer;
+      }
+    }
+
+    a.ui-menuitem-link {
+      margin-left: 10px;
+
+      .ui-menuitem-icon {
+        margin-right: 10px;
+      }
+    }
+
+    .form-group {
+      margin-top: 35px;
+    }
+  }
+
+  .ui-table-caption {
+    i {
+      margin: 4px 8px 0 4px;
+    }
+
+    div {
+      text-align: left;
+
+      input {
+        width: calc(100% - 30px);
+        display: inline;
+      }
+    }
+  }
+
+  .ui-table {
+    tr.modified td {
+      background-color: #d1e8f0;
+    }
+
+    i {
+      cursor: pointer;
+      color: @aqua;
+
+      &:hover {
+        color: @teal;
+      }
+    }
+  }
+
+  .ui-accordion {
+    .ui-accordion-header {
+      a {
+        text-decoration: none;
+      }
+    }
+
+    .ui-accordion-header-text,
+    .ui-accordion-toggle-icon {
+      color: @aqua;
+    }
+
+    .ui-accordion-header.ui-state-active {
+      background-color: @aqua;
+
+      .ui-accordion-header-text,
+      .ui-accordion-toggle-icon {
+        color: @white;
+      }
+    }
+  }
+
+  td {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  textarea {
+    resize: none;
+  }
+}
+
 .disabled-table-container {
   .disabled-table {
     cursor: not-allowed;

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -767,7 +767,7 @@ aggregate-report-table {
   }
 
   .property-input {
-    width: 98%;
+    width: 100%;
   }
 
   .sandbox-container {
@@ -835,13 +835,34 @@ aggregate-report-table {
       background-color: #d1e8f0;
     }
 
-    i {
-      cursor: pointer;
-      color: @aqua;
+    td {
+      i {
+        cursor: pointer;
+        color: @aqua;
+        margin-left: -10px;
 
-      &:hover {
-        color: @teal;
+        &:hover {
+          color: @teal;
+        }
       }
+    }
+
+    .ui-paginator-pages {
+      .ui-state-active {
+        background-color: @aqua;
+
+        &:hover {
+          background-color: @teal;
+        }
+      }
+
+      .ui-paginator-page:not(.ui-state-active) {
+        color: @aqua;
+      }
+    }
+
+    .ui-paginator-icon {
+      color: @aqua;
     }
   }
 


### PR DESCRIPTION
- Stubbing out backend calls - `sandbox.service.ts` will be completely reworked once the APIs are ready
- Temporarily keeping sandbox configuration mockData in memory - added TODOs to remove these mocks once backend is in place and integration is complete
- No integration for "Configuration Properties" section yet - this will be done in a separate PR
- For now, all sandboxes are editable in a single screen. May refactor this and create a completely separate screen for edit depending on client feedback next week