### PR TITLE
Fixing bugs related to pagination

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.html
@@ -9,6 +9,7 @@
       [globalFilterFields]="['key', 'value']"
       styleClass="table table-striped table-hover overflow rdw-scrollable-table"
       [paginator]="true"
+      [(first)]="first"
       [alwaysShowPaginator]="false"
       [rows]="20"
     >
@@ -44,7 +45,7 @@
           <th>Value</th>
         </tr>
       </ng-template>
-      <ng-template pTemplate="body" let-overrides let-i="rowIndex">
+      <ng-template pTemplate="body" let-overrides>
         <tr
           [ngClass]="{
             modified: overrides.value !== overrides.originalValue
@@ -57,9 +58,9 @@
               #overrideInput
               type="text"
               [value]="overrides.value"
-              [formControlName]="i"
+              [formControlName]="overrides.key"
               class="property-input"
-              (change)="updateOverride(overrides, i)"
+              (change)="updateOverride(overrides)"
             />
             <i
               class="fa fa-undo fa-md"

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { ConfigurationProperty } from '../model/configuration-property';
-import { FormArray, FormGroup } from '@angular/forms';
-import { cloneDeep } from 'lodash';
+import { FormGroup } from '@angular/forms';
 import { DataTable } from 'primeng/primeng';
 
 @Component({

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
@@ -55,7 +55,7 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
       .getFlattenedTranslations('en')
       .subscribe(translations => {
         for (let key in translations) {
-          let locationOverrideFormArray = <FormArray>(
+          let locationOverrideFormGroup = <FormGroup>(
             this.sandboxForm.controls['localizationOverrides']
           );
           if (translations.hasOwnProperty(key)) {
@@ -73,14 +73,14 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
                   override.originalValue
                 )
               );
-              locationOverrideFormArray.controls.push(
-                new FormControl(override.value)
+              locationOverrideFormGroup.controls[key] = new FormControl(
+                override.value
               );
             } else {
               this.localizationOverrides.push(
                 new ConfigurationProperty(key, value)
               );
-              locationOverrideFormArray.controls.push(new FormControl(value));
+              locationOverrideFormGroup.controls[key] = new FormControl(value);
             }
           }
         }

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/sandbox-details.component.ts
@@ -43,7 +43,7 @@ export class SandboxConfigurationDetailsComponent implements OnInit {
       label: [this.sandbox.label, CustomValidators.notBlank],
       description: [this.sandbox.description],
       configurationProperties: this.formBuilder.group({}),
-      localizationOverrides: this.formBuilder.array([])
+      localizationOverrides: this.formBuilder.group({})
     });
     this.mapLocalizationOverrides();
     this.configureMenuItems();

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/tenant-details.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/tenant-details.component.ts
@@ -29,8 +29,6 @@ export class TenantConfigurationDetailsComponent implements OnInit, OnChanges {
   tenant: TenantConfiguration;
   @Output()
   deleteClicked: EventEmitter<TenantConfiguration> = new EventEmitter();
-  // @Output()
-  // tenantUpdated: EventEmitter<TenantConfiguration> = new EventEmitter();
 
   expanded = false;
   editMode = false;
@@ -121,14 +119,14 @@ export class TenantConfigurationDetailsComponent implements OnInit, OnChanges {
         label: [this.tenant.label, CustomValidators.notBlank],
         description: [this.tenant.description],
         configurationProperties: this.formBuilder.group({}),
-        localizationOverrides: this.formBuilder.array([])
+        localizationOverrides: this.formBuilder.group({})
       });
     }
   }
 
   private mapLocalizationOverrides(localizationDefaults: any): void {
     for (let key in localizationDefaults) {
-      let locationOverrideFormArray = <FormArray>(
+      let locationOverrideFormGroup = <FormGroup>(
         this.tenantForm.controls['localizationOverrides']
       );
       if (localizationDefaults.hasOwnProperty(key)) {
@@ -141,14 +139,14 @@ export class TenantConfigurationDetailsComponent implements OnInit, OnChanges {
           this.localizationOverrides.push(
             new ConfigurationProperty(key, override.value, value)
           );
-          locationOverrideFormArray.controls.push(
-            new FormControl(override.value)
+          locationOverrideFormGroup.controls[key] = new FormControl(
+            override.value
           );
         } else {
           this.localizationOverrides.push(
             new ConfigurationProperty(key, value)
           );
-          locationOverrideFormArray.controls.push(new FormControl(value));
+          locationOverrideFormGroup.controls[key] = new FormControl(value);
         }
       }
     }

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.html
@@ -13,6 +13,7 @@
         </div>
         <div class="col-md-8">
           <input
+            #sandboxLabelInput
             type="text"
             class="form-control"
             name="label"

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
@@ -48,7 +48,7 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
       description: [null],
       dataSet: [null, Validators.required],
       configurationProperties: this.formBuilder.group({}),
-      localizationOverrides: this.formBuilder.array([])
+      localizationOverrides: this.formBuilder.group({})
     });
 
     this.service.getAvailableDataSets().subscribe(dataSets => {
@@ -73,7 +73,7 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
     this.translationLoader
       .getFlattenedTranslations('en')
       .subscribe(translations => {
-        let locationOverrideFormArray = <FormArray>(
+        let locationOverrideFormGroup = <FormGroup>(
           this.sandboxForm.controls['localizationOverrides']
         );
         for (let key in translations) {
@@ -83,7 +83,7 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
             this.localizationOverrides.push(
               new ConfigurationProperty(key, value)
             );
-            locationOverrideFormArray.controls.push(new FormControl(value));
+            locationOverrideFormGroup.controls[key] = new FormControl(value);
           }
         }
       });
@@ -103,37 +103,5 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
     };
     this.service.create(newSandbox);
     this.router.navigate(['sandboxes']);
-  }
-
-  updateOverride(override: ConfigurationProperty, index: number): void {
-    const overrides = <FormArray>(
-      this.sandboxForm.controls['localizationOverrides']
-    );
-    const newVal = overrides.controls[index].value;
-
-    if (this.localizationOverrides.indexOf(override) > -1) {
-      let existingOverride = this.localizationOverrides[
-        this.localizationOverrides.indexOf(override)
-      ];
-      existingOverride.value = newVal;
-    } else {
-      override.value = newVal;
-      this.localizationOverrides.push(override);
-    }
-  }
-
-  updateConfigurationProperty(
-    property: ConfigurationProperty,
-    index: number
-  ): void {
-    const properties = <FormArray>(
-      this.sandboxForm.controls['configurationProperties']
-    );
-    const newVal = properties.controls[index].value;
-
-    let existingProperty = this.configurationProperties[
-      this.configurationProperties.indexOf(property)
-    ];
-    existingProperty.value = newVal;
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
@@ -1,4 +1,10 @@
-import { Component } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import { Router } from '@angular/router';
 import { DataSet } from '../model/sandbox-configuration';
 import { SandboxService } from '../service/sandbox.service';
@@ -18,13 +24,16 @@ import { mapConfigurationProperties } from '../mapper/tenant.mapper';
   selector: 'new-sandbox',
   templateUrl: './new-sandbox.component.html'
 })
-export class NewSandboxConfigurationComponent {
+export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
   dataSets: DataSet[];
   sandboxForm: FormGroup;
   // Contains the full list of localization overrides, with default values
   localizationOverrides: ConfigurationProperty[] = [];
   // Contains the full list of configuration properties, with default values
   configurationProperties: any;
+
+  @ViewChild('sandboxLabelInput')
+  sandboxLabelInput: ElementRef;
 
   constructor(
     private service: SandboxService,
@@ -54,6 +63,10 @@ export class NewSandboxConfigurationComponent {
             configProperties
           ))
       );
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.sandboxLabelInput.nativeElement.focus());
   }
 
   private mapLocalizationOverrides() {

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.html
@@ -13,6 +13,7 @@
         </div>
         <div class="col-md-8">
           <input
+            #tenantKeyInput
             onkeyup="this.value = this.value.toUpperCase();"
             type="text"
             class="form-control"

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
@@ -62,7 +62,7 @@ export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
       label: [null, CustomValidators.notBlank],
       description: [null],
       configurationProperties: this.formBuilder.group({}),
-      localizationOverrides: this.formBuilder.array([])
+      localizationOverrides: this.formBuilder.group({})
     });
 
     this.mapLocalizationOverrides();
@@ -101,44 +101,12 @@ export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
     );
   }
 
-  updateOverride(override: ConfigurationProperty, index: number): void {
-    const overrides = <FormArray>(
-      this.tenantForm.controls['localizationOverrides']
-    );
-    const newVal = overrides.controls[index].value;
-
-    if (this.localizationOverrides.indexOf(override) > -1) {
-      let existingOverride = this.localizationOverrides[
-        this.localizationOverrides.indexOf(override)
-      ];
-      existingOverride.value = newVal;
-    } else {
-      override.value = newVal;
-      this.localizationOverrides.push(override);
-    }
-  }
-
-  updateConfigurationProperty(
-    property: ConfigurationProperty,
-    index: number
-  ): void {
-    const properties = <FormArray>(
-      this.tenantForm.controls['configurationProperties']
-    );
-    const newVal = properties.controls[index].value;
-
-    let existingProperty = this.configurationProperties[
-      this.configurationProperties.indexOf(property)
-    ];
-    existingProperty.value = newVal;
-  }
-
   private mapLocalizationOverrides() {
     this.translationLoader
       // TODO: Use the proper configured language code, do not hardcode english
       .getFlattenedTranslations('en')
       .subscribe(translations => {
-        let locationOverrideFormArray = <FormArray>(
+        let locationOverrideFormGroup = <FormGroup>(
           this.tenantForm.controls['localizationOverrides']
         );
         for (let key in translations) {
@@ -148,7 +116,7 @@ export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
             this.localizationOverrides.push(
               new ConfigurationProperty(key, value)
             );
-            locationOverrideFormArray.controls.push(new FormControl(value));
+            locationOverrideFormGroup.controls[key] = new FormControl(value);
           }
         }
       });

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
@@ -1,4 +1,10 @@
-import { Component, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import { Router } from '@angular/router';
 import { TenantService } from '../service/tenant.service';
 import {
@@ -20,7 +26,7 @@ import { TenantStore } from '../store/tenant.store';
   selector: 'new-tenant',
   templateUrl: './new-tenant.component.html'
 })
-export class NewTenantConfigurationComponent {
+export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
   tenantForm: FormGroup;
   // Contains the full list of localization overrides, with default values
   localizationOverrides: ConfigurationProperty[] = [];
@@ -29,6 +35,9 @@ export class NewTenantConfigurationComponent {
 
   @ViewChild('configurationPropertiesTable')
   configurationPropertiesTable: PropertyOverrideTreeTableComponent;
+
+  @ViewChild('tenantKeyInput')
+  tenantKeyInput: ElementRef;
 
   constructor(
     private service: TenantService,
@@ -66,6 +75,10 @@ export class NewTenantConfigurationComponent {
             configProperties
           ))
       );
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.tenantKeyInput.nativeElement.focus());
   }
 
   onSubmit(): void {


### PR DESCRIPTION
- Fixing an issue where a user would get "trapped" in an empty page of the localization data table if they were on a high-numbered page and they attempted to filter by a small number of modified properties.
- Fixing another issue where array/index based form group and control manage was resulting in some weird behavior when filtering and modifying properties. Instead I switched over to using a `FormGroup` and referencing the form controls by their key
- Not related to pagination, but per Nohemi's request, I added code to focus to the first input element on the "Create New Sandbox" and "Create New Tenant" forms.