### PR TITLE
Add landingPageUrl to reporting: used in org.opentestsystem.rdw.repor…

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
@@ -33,6 +33,13 @@ public interface ReportingSystemProperties {
     String getAccessDeniedUrl();
 
     /**
+     * Note: This is webapp specific
+     *
+     * @return The landing page url
+     */
+    String getLandingPageUrl();
+
+    /**
      * Note: This is webapp (reporting-service section) specific
      *
      * @return Iris vendor ID

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesImpl.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesImpl.java
@@ -13,6 +13,7 @@ public class ReportingSystemPropertiesImpl extends AbstractReportingSystemProper
     private String analyticsTrackingId;
     private String interpretiveGuideUrl;
     private String accessDeniedUrl;
+    private String landingPageUrl;
     private String irisVendorId;
     private Integer minItemDataYear;
     private Boolean percentileDisplayEnabled;
@@ -51,6 +52,15 @@ public class ReportingSystemPropertiesImpl extends AbstractReportingSystemProper
 
     public void setAccessDeniedUrl(String accessDeniedUrl) {
         this.accessDeniedUrl = accessDeniedUrl;
+    }
+
+    @Override
+    public String getLandingPageUrl() {
+        return landingPageUrl;
+    }
+
+    public void setLandingPageUrl(String landingPageUrl) {
+        this.landingPageUrl = landingPageUrl;
     }
 
     @Override

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolver.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolver.java
@@ -57,6 +57,14 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
 
     @Override
     @JsonView(ReportingSystemPropertiesJsonViews.Public.class)
+    public String getLandingPageUrl(){
+        return getResolvedReportingSystemProperties()
+                .map(ReportingSystemProperties::getLandingPageUrl)
+                .orElse(reportingSystemSettings.getLandingPageUrl());
+    }
+
+    @Override
+    @JsonView(ReportingSystemPropertiesJsonViews.Public.class)
     public String getIrisVendorId() {
         return getResolvedReportingSystemProperties()
                 .map(ReportingSystemProperties::getIrisVendorId)

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemSettings.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemSettings.java
@@ -13,6 +13,7 @@ public class ReportingSystemSettings extends AbstractReportingSystemProperties {
     private String analyticsTrackingId;
     private String interpretiveGuideUrl;
     private String accessDeniedUrl;
+    private String landingPageUrl;
     private String irisVendorId;
     private Integer minItemDataYear;
     private Boolean percentileDisplayEnabled;
@@ -52,6 +53,15 @@ public class ReportingSystemSettings extends AbstractReportingSystemProperties {
 
     public void setAccessDeniedUrl(final String accessDeniedUrl) {
         this.accessDeniedUrl = accessDeniedUrl;
+    }
+
+    @Override
+    public String getLandingPageUrl() {
+        return landingPageUrl;
+    }
+
+    public void setLandingPageUrl(String landingPageUrl) {
+        this.landingPageUrl = landingPageUrl;
     }
 
     @Override


### PR DESCRIPTION
…ting.web.ViewController and in .yml files, missing from ReportingSystemProperties.