### PR TITLE
RP-278	Reporting - Make S3 Interactions multi-tenant aware

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/TenantPathService.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/TenantPathService.java
@@ -1,0 +1,30 @@
+package org.opentestsystem.rdw.reporting.common.multitenant;
+
+import org.opentestsystem.rdw.multitenant.storage.TenantPathDefaultResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Strategy pattern to find the current tenant storage Path.  The goal being to abstract implementation
+ * variations away such as SecurityContext or TenantContextHolder
+ */
+@Service
+public class TenantPathService {
+    private TenantPathDefaultResolver tenantPathResolver;
+
+    @Autowired
+    TenantPathService(TenantPathDefaultResolver tenantPathResolver) {
+        this.tenantPathResolver = tenantPathResolver;
+    }
+
+    public TenantPathDefaultResolver getTenantPathResolver() {
+        return tenantPathResolver;
+    }
+    public String getPrefix() {
+        return tenantPathResolver.getTenantPathOverride().getPrefix();
+    }
+
+    public String getRoot() {
+        return tenantPathResolver.getTenantPathOverride().getRoot();
+    }
+}

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportContentService.java
@@ -23,6 +23,7 @@ import static org.springframework.util.StringUtils.isEmpty;
 
 /**
  * This implementation of a ReportContentService is backed by an ArchiveService.
+ * Archive service is tenant aware setting needed tenant prefix
  */
 @Service
 public class ArchiveBackedReportContentService implements ReportContentService {

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportService.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportService.java
@@ -2,7 +2,9 @@ package org.opentestsystem.rdw.reporting.processor.service;
 
 import com.amazonaws.services.s3.Headers;
 import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.multitenant.storage.TenantPathResolver;
 import org.opentestsystem.rdw.reporting.common.model.DistrictSchoolExportReportQuery;
+import org.opentestsystem.rdw.reporting.common.multitenant.TenantPathService;
 import org.opentestsystem.rdw.reporting.common.util.MediaTypes;
 import org.opentestsystem.rdw.reporting.common.security.User;
 import org.opentestsystem.rdw.reporting.processor.repository.ExamRepository;
@@ -20,15 +22,19 @@ public class ArchiveExamExportService implements ExamExportService {
     private static final String FileNameFormat = FileNamePrefix + "-%d.csv";
 
     // store exam exports near the other user reports
-    static final String ExportBasePath = ArchiveBackedReportContentService.BasePath + "EXAM-EXPORT/";
+    // Tenancy handled at the top level
+    private final String ExportBasePath = ArchiveBackedReportContentService.BasePath + "EXAM-EXPORT/";
 
     private final ExamRepository repository;
     private final ArchiveService archiveService;
+    private final TenantPathService tenantPathService;
 
+    // Tenancy handled at the top level
     @Autowired
-    ArchiveExamExportService(final ExamRepository repository, final ArchiveService archiveService) {
+    ArchiveExamExportService(final ExamRepository repository, final ArchiveService archiveService, final TenantPathService tenantPathService) {
         this.repository = repository;
         this.archiveService = archiveService;
+        this.tenantPathService = tenantPathService;
     }
 
     @Override
@@ -43,15 +49,17 @@ public class ArchiveExamExportService implements ExamExportService {
 
         return location;
     }
-
+    public String getExportBasePath() {
+        return tenantPathService.getPrefix() + "/" + ExportBasePath;
+    }
     private URI getFullyQualifiedUri(final long reportId) {
         return URI.create(archiveService
-                .getRawUri(ExportBasePath + String.format(FileNameFormat, reportId))
+                .getRawUri(getExportBasePath() + String.format(FileNameFormat, reportId))
                 .replace(FileSchemePrefix, "/")
         );
     }
 
     private URI getRelativeUri(final String uri) {
-        return URI.create(uri.substring(uri.indexOf(ExportBasePath + FileNamePrefix)));
+        return URI.create(uri.substring(uri.indexOf(getExportBasePath() + FileNamePrefix)));
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportServiceTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveExamExportServiceTest.java
@@ -1,13 +1,14 @@
 package org.opentestsystem.rdw.reporting.processor.service;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.multitenant.storage.TenantPathDefaultResolver;
 import org.opentestsystem.rdw.reporting.common.model.DistrictSchoolExportReportQuery;
+import org.opentestsystem.rdw.reporting.common.multitenant.TenantPathService;
 import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
 import org.opentestsystem.rdw.reporting.common.security.User;
 import org.opentestsystem.rdw.reporting.processor.repository.ExamRepository;
@@ -29,20 +30,35 @@ public class ArchiveExamExportServiceTest {
     @Mock
     private ArchiveService archiveService;
 
+    @Mock
+    private TenantPathService tenantPathService;
+
     private ArchiveExamExportService examExportService;
+
     private final User validUser = individual(statewide());
     private final User emptyPermissions = user();
 
     // service builds a report filename using the report id
-    private static final String FileName = "export-exam-1.csv";
-    private static final String RelativePath = ArchiveExamExportService.ExportBasePath + FileName;
+    private final String FileName = "export-exam-1.csv";
+    private final String S3Protocol = "s3://bucket/";
+    private final String DefaultPrefix = "";
+    private final String TenantPrefix = "NV";
+    private String rootPath;
+    private String RelativePath;
 
-    @Before
-    public void setup() {
-        examExportService = new ArchiveExamExportService(repository, archiveService);
+    //private TenantPathDefaultResolver tenantPathResolver = new TenantPathDefaultResolver();
+
+
+    // Sets up examExportService and paths
+    private void setupExportService(String prefix) {
+        when(tenantPathService.getPrefix()).thenReturn(prefix);
+        examExportService = new ArchiveExamExportService(repository, archiveService, tenantPathService);
+        rootPath = examExportService.getExportBasePath();
+        RelativePath = rootPath + FileName;
     }
 
-    private void setupFileArchiveTest() {
+    // File Archive methods
+    private void setupFileArchiveTest () {
         when(archiveService.getRawUri(RelativePath))
                 .thenReturn("file://" + RelativePath);
 
@@ -50,24 +66,64 @@ public class ArchiveExamExportServiceTest {
                 .thenAnswer((Answer<String>) invocationOnMock -> (String) invocationOnMock.getArguments()[2]);
     }
 
+    private void setupFileArchiveDefaultTest () {
+        setupExportService(DefaultPrefix);
+        setupFileArchiveTest();
+    }
+
+    private void setupFileArchiveTenantTest () {
+        setupExportService(TenantPrefix);
+        setupFileArchiveTest();
+    }
+
+    // S3 setup methods
     private void setupS3ArchiveTest() {
         when(archiveService.getRawUri(RelativePath))
-                .thenReturn("s3://bucket/" + RelativePath);
+                .thenReturn(S3Protocol + RelativePath);
 
         when(repository.export(any(PermissionSource.class), any(DistrictSchoolExportReportQuery.class), anyString()))
                 .thenAnswer((Answer<String>) invocationOnMock -> invocationOnMock.getArguments()[2] + ".part_0000");
     }
 
+    private void setupS3ArchiveDefaultTenantTest() {
+        setupExportService(DefaultPrefix);
+        setupS3ArchiveTest();
+    }
+
+    private void setupS3ArchiveTenantTest() {
+        setupExportService(TenantPrefix);
+        setupS3ArchiveTest();
+    }
+
     @Test
     public void itShouldReturnFileRelativeLocation() {
-        setupFileArchiveTest();
+        setupFileArchiveDefaultTest();
+        assertThat(examExportService.exportExams(validUser, new DistrictSchoolExportReportQuery(), 1).toASCIIString())
+                .isEqualToIgnoringCase(RelativePath);
+    }
+
+
+    @Test
+    public void itShouldReturnFileRelativeLocationWithTenantSet() {
+        setupFileArchiveTenantTest();
         assertThat(examExportService.exportExams(validUser, new DistrictSchoolExportReportQuery(), 1).toASCIIString())
                 .isEqualToIgnoringCase(RelativePath);
     }
 
     @Test
     public void itShouldPassQueryAndTrimFileSchemaWhenCallingRepo() {
-        setupFileArchiveTest();
+        setupFileArchiveDefaultTest();
+
+        final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
+
+        assertThat(examExportService.exportExams(validUser, query, 1).toASCIIString())
+                .isEqualToIgnoringCase(RelativePath);
+        verify(repository).export(validUser, query, "/" + RelativePath);
+    }
+
+    @Test
+    public void itShouldPassQueryAndTrimFileSchemaWhenCallingRepoWithTenantSet() {
+        setupFileArchiveTenantTest();
 
         final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
 
@@ -78,18 +134,41 @@ public class ArchiveExamExportServiceTest {
 
     @Test
     public void itShouldNotTrimS3SchemaWhenPassingToRepo() {
-        setupS3ArchiveTest();
+        setupS3ArchiveDefaultTenantTest();
 
         final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
 
         assertThat(examExportService.exportExams(validUser, query, 1).toASCIIString())
                 .isEqualToIgnoringCase(RelativePath + ".part_0000");
-        verify(repository).export(validUser, query, "s3://bucket/" + RelativePath);
+        verify(repository).export(validUser, query, S3Protocol + RelativePath);
+    }
+
+
+    @Test
+    public void itShouldNotTrimS3SchemaWhenPassingToRepoWithTenantSet() {
+        setupS3ArchiveTenantTest();
+
+        final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
+
+        assertThat(examExportService.exportExams(validUser, query, 1).toASCIIString())
+                .isEqualToIgnoringCase(RelativePath + ".part_0000");
+        verify(repository).export(validUser, query, S3Protocol + RelativePath);
     }
 
     @Test
     public void itShouldPassEmptyPermissionScopeWhenUserPermissionsIsEmpty() {
-        setupFileArchiveTest();
+        setupFileArchiveDefaultTest();
+
+        final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
+
+        assertThat(examExportService.exportExams(emptyPermissions, query, 1).toASCIIString())
+                .isEqualToIgnoringCase(RelativePath);
+        verify(repository).export(emptyPermissions, query, "/" + RelativePath);
+    }
+
+    @Test
+    public void itShouldPassEmptyPermissionScopeWhenUserPermissionsIsEmptyWithTenantSet() {
+        setupFileArchiveTenantTest();
 
         final DistrictSchoolExportReportQuery query = new DistrictSchoolExportReportQuery();
 

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/artifact/AmazonS3ArtifactRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/artifact/AmazonS3ArtifactRepository.java
@@ -9,6 +9,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
 
+
+/*
+Instance wide, doesn't need to be tenant aware.
+ */
 @Repository
 public class AmazonS3ArtifactRepository implements ArtifactRepository {
     private ArtifactRepositorySettings properties;

--- a/reporting-service/src/main/resources/application.yml
+++ b/reporting-service/src/main/resources/application.yml
@@ -98,6 +98,7 @@ cloud:
       auto: false
 
 artifacts:
+  # This is an instance wide config, and not tenant aware
   #Root location of assessment files [s3://some-bucket/ | classpath: | etc]
   root: ${rdw.resource.root:"classpath:"}
   exam-item:


### PR DESCRIPTION
Using Common TenantPathResolver to set tenant path for S3 and local archives
defaulting "" to keep as much as the same as before.
