### PR TITLE
Sandbox/Tenant Configuration Bugfixes

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
@@ -15,6 +15,7 @@ import { SandboxService } from '../service/sandbox.service';
 import { ApplicationSettingsService } from '../../../app-settings.service';
 import { flattenJsonObject } from '../../../shared/support/support';
 import { TranslateService } from '@ngx-translate/core';
+import { CustomValidators } from '../../../shared/validator/custom-validators';
 
 @Component({
   selector: 'sandbox-details-config',
@@ -48,7 +49,7 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.sandboxForm = this.formBuilder.group({
-      label: [this.sandbox.label, Validators.required],
+      label: [this.sandbox.label, CustomValidators.required],
       description: [this.sandbox.description],
       configurationProperties: this.formBuilder.array([]),
       localizationOverrides: this.formBuilder.array([])

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/tenant-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/tenant-details.component.ts
@@ -15,6 +15,7 @@ import { flattenJsonObject } from '../../../shared/support/support';
 import { TranslateService } from '@ngx-translate/core';
 import { TenantConfiguration } from '../model/tenant-configuration';
 import { TenantService } from '../service/tenant.service';
+import { CustomValidators } from '../../../shared/validator/custom-validators';
 
 @Component({
   selector: 'tenant-details-config',
@@ -44,7 +45,7 @@ export class TenantConfigurationDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.tenantForm = this.formBuilder.group({
-      label: [this.tenant.label, Validators.required],
+      label: [this.tenant.label, CustomValidators.required],
       description: [this.tenant.description],
       configurationProperties: this.formBuilder.array([]),
       localizationOverrides: this.formBuilder.array([])

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
@@ -13,6 +13,7 @@ import { RdwTranslateLoader } from '../../../shared/i18n/rdw-translate-loader';
 import { ConfigurationProperty } from '../model/configuration-property';
 import { ApplicationSettingsService } from '../../../app-settings.service';
 import { flattenJsonObject } from '../../../shared/support/support';
+import { CustomValidators } from '../../../shared/validator/custom-validators';
 
 @Component({
   selector: 'new-sandbox',
@@ -36,7 +37,7 @@ export class NewSandboxConfigurationComponent {
 
   ngOnInit(): void {
     this.sandboxForm = this.formBuilder.group({
-      label: [null, Validators.required],
+      label: [null, CustomValidators.required],
       description: [null],
       dataSet: [null, Validators.required],
       configurationProperties: this.formBuilder.array([]),

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
@@ -12,6 +12,7 @@ import { RdwTranslateLoader } from '../../../shared/i18n/rdw-translate-loader';
 import { ConfigurationProperty } from '../model/configuration-property';
 import { ApplicationSettingsService } from '../../../app-settings.service';
 import { flattenJsonObject } from '../../../shared/support/support';
+import { CustomValidators } from '../../../shared/validator/custom-validators';
 
 @Component({
   selector: 'new-tenant',
@@ -34,9 +35,8 @@ export class NewTenantConfigurationComponent {
 
   ngOnInit(): void {
     this.tenantForm = this.formBuilder.group({
-      label: [null, Validators.required],
+      label: [null, CustomValidators.required],
       description: [null],
-      template: [null, Validators.required],
       configurationProperties: this.formBuilder.array([]),
       localizationOverrides: this.formBuilder.array([])
     });

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/sandbox.component.html
@@ -21,5 +21,8 @@
         (resetDataClicked)="openResetDataModal(sandbox)"
       ></sandbox-details-config>
     </div>
+    <div *ngIf="sandboxes.length === 0">
+      <h3>{{ 'sandbox-config.empty' | translate }}</h3>
+    </div>
   </div>
 </div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/tenant.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/tenant.component.html
@@ -19,5 +19,8 @@
         (deleteClicked)="openDeleteTenantModal(tenant)"
       ></tenant-details-config>
     </div>
+    <div *ngIf="tenants.length === 0">
+      <h3>{{ 'tenant-config.empty' | translate }}</h3>
+    </div>
   </div>
 </div>

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/tenant.component.ts
@@ -32,8 +32,8 @@ export class TenantConfigurationComponent {
     let modal: DeleteTenantConfigurationModalComponent = modalReference.content;
     modal.tenant = tenant;
     this._modalSubscriptions.push(
-      modal.deleted.subscribe(sandbox => {
-        console.log(sandbox);
+      modal.deleted.subscribe(tenant => {
+        console.log(tenant);
       })
     );
   }

--- a/webapp/src/main/webapp/src/app/shared/validator/custom-validators.ts
+++ b/webapp/src/main/webapp/src/app/shared/validator/custom-validators.ts
@@ -1,0 +1,20 @@
+import { FormControl, ValidationErrors } from '@angular/forms';
+import { isString } from 'lodash';
+
+export class CustomValidators {
+  /**
+   * A static validator that trims input before checking if it is null or an empty string
+   * @param control
+   * @returns an error if the control value is null, or is composed of only whitespace
+   */
+  static required(control: FormControl): ValidationErrors | null {
+    return CustomValidators.isBlank(control.value) ||
+      (isString(control.value) && control.value.trim() == '')
+      ? { required: true }
+      : null;
+  }
+
+  private static isBlank(value: string): boolean {
+    return value == null || value.trim().length === 0;
+  }
+}

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -890,7 +890,8 @@
     "config-properties": {
       "modified": "Show modified properties only",
       "empty": "No configuration properties found"
-    }
+    },
+    "empty": "No sandbox configurations found. Create a new tenant by clicking the \"Create New Sandbox\" button"
   },
   "tenant-config": {
     "title": "Tenant Configuration",
@@ -907,7 +908,8 @@
       "configuration-properties": "Configuration Properties",
       "localization-overrides": "Localization Overrides",
       "search": "Search by key or value"
-    }
+    },
+    "empty": "No tenant configurations found. Create a new tenant by clicking the \"Create New Tenant\" button"
   },
   "embargo-alert": {
     "message": "Summative test results in your region of administration are not yet released. These results may be viewed online but not downloaded."

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -797,6 +797,7 @@ aggregate-report-table {
       h4,
       h5 {
         color: @gray-darker;
+        white-space: pre;
       }
 
       button {


### PR DESCRIPTION
- Fixing issue where line breaks were not being displayed for the description despite the textarea allowing linebreaks when editing
- Creating a custom validator to trim control values before checking for null/empty string (surprised the standard angular validator does not already do this!)
- Adding a nice message for when there are no sandboxes/tenants to display