### PR TITLE
RP-366 Create Sandbox API/Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ out/
 .idea
 *.iws
 *.iml
-*.ipr
+*.DS_Store
 
 ### NetBeans ###
 nbproject/private/

--- a/admin-service/build.gradle
+++ b/admin-service/build.gradle
@@ -5,6 +5,7 @@ ext['groovy.version'] = '2.5.6'
 dependencies {
     compile project(':rdw-reporting-common')
     compile project(':rdw-reporting-common-web')
+    compile project(':rdw-reporting-aggregate-service')
     compile 'org.opentestsystem.rdw.common:rdw-common-archive'
     compile 'org.opentestsystem.rdw.common:rdw-common-group'
     compile 'org.opentestsystem.rdw.common:rdw-common-model'

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/ApplicationSandboxConfiguration.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/ApplicationSandboxConfiguration.java
@@ -1,0 +1,50 @@
+package org.opentestsystem.rdw.admin.model;
+
+import org.opentestsystem.rdw.multitenant.TenantProperties;
+import org.opentestsystem.rdw.olap.configuration.AggregateReportingPropertiesTenant;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
+
+import java.util.Set;
+
+/**
+ * All of the application Default properties for a Sandbox
+ */
+public class ApplicationSandboxConfiguration {
+    private TenantProperties.Tenant tenant; // Tenant used to create sandbox, and where sandbox exists
+    private Set<DataSet> dataSets; // collection of dataSets preconfigured for this tenant
+    private ReportingSystemPropertiesImpl reporting; // default Reporting system properties
+    private AggregateReportingPropertiesTenant aggregateReportingPropertiesTenant;
+
+
+    public ReportingSystemPropertiesImpl getReporting() {
+        return reporting;
+    }
+
+    public void setReporting(final ReportingSystemPropertiesImpl reporting) {
+        this.reporting = reporting;
+    }
+
+    public TenantProperties.Tenant getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(final TenantProperties.Tenant tenant) {
+        this.tenant = tenant;
+    }
+
+    public Set<DataSet> getDataSets() {
+        return dataSets;
+    }
+
+    public void setDataSets(final Set<DataSet> dataSets) {
+        this.dataSets = dataSets;
+    }
+
+    public AggregateReportingPropertiesTenant getAggregateReportingPropertiesTenant() {
+        return aggregateReportingPropertiesTenant;
+    }
+
+    public void setAggregateReportingPropertiesTenant(final AggregateReportingPropertiesTenant aggregateReportingPropertiesTenant) {
+        this.aggregateReportingPropertiesTenant = aggregateReportingPropertiesTenant;
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/ApplicationSandboxConfigurations.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/ApplicationSandboxConfigurations.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.admin.model;
+
+import java.util.Set;
+
+/**
+ * Used to return the default Tenant & Sandbox data with a current list of sandboxes
+ */
+public class ApplicationSandboxConfigurations {
+    private ApplicationSandboxConfiguration applicationSandboxConfiguration;
+    private Set<SandboxConfiguration> sandboxes;
+
+    public ApplicationSandboxConfiguration getApplicationSandboxConfiguration() {
+        return applicationSandboxConfiguration;
+    }
+
+    public void setApplicationSandboxConfiguration(final ApplicationSandboxConfiguration applicationSandboxConfiguration) {
+        this.applicationSandboxConfiguration = applicationSandboxConfiguration;
+    }
+
+    public Set<SandboxConfiguration> getSandboxes() {
+        return sandboxes;
+    }
+
+    public void setSandboxes(final Set<SandboxConfiguration> sandboxes) {
+        this.sandboxes = sandboxes;
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/DataSet.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/DataSet.java
@@ -1,0 +1,28 @@
+package org.opentestsystem.rdw.admin.model;
+
+/**
+ * DataSet is a preconfigured set of metadata the Sandbox uses.
+ */
+public class DataSet {
+    private String dataSet; // label name of the DataSet
+    private String key; // unique key
+
+    DataSet() {}
+
+    public String getDataSet() {
+        return dataSet;
+    }
+
+    public void setDataSet(final String dataSet) {
+        this.dataSet = dataSet;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/DataSet.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/DataSet.java
@@ -4,17 +4,17 @@ package org.opentestsystem.rdw.admin.model;
  * DataSet is a preconfigured set of metadata the Sandbox uses.
  */
 public class DataSet {
-    private String dataSet; // label name of the DataSet
+    private String label; // label name of the DataSet
     private String key; // unique key
 
     DataSet() {}
 
-    public String getDataSet() {
-        return dataSet;
+    public String getLabel() {
+        return label;
     }
 
-    public void setDataSet(final String dataSet) {
-        this.dataSet = dataSet;
+    public void setLabel(final String label) {
+        this.label = label;
     }
 
     public String getKey() {

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/Sandbox.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/Sandbox.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.rdw.admin.model;
+
+public class Sandbox {
+    private String id;
+    private String key;
+    private String name;
+    private String description;
+    private String tenantKey; // the tenant key used to create this sandbox
+    private String dataSetKey;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDecscription(final String description) {
+        this.description = description;
+    }
+
+    public String getTenantKey() {
+        return tenantKey;
+    }
+
+    public void setTenantKey(final String tenantKey) {
+        this.tenantKey = tenantKey;
+    }
+
+    public String getDataSetKey() {
+        return dataSetKey;
+    }
+
+    public void setDataSetKey(final String dataSetKey) {
+        this.dataSetKey = dataSetKey;
+    }
+
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfiguration.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfiguration.java
@@ -1,0 +1,52 @@
+package org.opentestsystem.rdw.admin.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opentestsystem.rdw.olap.configuration.AggregateReportingPropertiesTenant;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Properties & data used to create and update a Sandbox
+ */
+public class SandboxConfiguration {
+
+    private Sandbox sandbox;
+    private ReportingSystemPropertiesImpl reporting;
+    @JsonProperty("aggregator")
+    private AggregateReportingPropertiesTenant aggregateReportingPropertiesTenant;
+    private Map<String, String> localization = new LinkedHashMap<>();
+
+    public Sandbox getSandbox() {
+        return sandbox;
+    }
+
+    public void setSandbox(final Sandbox sandbox) {
+        this.sandbox = sandbox;
+    }
+
+    public ReportingSystemPropertiesImpl getReporting() {
+        return reporting;
+    }
+
+    public void setReporting(final ReportingSystemPropertiesImpl reporting) {
+        this.reporting = reporting;
+    }
+
+    public AggregateReportingPropertiesTenant getAggregateReportingPropertiesTenant() {
+        return aggregateReportingPropertiesTenant;
+    }
+
+    public void setAggregateReportingPropertiesTenant(final AggregateReportingPropertiesTenant aggregateReportingPropertiesTenant) {
+        this.aggregateReportingPropertiesTenant = aggregateReportingPropertiesTenant;
+    }
+
+    public Map<String, String> getLocalization() {
+        return localization;
+    }
+
+    public void setLocalization(final Map<String, String> localization) {
+        this.localization = localization;
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
@@ -25,17 +25,17 @@ public class SandboxConfigurationStubs {
     public static Set<DataSet> getDataSets() {
         Set<DataSet> dataSets = new HashSet<>();
         DataSet dataSetCa = new DataSet();
-        dataSetCa.setDataSet("California Interim Data Set");
+        dataSetCa.setLabel("California Interim Data Set");
         dataSetCa.setKey("ca_interim");
         dataSets.add(dataSetCa);
 
         DataSet dataSetMi = new DataSet();
-        dataSetMi.setDataSet("Michigan Summative Data Set");
+        dataSetMi.setLabel("Michigan Summative Data Set");
         dataSetMi.setKey("mi_summative");
         dataSets.add(dataSetMi);
 
         DataSet dataSetSbac = new DataSet();
-        dataSetSbac.setDataSet("SBAC Interim Data Set");
+        dataSetSbac.setLabel("SBAC Interim Data Set");
         dataSetSbac.setKey("sbac_interim");
         dataSets.add(dataSetMi);
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
@@ -1,0 +1,110 @@
+package org.opentestsystem.rdw.admin.model;
+
+import org.opentestsystem.rdw.olap.configuration.AggregateReportingPropertiesTenant;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * TODO This will be moved to test once full sandbox configurations are managed
+ */
+public class SandboxConfigurationStubs {
+
+    // Default Tenant will be California
+    public static ApplicationSandboxConfiguration getApplicationSandboxConfigurationDefault() {
+        ApplicationSandboxConfiguration applicationSandboxConfiguration = new ApplicationSandboxConfiguration();
+        applicationSandboxConfiguration.setTenant(TenantConfigurationStubs.getTenantCA());
+        applicationSandboxConfiguration.setDataSets(getDataSets());
+        applicationSandboxConfiguration.setReporting(TenantConfigurationStubs.getReporting());
+        applicationSandboxConfiguration.setAggregateReportingPropertiesTenant(getAggregrateReportingProperties());
+        return applicationSandboxConfiguration;
+    }
+
+    public static Set<DataSet> getDataSets() {
+        Set<DataSet> dataSets = new HashSet<>();
+        DataSet dataSetCa = new DataSet();
+        dataSetCa.setDataSet("California Interim Data Set");
+        dataSetCa.setKey("ca_interim");
+        dataSets.add(dataSetCa);
+
+        DataSet dataSetMi = new DataSet();
+        dataSetMi.setDataSet("Michigan Summative Data Set");
+        dataSetMi.setKey("mi_summative");
+        dataSets.add(dataSetMi);
+
+        DataSet dataSetSbac = new DataSet();
+        dataSetSbac.setDataSet("SBAC Interim Data Set");
+        dataSetSbac.setKey("sbac_interim");
+        dataSets.add(dataSetMi);
+
+        return dataSets;
+    }
+    public static SandboxConfiguration getCaInterimSandboxConfiguration() {
+        SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
+        sandboxConfiguration.setSandbox(getSandboxCAInfo());
+        sandboxConfiguration.setReporting(TenantConfigurationStubs.getReporting());
+        sandboxConfiguration.setLocalization(getCaLocalization());
+        sandboxConfiguration.setAggregateReportingPropertiesTenant(getAggregrateReportingProperties());
+        return sandboxConfiguration;
+    }
+
+    public static SandboxConfiguration getMiInterimSandboxConfiguration() {
+        SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
+        sandboxConfiguration.setSandbox(getSandboxMIInfo());
+        sandboxConfiguration.setReporting(TenantConfigurationStubs.getReporting());
+        sandboxConfiguration.setLocalization(getCaLocalization());
+        sandboxConfiguration.setAggregateReportingPropertiesTenant(getAggregrateReportingProperties());
+        return sandboxConfiguration;
+    }
+
+    private static Sandbox getSandboxCAInfo() {
+        Sandbox sandbox = new Sandbox();
+        sandbox.setDataSetKey("sbac_interim");
+        sandbox.setTenantKey("CA");
+        sandbox.setDecscription("A sandbox for CA using sbac_interim dataset");
+        sandbox.setId("CA");
+        sandbox.setKey("CA");
+        sandbox.setName("California");
+        return sandbox;
+    }
+
+    private static Sandbox getSandboxMIInfo() {
+        Sandbox sandbox = new Sandbox();
+        sandbox.setDataSetKey("sbac_interim");
+        sandbox.setTenantKey("MI");
+        sandbox.setDecscription("A sandbox for MI using sbac_interim dataset");
+        sandbox.setId("MI");
+        sandbox.setKey("MI");
+        sandbox.setName("Michigan");
+        return sandbox;
+    }
+
+    public static Map<String, String> getCaLocalization() {
+        Map<String, String> localization = new LinkedHashMap<>();
+        localization.put("common.ethnicity.HispanicOrLatinoEthnicity", "Hispanic or Latino");
+        localization.put("common.ethnicity.Asian", "Asian");
+        return localization;
+    }
+
+
+    public static AggregateReportingPropertiesTenant getAggregrateReportingProperties() {
+        AggregateReportingPropertiesTenant aggregateReportingProperties = new AggregateReportingPropertiesTenant();
+        Set<String> assessmentTypes = new HashSet<>();
+        assessmentTypes.add("ica");
+        assessmentTypes.add("sum");
+        assessmentTypes.add("iab");
+        aggregateReportingProperties.setAssessmentTypes(assessmentTypes);
+        Set<String> assessments = new HashSet<>();
+        assessmentTypes.add("sum");
+        aggregateReportingProperties.setStateAggregateAssessmentTypes(assessments);
+        Set<String> stateAssessments = new HashSet<>();
+        stateAssessments.add("sum");
+        stateAssessments.add("iab");
+        aggregateReportingProperties.setStatewideUserAssessmentTypes(stateAssessments);
+        return aggregateReportingProperties;
+    }
+
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TenantConfigurationStubs.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TenantConfigurationStubs.java
@@ -68,7 +68,7 @@ public class TenantConfigurationStubs {
     }
 
     //  Defaults for Reporting
-    static private  ReportingSystemPropertiesImpl getReporting() {
+    static public  ReportingSystemPropertiesImpl getReporting() {
         ReportingSystemPropertiesImpl  reporting = new  ReportingSystemPropertiesImpl();
         reporting.setSchoolYear(2018);
         reporting.setTransferAccessEnabled(true);
@@ -77,7 +77,7 @@ public class TenantConfigurationStubs {
         reporting.setUserGuideUrl("https://portal.smarterbalanced.org/library/en/reporting-system-user-guide.pdf");
         reporting.setInterpretiveGuideUrl("https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf");
         reporting.setPercentileDisplayEnabled(true);
-        //reporting.setLandingPageUrl("forward:/landing.html");
+        reporting.setLandingPageUrl("forward:/landing.html");
         List<String> languages = new ArrayList<>();
         languages.add("en");
         reporting.setReportLanguages(languages);
@@ -99,11 +99,6 @@ public class TenantConfigurationStubs {
     // TenantConfiguration  Mocks
     static public TenantConfiguration createMockTenantCA() {
         TenantConfiguration tenantConfiguration = new TenantConfiguration();
-        TenantProperties.Tenant tenant = new TenantProperties.Tenant();
-        tenant.setId("CA");
-        tenant.setKey("CA");
-        tenant.setName("California");
-        tenant.setDescription("This is a CA description");
 
         ArchivePropertiesTenant archivePropertiesTenant = getArchivePropertiesTenant();
         archivePropertiesTenant.setPathPrefix("ca");
@@ -137,16 +132,29 @@ public class TenantConfigurationStubs {
         localization.put("common.ethnicity.NativeHawaiianOrOtherPacificIslander", "Native Hawaiian or Other Pacific Islander");
         localization.put("common.ethnicity.DemographicRaceTwoOrMoreRaces", "Two or More Races");
 
-        return getTenantConfiguration(tenantConfiguration, tenant, reporting, datasourcesMap, archivePropertiesTenant, localization);
+        return getTenantConfiguration(tenantConfiguration, getTenantCA(), reporting, datasourcesMap, archivePropertiesTenant, localization);
     }
 
-    static public  TenantConfiguration createMockTenantNV() {
-        TenantConfiguration tenantConfiguration = new TenantConfiguration();
+    static public TenantProperties.Tenant getTenantCA() {
+        TenantProperties.Tenant tenant = new TenantProperties.Tenant();
+        tenant.setId("CA");
+        tenant.setKey("CA");
+        tenant.setName("California");
+        tenant.setDescription("This is a CA description");
+        return tenant;
+    }
+
+    static public TenantProperties.Tenant getTenantNV() {
         TenantProperties.Tenant tenant = new TenantProperties.Tenant();
         tenant.setId("NV");
         tenant.setKey("NV");
         tenant.setName("Nevada");
         tenant.setDescription("This is a Nevada description");
+        return tenant;
+    }
+
+    static public  TenantConfiguration createMockTenantNV() {
+        TenantConfiguration tenantConfiguration = new TenantConfiguration();
 
         ArchivePropertiesTenant archivePropertiesTenant = getArchivePropertiesTenant();
         archivePropertiesTenant.setPathPrefix("nv");
@@ -180,7 +188,7 @@ public class TenantConfigurationStubs {
         localization.put("common.ethnicity.HispanicOrLatinoEthnicity", "Hispanic or Latino");
         localization.put("common.ethnicity.Asian", "Asian");
 
-        return getTenantConfiguration(tenantConfiguration, tenant, reporting, datasourcesMap, archivePropertiesTenant, localization);
+        return getTenantConfiguration(tenantConfiguration, getTenantNV(), reporting, datasourcesMap, archivePropertiesTenant, localization);
     }
 
     // create a tenantConfiguration that can be used to create and update a tenant
@@ -202,7 +210,7 @@ public class TenantConfigurationStubs {
         return tenantConfiguration;
     }
 
-    static private Map<String, String> getLocalization() {
+    static public Map<String, String> getLocalization() {
         Map<String, String> localization = new LinkedHashMap<>();
         localization.put("common.ethnicity.HispanicOrLatinoEthnicity", "Hispanic or Latino");
         localization.put("common.ethnicity.Asian", "Asian");

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SandboxConfigurationRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SandboxConfigurationRepository.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+
+import java.util.Set;
+
+public interface SandboxConfigurationRepository {
+
+    /**
+     * @return the sandbox default configuration and the list of existing sandboxes
+     */
+    Set<SandboxConfiguration> getAll();
+
+    /**
+     * @param sandboxConfiguration to create
+     * @return the newly added sandboxConfiguration
+     */
+    SandboxConfiguration add(SandboxConfiguration sandboxConfiguration);
+
+    /**
+     * @param sandboxConfiguration with the updated sandbox data
+     * @return the updated SandboxConfiguration
+     */
+    SandboxConfiguration update(SandboxConfiguration sandboxConfiguration);
+
+    /**
+     * @param key of the sandboxConfiguration to delete
+     */
+    void delete(String key);
+
+    /**
+     * @param key of the Sandbox to reset its DataSet
+     */
+    void reset(String key);
+
+    /**
+     * @param key of the sandbox to check
+     * @return true if the sandbox key exists
+     */
+    Boolean sandboxExists(String key);
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepository.java
@@ -3,16 +3,16 @@ package org.opentestsystem.rdw.admin.repository.impl;
 import com.google.common.collect.ImmutableSet;
 import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
 import org.opentestsystem.rdw.admin.repository.SandboxConfigurationRepository;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 @Repository
 public class InMemorySandboxConfigurationRepository implements SandboxConfigurationRepository {
 
-    private HashMap<String, SandboxConfiguration> sandboxConfigurationMap = new HashMap<>();
+    private Map<String, SandboxConfiguration> sandboxConfigurationMap = new HashMap<>();
 
     public InMemorySandboxConfigurationRepository () {}
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepository.java
@@ -1,0 +1,57 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.repository.SandboxConfigurationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Set;
+
+@Repository
+public class InMemorySandboxConfigurationRepository implements SandboxConfigurationRepository {
+
+    private HashMap<String, SandboxConfiguration> sandboxConfigurationMap = new HashMap<>();
+
+    public InMemorySandboxConfigurationRepository () {}
+
+    @Override
+    public Set<SandboxConfiguration> getAll() {
+        return ImmutableSet.copyOf(sandboxConfigurationMap.values());
+    }
+
+    @Override
+    public SandboxConfiguration add(SandboxConfiguration sandboxConfiguration) {
+        SandboxConfiguration sandbox = sandboxConfigurationMap.putIfAbsent(sandboxConfiguration.getSandbox().getTenantKey(), sandboxConfiguration);
+        if (sandbox == null) {
+            sandbox = sandboxConfigurationMap.get(sandboxConfiguration.getSandbox().getTenantKey());
+        }
+        return sandbox;
+    }
+
+    @Override
+    public SandboxConfiguration update(SandboxConfiguration sandboxConfiguration) {
+        SandboxConfiguration sandbox = sandboxConfigurationMap.replace(sandboxConfiguration.getSandbox().getTenantKey(), sandboxConfiguration);
+        if (sandbox == null) {
+            sandbox = sandboxConfigurationMap.get(sandboxConfiguration.getSandbox().getTenantKey());
+        }
+        return sandbox;
+    }
+
+    @Override
+    public void delete(final String key) {
+        sandboxConfigurationMap.remove(key);
+    }
+
+
+    @Override
+    public void reset(final String key) {
+        // TODO make it actually resetData : currently No op
+    }
+
+    @Override
+    public Boolean sandboxExists( String key) {
+        return sandboxConfigurationMap.containsKey(key);
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/SandboxService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/SandboxService.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.admin.service;
+
+import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+
+public interface SandboxService {
+    /**
+     * Retrieve the default application information and a list of sandboxes and their configurations.
+     * If there are no sandboxes configured, only the default information is returned.
+     * @return  The Default information and a list of all existing sandboxes  for this Instance
+     */
+    ApplicationSandboxConfigurations getAll();
+    /**
+     * @param sandboxConfiguration The updated sandbox Configuration to save
+     * @return the newly created SandboxConfiguration
+     */
+    SandboxConfiguration create( SandboxConfiguration sandboxConfiguration);
+    /**
+     * @param sandboxConfiguration The updated sandbox Configuration to save
+     * @return the updated SandboxConfiguration
+     */
+    SandboxConfiguration update(SandboxConfiguration sandboxConfiguration);
+    /**
+     * removes a sandbox - including all shutdown procedures
+     * - todo tbd what this actually means
+     * @param key the sandboxKey  to remove
+     */
+    void delete( String key);
+
+    /**
+     * @param key of sandbox to reset the dataSet back to the default data
+     */
+    void resetDataSet(String key);
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxService.java
@@ -1,0 +1,89 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
+import org.opentestsystem.rdw.admin.repository.impl.InMemorySandboxConfigurationRepository;
+import org.opentestsystem.rdw.admin.service.SandboxService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+public class DefaultSandboxService implements SandboxService {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultSandboxService.class);
+
+    private InMemorySandboxConfigurationRepository inMemorySandboxConfigurationRepository;
+
+    @Autowired
+    DefaultSandboxService(InMemorySandboxConfigurationRepository inMemorySandboxConfigurationRepository) {
+        this.inMemorySandboxConfigurationRepository = inMemorySandboxConfigurationRepository;
+        // todo: remove mock - Populate with mock sandboxConfigurations at service start
+        addMockData();
+    }
+
+    private void addMockData() {
+        inMemorySandboxConfigurationRepository.add(SandboxConfigurationStubs.getCaInterimSandboxConfiguration());
+        inMemorySandboxConfigurationRepository.add(SandboxConfigurationStubs.getMiInterimSandboxConfiguration());
+    }
+    @Override
+    public ApplicationSandboxConfigurations getAll() {
+        ApplicationSandboxConfigurations applicationSandboxConfigurations = new ApplicationSandboxConfigurations();
+        applicationSandboxConfigurations.setSandboxes(inMemorySandboxConfigurationRepository.getAll());
+        applicationSandboxConfigurations.setApplicationSandboxConfiguration(SandboxConfigurationStubs.getApplicationSandboxConfigurationDefault());
+        logger.debug("Returning the current sandbox configurations with {} sandboxes configured.", applicationSandboxConfigurations.getSandboxes().size());
+
+        return applicationSandboxConfigurations;
+    }
+
+    @Override
+    public SandboxConfiguration create(final SandboxConfiguration sandboxConfiguration) {
+        logger.debug("Creating sandbox with key {}", sandboxConfiguration.getSandbox().getKey());
+        validateNewSandbox(sandboxConfiguration);
+        return inMemorySandboxConfigurationRepository.add(sandboxConfiguration);
+    }
+
+    @Override
+    public SandboxConfiguration update(final SandboxConfiguration sandboxConfiguration) {
+        logger.debug("Updating with sandbox with key = {}", sandboxConfiguration.getSandbox().getKey());
+        validateExistingSandbox(sandboxConfiguration);
+        return inMemorySandboxConfigurationRepository.update(sandboxConfiguration);
+    }
+
+    @Override
+    public void delete(final String key) {
+        logger.debug("removing the sandbox key {}",key);
+        inMemorySandboxConfigurationRepository.delete(key);
+    }
+
+    @Override
+    public void resetDataSet(String key) {
+        logger.debug("Resetting the DataSet for the Sandbox key {}",key);
+        // todo actually reset the data - just calling a inMemory func for now
+        inMemorySandboxConfigurationRepository.reset(key);
+    }
+
+    private void validateNewSandbox(final SandboxConfiguration sandboxConfiguration) {
+        // TODO update with full if exists checks
+        if (inMemorySandboxConfigurationRepository.sandboxExists(sandboxConfiguration.getSandbox().getKey())) {
+            String errorMsg = "Sandbox: " + sandboxConfiguration.getSandbox().getName() +
+                    " key: " + sandboxConfiguration.getSandbox().getKey() + " exists already. Please update existing sandbox, or add another sandbox key.";
+            logger.error(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+    }
+
+    private void validateExistingSandbox(final SandboxConfiguration sandboxConfiguration) {
+        // TODO update with full if exists checks
+        if (!inMemorySandboxConfigurationRepository.sandboxExists(sandboxConfiguration.getSandbox().getKey())) {
+            String errorMsg = "Sandbox: " + sandboxConfiguration.getSandbox().getName() +
+                    " key: " + sandboxConfiguration.getSandbox().getKey() + " not found.";
+            logger.error(errorMsg);
+            throw new NoSuchElementException(errorMsg);
+        }
+    }
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/SandboxController.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/SandboxController.java
@@ -27,6 +27,7 @@ public class SandboxController {
     }
 
     @GetMapping
+    @ResponseBody
     public ApplicationSandboxConfigurations getSandboxes() {
         return service.getAll();
     }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/SandboxController.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/SandboxController.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.service.SandboxService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/sandboxes")
+public class SandboxController {
+
+    private SandboxService service;
+
+    public SandboxController(SandboxService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public ApplicationSandboxConfigurations getSandboxes() {
+        return service.getAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseBody
+    public SandboxConfiguration create(@RequestBody final SandboxConfiguration sandboxConfiguration) {
+        return service.create(sandboxConfiguration);
+    }
+
+    @PutMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    @ResponseBody
+    public SandboxConfiguration put(@RequestBody final SandboxConfiguration sandboxConfiguration) {
+        return service.update(sandboxConfiguration);
+    }
+
+    @DeleteMapping("/{key}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable("key") final String key) {
+        service.delete(key);
+    }
+
+    @PutMapping("/{key}/reset")
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    public void resetDataSet(@PathVariable("key") final String key) {
+        service.resetDataSet(key);
+    }
+
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepositoryTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/InMemorySandboxConfigurationRepositoryTest.java
@@ -1,0 +1,86 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InMemorySandboxConfigurationRepositoryTest {
+
+    private InMemorySandboxConfigurationRepository inMemorySandboxRepository;
+
+    @Before
+    public void setup() {
+        // creating a new repo so the map is empty at the start of the tests
+        inMemorySandboxRepository = new InMemorySandboxConfigurationRepository();
+    }
+
+    @Test
+    public void isShouldRetrieveSandboxesSuccessfully() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxCfg = inMemorySandboxRepository.add(sandboxConfigurationCa);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxCfg.getSandbox().getKey())).isTrue();
+        verifySandboxes(sandboxCfg, sandboxConfigurationCa);
+
+        SandboxConfiguration sandboxConfigurationMi = SandboxConfigurationStubs.getMiInterimSandboxConfiguration();
+        SandboxConfiguration sandboxMiCfg = inMemorySandboxRepository.add(sandboxConfigurationMi);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxMiCfg.getSandbox().getKey())).isTrue();
+        verifySandboxes(sandboxMiCfg, sandboxConfigurationMi);
+        assertThat(inMemorySandboxRepository.getAll()).isNotNull().isNotEmpty();
+        assertThat(inMemorySandboxRepository.getAll().size()).isEqualTo(2);
+        verifySandboxes(sandboxMiCfg, sandboxConfigurationMi);
+    }
+
+    @Test
+    public void isShouldAddtoRepoSuccessfully() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxCfg = inMemorySandboxRepository.add(sandboxConfigurationCa);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxCfg.getSandbox().getKey())).isTrue();
+        verifySandboxes(sandboxCfg, sandboxConfigurationCa);
+    }
+
+    @Test
+    public void isShouldUpdateRepoSuccessfully() {
+        // add tenant to update
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        inMemorySandboxRepository.add(sandboxConfigurationCa);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).isTrue();
+
+        //updating the description
+        sandboxConfigurationCa.getSandbox().setDecscription("Updating to something Different");
+        SandboxConfiguration updatedSandboxCfg = inMemorySandboxRepository.update(sandboxConfigurationCa);
+        assertThat(updatedSandboxCfg.getSandbox().getDescription()).isEqualTo(sandboxConfigurationCa.getSandbox().getDescription());
+    }
+
+    @Test
+    public void isShouldDeleteFromRepoSuccessfully() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxCfg = inMemorySandboxRepository.add(sandboxConfigurationCa);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxCfg.getSandbox().getKey())).isTrue();
+
+        inMemorySandboxRepository.delete(sandboxConfigurationCa.getSandbox().getKey());
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).isFalse();
+    }
+
+    @Test
+    public void isShouldCallResetSuccessfully() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxCfg = inMemorySandboxRepository.add(sandboxConfigurationCa);
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxCfg.getSandbox().getKey())).isTrue();
+
+        inMemorySandboxRepository.reset(sandboxConfigurationCa.getSandbox().getKey());
+        assertThat(inMemorySandboxRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).isTrue();
+    }
+
+    private void verifySandboxes(final SandboxConfiguration sandboxConfiguration, final SandboxConfiguration expectedSandboxConfiguration) {
+        assertThat(sandboxConfiguration.getSandbox().getKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getKey());
+        assertThat(sandboxConfiguration.getSandbox().getId()).isEqualTo(expectedSandboxConfiguration.getSandbox().getId());
+        assertThat(sandboxConfiguration.getSandbox().getDataSetKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getDataSetKey());
+        assertThat(sandboxConfiguration.getSandbox().getTenantKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getTenantKey());
+        assertThat(sandboxConfiguration.getSandbox().getDescription()).isEqualTo(expectedSandboxConfiguration.getSandbox().getDescription());
+        assertThat(sandboxConfiguration.getSandbox().getName()).isEqualTo(expectedSandboxConfiguration.getSandbox().getName());
+    }
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxServiceTest.java
@@ -1,0 +1,187 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
+import org.opentestsystem.rdw.admin.repository.impl.InMemorySandboxConfigurationRepository;
+import org.opentestsystem.rdw.olap.configuration.AggregateReportingPropertiesTenant;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+public class DefaultSandboxServiceTest {
+
+    private DefaultSandboxService service;
+
+    private InMemorySandboxConfigurationRepository inMemorySandboxConfigurationRepository;
+
+    @Before
+    public void setup() {
+        inMemorySandboxConfigurationRepository = mock(InMemorySandboxConfigurationRepository.class);
+        service = new DefaultSandboxService(inMemorySandboxConfigurationRepository);
+    }
+
+    @Test
+    public void itShouldRetrieveAllSandboxes(){
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxConfigurationMi = SandboxConfigurationStubs.getMiInterimSandboxConfiguration();
+        Set<SandboxConfiguration> sandboxConfigurations = ImmutableSet.of(sandboxConfigurationCa, sandboxConfigurationMi);
+        when(inMemorySandboxConfigurationRepository.getAll()).thenReturn(sandboxConfigurations);
+
+        ApplicationSandboxConfigurations applicationSandboxConfigurations = service.getAll();
+
+        verify(inMemorySandboxConfigurationRepository).getAll();
+
+        assertThat(applicationSandboxConfigurations).isNotNull();
+        assertThat(applicationSandboxConfigurations.getApplicationSandboxConfiguration()).isNotNull();
+        assertThat(applicationSandboxConfigurations.getSandboxes()).isNotEmpty();
+        assertThat(applicationSandboxConfigurations.getSandboxes().size()).isEqualTo(2);
+
+        Optional<SandboxConfiguration> sandboxCa = getSandboxConfigurationFromKey(applicationSandboxConfigurations, sandboxConfigurationCa.getSandbox().getKey());
+        assertThat(sandboxCa).isPresent();
+        if(sandboxCa.isPresent()) {
+            verifySandboxes(sandboxCa.get(), sandboxConfigurationCa);
+        }
+
+        Optional<SandboxConfiguration> sandboxMi = getSandboxConfigurationFromKey(applicationSandboxConfigurations, sandboxConfigurationMi.getSandbox().getKey());
+        assertThat(sandboxMi).isPresent();
+        if(sandboxMi.isPresent()) {
+            verifySandboxes(sandboxMi.get(), sandboxConfigurationMi);
+        }
+    }
+
+    @Test
+    public void itShouldCreateSandbox() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        when(inMemorySandboxConfigurationRepository.add(sandboxConfigurationCa)).thenReturn(sandboxConfigurationCa);
+        SandboxConfiguration sandboxConfiguration = service.create(sandboxConfigurationCa);
+
+        verify(inMemorySandboxConfigurationRepository).add(sandboxConfigurationCa);
+        assertThat(sandboxConfiguration).isNotNull();
+        assertThat(sandboxConfiguration.getSandbox()).isNotNull();
+        verifySandboxes(sandboxConfiguration, sandboxConfigurationCa);
+    }
+
+    @Test
+    public void itShouldUpdateSandbox() {
+        String expectedDescription = "Sandbox's New description for Testing";
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration updatedSandboxConfiguration = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        updatedSandboxConfiguration.getSandbox().setDecscription(expectedDescription);
+        when(inMemorySandboxConfigurationRepository.update(sandboxConfigurationCa)).thenReturn(updatedSandboxConfiguration);
+        when(inMemorySandboxConfigurationRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).thenReturn(true);
+
+        SandboxConfiguration sandboxCfg = service.update(sandboxConfigurationCa);
+
+        verify(inMemorySandboxConfigurationRepository).update(sandboxConfigurationCa);
+        verifySandboxes(sandboxCfg, updatedSandboxConfiguration);
+    }
+
+    @Test
+    public void itShouldDeleteSandbox() {
+        String key = SandboxConfigurationStubs.getCaInterimSandboxConfiguration().getSandbox().getKey();
+        service.delete(key);
+        verify(inMemorySandboxConfigurationRepository).delete(key);
+    }
+
+    @Test
+    public void itShouldResetSandbox() {
+        String key = SandboxConfigurationStubs.getCaInterimSandboxConfiguration().getSandbox().getKey();
+        service.resetDataSet(key);
+        verify(inMemorySandboxConfigurationRepository).reset(key);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void itShouldNotCreateSandbox() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        when(inMemorySandboxConfigurationRepository.add(sandboxConfigurationCa)).thenReturn(sandboxConfigurationCa);
+        when(inMemorySandboxConfigurationRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).thenReturn(true);
+        service.create(sandboxConfigurationCa);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldNotUpdateSandbox() {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        when(inMemorySandboxConfigurationRepository.add(sandboxConfigurationCa)).thenReturn(sandboxConfigurationCa);
+        when(inMemorySandboxConfigurationRepository.sandboxExists(sandboxConfigurationCa.getSandbox().getKey())).thenReturn(false);
+        service.update(sandboxConfigurationCa);
+    }
+
+    private void verifySandboxes(final SandboxConfiguration sandboxConfiguration, final SandboxConfiguration expectedSandboxConfiguration) {
+        assertThat(sandboxConfiguration.getSandbox().getKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getKey());
+        assertThat(sandboxConfiguration.getSandbox().getId()).isEqualTo(expectedSandboxConfiguration.getSandbox().getId());
+        assertThat(sandboxConfiguration.getSandbox().getDataSetKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getDataSetKey());
+        assertThat(sandboxConfiguration.getSandbox().getTenantKey()).isEqualTo(expectedSandboxConfiguration.getSandbox().getTenantKey());
+        assertThat(sandboxConfiguration.getSandbox().getDescription()).isEqualTo(expectedSandboxConfiguration.getSandbox().getDescription());
+        assertThat(sandboxConfiguration.getSandbox().getName()).isEqualTo(expectedSandboxConfiguration.getSandbox().getName());
+
+        verifyReporting(sandboxConfiguration.getReporting(), expectedSandboxConfiguration.getReporting());
+        verifyLocalization(sandboxConfiguration.getLocalization(), expectedSandboxConfiguration.getLocalization());
+
+        verifyAggregatorProperties(sandboxConfiguration.getAggregateReportingPropertiesTenant(), expectedSandboxConfiguration.getAggregateReportingPropertiesTenant());
+    }
+
+    /**
+     * the aggregator property list can be null
+     * @param aggregateProperties retrieved properties
+     * @param expectedAggregateProperties exprected properties
+     */
+    private void verifyAggregatorProperties(AggregateReportingPropertiesTenant aggregateProperties, AggregateReportingPropertiesTenant expectedAggregateProperties) {
+        assertThat(aggregateProperties.getAssessmentTypes().size()).isEqualTo(expectedAggregateProperties.getAssessmentTypes().size());
+        assertThat(aggregateProperties.getStateAggregateAssessmentTypes().size()).isEqualTo(expectedAggregateProperties.getStateAggregateAssessmentTypes().size());
+        assertThat(aggregateProperties.getStatewideUserAssessmentTypes().size()).isEqualTo(expectedAggregateProperties.getStatewideUserAssessmentTypes().size());
+    }
+    private void verifyLocalization(final Map<String, String> localization, final Map<String, String> expectedLocalization) {
+        assertThat(localization.size()).isEqualTo(expectedLocalization.size());
+    }
+
+    private void verifyReporting(final ReportingSystemProperties reportingSystemSettings, final ReportingSystemProperties expectedReportingSystemSettings) {
+        assertThat(reportingSystemSettings.getAccessDeniedUrl()).isEqualTo(expectedReportingSystemSettings.getAccessDeniedUrl());
+        assertThat(reportingSystemSettings.getAnalyticsTrackingId()).isEqualTo(expectedReportingSystemSettings.getAnalyticsTrackingId());
+        assertThat(reportingSystemSettings.getInterpretiveGuideUrl()).isEqualTo(expectedReportingSystemSettings.getInterpretiveGuideUrl());
+        assertThat(reportingSystemSettings.getIrisVendorId()).isEqualTo(expectedReportingSystemSettings.getIrisVendorId());
+        assertThat(reportingSystemSettings.getLandingPageUrl()).isEqualTo(expectedReportingSystemSettings.getLandingPageUrl());
+        assertThat(reportingSystemSettings.getMinItemDataYear()).isEqualTo(expectedReportingSystemSettings.getMinItemDataYear());
+        assertThat(reportingSystemSettings.getSchoolYear()).isEqualTo(expectedReportingSystemSettings.getSchoolYear());
+        assertThat(reportingSystemSettings.getUserGuideUrl()).isEqualTo(expectedReportingSystemSettings.getUserGuideUrl());
+        assertThat(reportingSystemSettings.getTargetReport()).isEqualTo(expectedReportingSystemSettings.getTargetReport());
+        assertThat(reportingSystemSettings.getTranslationLocation()).isEqualTo(expectedReportingSystemSettings.getTranslationLocation());
+        assertThat(reportingSystemSettings.isPercentileDisplayEnabled()).isEqualTo(expectedReportingSystemSettings.isPercentileDisplayEnabled());
+        assertThat(reportingSystemSettings.isTransferAccessEnabled()).isEqualTo(expectedReportingSystemSettings.isTransferAccessEnabled());
+        assertThat(reportingSystemSettings.getState()).isNotNull();
+        assertThat(reportingSystemSettings.getState().getCode()).isEqualTo(expectedReportingSystemSettings.getState().getCode());
+        assertThat(reportingSystemSettings.getState().getName()).isEqualTo(expectedReportingSystemSettings.getState().getName());
+
+        assertThat(reportingSystemSettings.getReportLanguages().size()).isEqualTo(expectedReportingSystemSettings.getReportLanguages().size());
+        assertThat(reportingSystemSettings.getUiLanguages().size()).isEqualTo(expectedReportingSystemSettings.getUiLanguages().size());
+        assertThat(reportingSystemSettings.getEffectiveReportLanguages().size()).isEqualTo(expectedReportingSystemSettings.getEffectiveReportLanguages().size());
+
+    }
+
+    /**
+     * Lookup the given key in the ApplicationSandboxConfigurations sandbox list
+     * @param applicationSandboxConfigurations contains the list of sandboxes to look through
+     * @param key The key of the sandbox to find
+     * @return SandboxConfiguration if key is found
+     */
+    private Optional<SandboxConfiguration> getSandboxConfigurationFromKey(final ApplicationSandboxConfigurations applicationSandboxConfigurations, String key) {
+        return applicationSandboxConfigurations.getSandboxes().stream()
+                .filter(sandbox ->
+                        sandbox.getSandbox().getKey().equals(key)
+                ).findFirst();
+    }
+
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/SandboxControllerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/SandboxControllerTest.java
@@ -1,0 +1,109 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
+import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
+import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
+import org.opentestsystem.rdw.admin.service.SandboxService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = {SandboxController.class}, secure = false)
+public class SandboxControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private SandboxService service;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void itShouldReturnAllSandboxInformation() throws Exception{
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        SandboxConfiguration sandboxConfigurationMi = SandboxConfigurationStubs.getMiInterimSandboxConfiguration();
+        Set<SandboxConfiguration> sandboxConfigurations = ImmutableSet.of(sandboxConfigurationCa, sandboxConfigurationMi);
+        ApplicationSandboxConfigurations applicationSandboxConfigurations = new ApplicationSandboxConfigurations();
+        applicationSandboxConfigurations.setSandboxes(sandboxConfigurations);
+        applicationSandboxConfigurations.setApplicationSandboxConfiguration(SandboxConfigurationStubs.getApplicationSandboxConfigurationDefault());
+
+        when(service.getAll()).thenReturn(applicationSandboxConfigurations);
+
+        mvc.perform( get("/sandboxes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(service).getAll();
+    }
+
+    @Test
+    public void isShouldCreateSandbox() throws Exception {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        when(service.create(any(SandboxConfiguration.class))).thenReturn(sandboxConfigurationCa);
+        mvc.perform( post("/sandboxes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(sandboxConfigurationCa))
+        ).andExpect(status().isCreated());
+
+        verify(service).create(any(SandboxConfiguration.class));
+    }
+
+    @Test
+    public void itShouldResetDataSet() throws Exception {
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+
+       mvc.perform(
+                put(String.format("/sandboxes/%s/reset", sandboxConfigurationCa.getSandbox().getKey()))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(service).resetDataSet(sandboxConfigurationCa.getSandbox().getKey());
+    }
+
+    @Test
+    public void isShouldUpdate() throws Exception{
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+        when(service.update(any(SandboxConfiguration.class))).thenReturn(sandboxConfigurationCa);
+
+        mvc.perform( put("/sandboxes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(sandboxConfigurationCa))
+        ).andExpect(status().isOk());
+
+        verify(service).update(any(SandboxConfiguration.class));
+    }
+
+    @Test
+    public void itShouldDelete() throws  Exception{
+        SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
+
+        // add tenantToDelete
+        mvc.perform( delete(String.format("/sandboxes/%s", sandboxConfigurationCa.getSandbox().getKey()))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(service).delete(any(String.class));
+    }
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantControllerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 
 import com.google.common.collect.ImmutableSet;
-import com.jayway.jsonpath.JsonPath;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)


### PR DESCRIPTION
Created the initial Sandbox service with CRUD and a reset endpoint
it uses an inMemory repo to store the sandboxConfigurations
and simple checks on create & update
At startup to populates the repo with 2 mock sandboxes.

NOTE: this is post before fully complete to allow for UI integration.
Still need to pull in real data lookup and saving sandbox data. 