### PR TITLE
Fixing pagination bug in "New Tenant" and "New Sandbox" overrides datatable

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/component/property-override-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { ConfigurationProperty } from '../model/configuration-property';
 import { FormGroup } from '@angular/forms';
 import { DataTable } from 'primeng/primeng';
@@ -8,9 +8,27 @@ import { DataTable } from 'primeng/primeng';
   templateUrl: './property-override-table.component.html'
 })
 //TODO: Implement ControlValueAccessor
-export class PropertyOverrideTableComponent implements OnInit {
+export class PropertyOverrideTableComponent {
+  private _configurationProperties: ConfigurationProperty[] = [];
+
+  get configurationProperties(): ConfigurationProperty[] {
+    return this._configurationProperties;
+  }
+
   @Input()
-  configurationProperties: ConfigurationProperty[] = [];
+  set configurationProperties(
+    configurationProperties: ConfigurationProperty[]
+  ) {
+    this._configurationProperties = configurationProperties;
+
+    if (
+      !this.filteredConfigurationProperties &&
+      configurationProperties.length > 0
+    ) {
+      this.filteredConfigurationProperties = configurationProperties;
+    }
+  }
+
   @Input()
   propertiesArrayName: string;
   @Input()
@@ -18,14 +36,10 @@ export class PropertyOverrideTableComponent implements OnInit {
   @ViewChild('dt') dataTable: DataTable;
 
   showModifiedPropertiesOnly = false;
-  filteredConfigurationProperties: ConfigurationProperty[] = [];
+  filteredConfigurationProperties: ConfigurationProperty[];
   first = 0;
 
   constructor() {}
-
-  ngOnInit(): void {
-    this.filteredConfigurationProperties = this.configurationProperties;
-  }
 
   updateOverride(override: ConfigurationProperty): void {
     const formGroup = <FormGroup>this.form.controls[this.propertiesArrayName];

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.ts
@@ -11,7 +11,6 @@ import { SandboxService } from '../service/sandbox.service';
 import {
   FormBuilder,
   FormGroup,
-  FormArray,
   Validators,
   FormControl
 } from '@angular/forms';
@@ -54,7 +53,9 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
     this.service.getAvailableDataSets().subscribe(dataSets => {
       this.dataSets = dataSets;
     });
+
     this.mapLocalizationOverrides();
+
     this.service
       .getDefaultConfigurationProperties()
       .subscribe(
@@ -80,9 +81,10 @@ export class NewSandboxConfigurationComponent implements OnInit, AfterViewInit {
           // check also if property is not inherited from prototype
           if (translations.hasOwnProperty(key)) {
             let value = translations[key];
-            this.localizationOverrides.push(
+            this.localizationOverrides = [
+              ...this.localizationOverrides,
               new ConfigurationProperty(key, value)
-            );
+            ];
             locationOverrideFormGroup.controls[key] = new FormControl(value);
           }
         }

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.ts
@@ -10,7 +10,6 @@ import { TenantService } from '../service/tenant.service';
 import {
   FormBuilder,
   FormGroup,
-  FormArray,
   Validators,
   FormControl
 } from '@angular/forms';
@@ -103,7 +102,6 @@ export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
 
   private mapLocalizationOverrides() {
     this.translationLoader
-      // TODO: Use the proper configured language code, do not hardcode english
       .getFlattenedTranslations('en')
       .subscribe(translations => {
         let locationOverrideFormGroup = <FormGroup>(
@@ -113,9 +111,10 @@ export class NewTenantConfigurationComponent implements OnInit, AfterViewInit {
           // check also if property is not inherited from prototype
           if (translations.hasOwnProperty(key)) {
             let value = translations[key];
-            this.localizationOverrides.push(
+            this.localizationOverrides = [
+              ...this.localizationOverrides,
               new ConfigurationProperty(key, value)
-            );
+            ];
             locationOverrideFormGroup.controls[key] = new FormControl(value);
           }
         }


### PR DESCRIPTION
There was a timing issue causing the "New Tenant" page to render only a single page (unless the "modified" checkbox was toggled). The ngOnInit() of the child component was being called before we the parent component had actually provided the list of properties.