### PR TITLE
Sandbox Login - UI work + Security changes to allow access

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Users.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Users.java
@@ -4,6 +4,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public final class Users {
+    private static final String ANONYMOUS_USER = "anonymousUser";
 
     private Users() {
     }
@@ -12,6 +13,13 @@ public final class Users {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             throw new IllegalStateException("user not authenticated");
+        }
+        if (ANONYMOUS_USER.equals(authentication.getPrincipal())) {
+            return User.builderExt()
+                    .id(ANONYMOUS_USER)
+                    .username(ANONYMOUS_USER)
+                    .password(ANONYMOUS_USER)
+                    .build();
         }
         if (!(authentication.getPrincipal() instanceof User)) {
             throw new ClassCastException("authentication principal must be of type " + User.class.getName());

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Users.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/security/Users.java
@@ -14,6 +14,7 @@ public final class Users {
         if (authentication == null) {
             throw new IllegalStateException("user not authenticated");
         }
+        // TODO: By the time we get here, we should already haven an "anonymous" user object in our security context
         if (ANONYMOUS_USER.equals(authentication.getPrincipal())) {
             return User.builderExt()
                     .id(ANONYMOUS_USER)

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlWebSecurityConfiguration.java
@@ -510,6 +510,11 @@ public abstract class SamlWebSecurityConfiguration extends WebSecurityConfigurer
 
         http
                 .authorizeRequests()
+                .antMatchers("/sandbox-login").anonymous()
+                .antMatchers("/api/translations/**").permitAll()
+                .antMatchers("/api/user").permitAll()
+                .antMatchers("/api/settings").permitAll()
+                .antMatchers("/api/reporting-service/subjects").permitAll()
                 .antMatchers("/**").authenticated()
                 .anyRequest().authenticated();
         http

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/user/DefaultUserContextService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/user/DefaultUserContextService.java
@@ -10,6 +10,10 @@ class DefaultUserContextService implements UserContextService {
 
     @Override
     public UserContext getUserContext(@NotNull final User user) {
+        // Return an anonymous user context, or "empty" user if the user is not defined
+        if (user == null) {
+            return UserContext.builder().build();
+        }
         return UserContext.builder()
                 .firstName(user.getFirstName())
                 .lastName(user.getLastName())

--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -44,10 +44,7 @@
             [ngClass]="{ show: navbarOpen }"
           >
             <ul class="nav navbar-nav navbar-right">
-              <li
-                class="navbar-link nav-item"
-                *ngIf="user && user.firstName && user.lastName"
-              >
+              <li class="navbar-link nav-item" *ngIf="!isAnonymousUser()">
                 <a
                   href="{{
                     applicationSettings ? applicationSettings.userGuideUrl : '#'
@@ -56,10 +53,7 @@
                   >{{ 'common.navigation.user-guide' | translate }}</a
                 >
               </li>
-              <li
-                class="navbar-link nav-item"
-                *ngIf="user && user.firstName && user.lastName"
-              >
+              <li class="navbar-link nav-item" *ngIf="!isAnonymousUser()">
                 <a
                   href="{{
                     applicationSettings
@@ -88,11 +82,7 @@
               </li>
 
               <li class="navbar-link  nav-item">
-                <div
-                  class="btn-group"
-                  dropdown
-                  *ngIf="user && user.firstName && user.lastName"
-                >
+                <div class="btn-group" dropdown *ngIf="!isAnonymousUser()">
                   <button
                     type="button"
                     dropdownToggle

--- a/webapp/src/main/webapp/src/app/app.component.html
+++ b/webapp/src/main/webapp/src/app/app.component.html
@@ -44,7 +44,10 @@
             [ngClass]="{ show: navbarOpen }"
           >
             <ul class="nav navbar-nav navbar-right">
-              <li class="navbar-link nav-item">
+              <li
+                class="navbar-link nav-item"
+                *ngIf="user && user.firstName && user.lastName"
+              >
                 <a
                   href="{{
                     applicationSettings ? applicationSettings.userGuideUrl : '#'
@@ -53,7 +56,10 @@
                   >{{ 'common.navigation.user-guide' | translate }}</a
                 >
               </li>
-              <li class="navbar-link nav-item">
+              <li
+                class="navbar-link nav-item"
+                *ngIf="user && user.firstName && user.lastName"
+              >
                 <a
                   href="{{
                     applicationSettings
@@ -82,7 +88,11 @@
               </li>
 
               <li class="navbar-link  nav-item">
-                <div class="btn-group" dropdown>
+                <div
+                  class="btn-group"
+                  dropdown
+                  *ngIf="user && user.firstName && user.lastName"
+                >
                   <button
                     type="button"
                     dropdownToggle

--- a/webapp/src/main/webapp/src/app/app.component.ts
+++ b/webapp/src/main/webapp/src/app/app.component.ts
@@ -85,6 +85,12 @@ export class AppComponent {
     this.navbarOpen = !this.navbarOpen;
   }
 
+  isAnonymousUser(): boolean {
+    return (
+      !this.user || (this.user.firstName == null && this.user.lastName == null)
+    );
+  }
+
   private initializeAnalytics(trackingId: string): void {
     const googleAnalyticsProvider: Function = window['ga'];
     if (googleAnalyticsProvider && trackingId) {

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { ApplicationSettingsResolve } from './app-settings.resolve';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { HomeModule } from './home/home.module';
 import { HttpModule } from '@angular/http';
+import { SandboxLoginModule } from './sandbox/sandbox-login.module';
 
 @NgModule({
   declarations: [AppComponent, ErrorComponent, AccessDeniedComponent],
@@ -42,6 +43,7 @@ import { HttpModule } from '@angular/http';
     RouterModule.forRoot([]),
     UserModule,
     FormsModule,
+    SandboxLoginModule,
     BsDropdownModule.forRoot(),
     TabsModule.forRoot(),
     PopoverModule.forRoot(),

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -43,6 +43,7 @@ import { SandboxConfigurationComponent } from './admin/sandbox-tenants/pages/san
 import { NewSandboxConfigurationComponent } from './admin/sandbox-tenants/pages/new-sandbox.component';
 import { TenantConfigurationComponent } from './admin/sandbox-tenants/pages/tenant.component';
 import { NewTenantConfigurationComponent } from './admin/sandbox-tenants/pages/new-tenant.component';
+import { SandboxLoginComponent } from './sandbox/sandbox-login.component';
 
 export const studentPipe = new StudentPipe();
 export const adminRoute = {
@@ -302,7 +303,6 @@ export const routes: Routes = [
   },
   {
     path: '',
-    canActivate: [RoutingAuthorizationCanActivate],
     resolve: {
       translateComplete: TranslateResolve
     },
@@ -431,11 +431,21 @@ export const routes: Routes = [
         pathMatch: 'full',
         component: ErrorComponent
       }
-    ]
+    ].map(route => {
+      return {
+        ...route,
+        canActivate: [RoutingAuthorizationCanActivate]
+      };
+    })
   },
   {
     path: 'access-denied',
     pathMatch: 'full',
     component: AccessDeniedComponent
+  },
+  {
+    path: 'sandbox-login',
+    pathMatch: 'full',
+    component: SandboxLoginComponent
   }
 ];

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.html
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.html
@@ -1,4 +1,4 @@
-<div class="row" style="display: flex;">
+<div class="row" class="sandbox-login">
   <div class="col-xs-5 center-block well">
     <h2 class="text-center">{{ 'sandbox-login.title' | translate }}</h2>
     <form [formGroup]="form">

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.html
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.html
@@ -1,0 +1,53 @@
+<div class="row" style="display: flex;">
+  <div class="col-xs-5 center-block well">
+    <h2 class="text-center">{{ 'sandbox-login.title' | translate }}</h2>
+    <form [formGroup]="form">
+      <div>
+        <label for="sandbox" class="control-label">
+          {{ 'sandbox-login.labels.sandbox' | translate }}</label
+        >
+        <select
+          id="sandbox"
+          formControlName="sandbox"
+          (ngModelChange)="sandboxSelected($event)"
+          class="form-control"
+        >
+          <option [ngValue]="null"></option>
+          <option *ngFor="let sandbox of sandboxes" [ngValue]="sandbox.key">
+            {{ sandbox.label }} ({{ sandbox.key }})
+          </option>
+        </select>
+      </div>
+      <div>
+        <label for="username" class="control-label">
+          {{ 'sandbox-login.labels.username' | translate }}</label
+        >
+        <input
+          id="username"
+          type="text"
+          formControlName="username"
+          class="form-control"
+        />
+      </div>
+      <div>
+        <label for="role" class="control-label">
+          {{ 'sandbox-login.labels.role' | translate }}</label
+        >
+        <select id="role" formControlName="role" class="form-control">
+          <option [ngValue]="null"></option>
+          <option *ngFor="let role of roles" [ngValue]="role.id">
+            {{ role.label }}
+          </option>
+        </select>
+      </div>
+      <button
+        type="submit"
+        class="btn btn-primary mt-md text-center col-md-12"
+        [disabled]="form.invalid"
+        (click)="onSubmit()"
+      >
+        {{ 'sandbox-login.login' | translate }}
+      </button>
+    </form>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.ts
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.ts
@@ -29,7 +29,7 @@ export class SandboxLoginComponent implements OnInit {
 
   sandboxSelected(selectedSandboxKey: string): void {
     const roleControl = this.form.get('role');
-    if (!selectedSandboxKey || selectedSandboxKey === 'null') {
+    if (!selectedSandboxKey) {
       roleControl.disable();
       roleControl.setValue(null);
     } else {

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.ts
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { SandboxLoginService } from './sandbox-login.service';
+import { Role, Sandbox } from './sandbox';
+
+@Component({
+  selector: 'sandbox-login',
+  templateUrl: './sandbox-login.component.html'
+})
+export class SandboxLoginComponent implements OnInit {
+  form: FormGroup;
+  sandboxes: Sandbox[];
+  roles: Role[] = [];
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private service: SandboxLoginService
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.formBuilder.group({
+      sandbox: [null, Validators.required],
+      username: [null, Validators.required],
+      role: [{ value: null, disabled: true }, Validators.required]
+    });
+
+    this.service.getAll().subscribe(sandboxes => (this.sandboxes = sandboxes));
+  }
+
+  sandboxSelected(selectedSandboxKey: string): void {
+    const roleControl = this.form.get('role');
+    if (!selectedSandboxKey || selectedSandboxKey === 'null') {
+      roleControl.disable();
+      roleControl.setValue(null);
+    } else {
+      roleControl.enable();
+      roleControl.setValue(null);
+      const selectedSandbox = this.sandboxes.find(
+        sandbox => selectedSandboxKey === sandbox.key
+      );
+      this.roles = selectedSandbox.roles;
+    }
+  }
+
+  onSubmit(): void {
+    // TODO: Integrate with backend APIs/login
+    console.log(this.form.value);
+  }
+}

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.module.ts
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.module.ts
@@ -1,0 +1,14 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SandboxLoginComponent } from './sandbox-login.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { SandboxLoginService } from './sandbox-login.service';
+
+@NgModule({
+  declarations: [SandboxLoginComponent],
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, TranslateModule],
+  exports: [SandboxLoginComponent],
+  providers: [SandboxLoginService]
+})
+export class SandboxLoginModule {}

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox-login.service.ts
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox-login.service.ts
@@ -1,0 +1,111 @@
+import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { DataService } from '../shared/data/data.service';
+import { catchError, map } from 'rxjs/operators';
+import { AdminServiceRoute } from '../shared/service-route';
+import { ResponseUtils } from '../shared/response-utils';
+import { Sandbox } from './sandbox';
+
+const ResourceRoute = `${AdminServiceRoute}/sandboxes/login`;
+
+/**
+ * Service responsible for sandboxes
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SandboxLoginService {
+  constructor(private dataService: DataService) {}
+
+  /**
+   * Gets all sandbox configurations for the system
+   */
+  getAll(): Observable<Sandbox[]> {
+    const mockData = [
+      {
+        label: 'California Sandbox',
+        key: 'ca_sandbox_0',
+        baseUrl: 'http://localhost:8080/sandbox/',
+        roles: [
+          {
+            id: 'teacher_harborside_g4',
+            label: 'Teacher - Harborside - Grade 4'
+          },
+          {
+            id: 'teacher_harborside_g5',
+            label: 'Teacher - Harborside - Grade 5'
+          },
+          {
+            id: 'teacher_harborside_g6',
+            label: 'Teacher - Harborside - Grade 6'
+          },
+          {
+            id: 'district_sweetwater',
+            label: 'District Administrator - Sweetwater'
+          },
+          {
+            id: 'district_san_diego',
+            label: 'District Administrator - San Diego'
+          },
+          {
+            id: 'school_admin_harborside',
+            label: 'School Administrator - Harborside'
+          },
+          {
+            id: 'school_admin_castle_park',
+            label: 'School Administrator - Castle Park'
+          }
+        ]
+      },
+      {
+        label: 'Michigan Sandbox',
+        key: 'mi_sandbox_0',
+        baseUrl: 'http://localhost:8080/sandbox/',
+        roles: [
+          {
+            id: 'teacher_rosebank_g4',
+            label: 'Teacher - Rosebank - Grade 6'
+          },
+          {
+            id: 'teacher_rosebank_g4',
+            label: 'Teacher - Rosebank - Grade 7'
+          },
+          {
+            id: 'teacher_rosebank_g4',
+            label: 'Teacher - Rosebank - Grade 8'
+          },
+          {
+            id: 'district_sweetwater',
+            label: 'District Administrator - Detroit'
+          },
+          {
+            id: 'district_lansing',
+            label: 'District Administrator - Landsing'
+          },
+          {
+            id: 'school_admin_detroit',
+            label: 'School Administrator - Detroit Elementary'
+          },
+          {
+            id: 'school_admin_grand_rapids',
+            label: 'School Administrator - Grand Rapids'
+          }
+        ]
+      }
+    ];
+
+    return new Observable(observer => observer.next(mockData));
+    // TODO: Integrate API
+    // return this.dataService
+    //   .get(`${ResourceRoute}`);
+  }
+
+  /**
+   * Creates a new sandbox
+   * @param sandbox - The sandbox to create
+   */
+  login(sandbox: Sandbox, username: string, roleKey: string): Observable<void> {
+    // TODO: Integrate API
+    return Observable.create();
+  }
+}

--- a/webapp/src/main/webapp/src/app/sandbox/sandbox.ts
+++ b/webapp/src/main/webapp/src/app/sandbox/sandbox.ts
@@ -1,0 +1,11 @@
+export interface Sandbox {
+  label: string;
+  key: string;
+  baseUrl: string;
+  roles: Role[];
+}
+
+export interface Role {
+  id: string;
+  label: string;
+}

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -858,87 +858,6 @@
     },
     "title": "Manage Embargo"
   },
-  "sandbox-config": {
-    "title": "Sandbox Configuration",
-    "new-sandbox": {
-      "header": "Create New Sandbox"
-    },
-    "delete-modal": {
-      "header": "Delete <strong>{{label}}</strong>?",
-      "body": "Are you sure you wish to delete the sandbox <strong>{{label}}</strong>?",
-      "success": "Sandbox was successfully deleted"
-    },
-    "archive-modal": {
-      "header": "Archive <strong>{{label}}</strong>?",
-      "body": "Are you sure you wish to archive the sandbox <strong>{{label}}</strong>?"
-    },
-    "reset-modal": {
-      "header": "Reset data for <strong>{{label}}</strong>?",
-      "body": "Are you sure you wish to reset the data for the the sandbox <strong>{{label}}</strong>?",
-      "success": "Sandbox data was successfully reset"
-    },
-    "fields": {
-      "label": "Sandbox Name / Label:",
-      "description": "Description:",
-      "data-set": "Data Set:",
-      "configuration-properties": "Configuration Properties",
-      "localization-overrides": "Localization Overrides",
-      "search": "Search by key or value"
-    },
-    "actions": {
-      "reset": "Reset Data",
-      "archive": "Archive",
-      "delete": "Delete"
-    },
-    "config-properties": {
-      "modified": "Show modified properties only",
-      "empty": "No configuration properties found"
-    },
-    "empty": "No sandbox configurations found. Create a new tenant by clicking the \"Create New Sandbox\" button",
-    "errors": {
-      "reset": "An unknown error occurred when attempting to reset the sandbox data",
-      "update": "An unknown error occurred when attempting to update the sandbox",
-      "create": "An unknown error occurred when attempting to create the sandbox",
-      "delete": "An unknown error occurred when attempting to delete the sandbox"
-    }
-  },
-  "tenant-config": {
-    "title": "Tenant Configuration",
-    "new-tenant": {
-      "header": "Create New Tenant"
-    },
-    "delete-modal": {
-      "header": "Delete <strong>{{label}}</strong>?",
-      "body": "Are you sure you wish to delete the tenant <strong>{{label}}</strong>?",
-      "success": "Tenant was successfully deleted"
-    },
-    "fields": {
-      "id": "Tenant ID",
-      "key": "Tenant Key",
-      "label": "Tenant Name / Label:",
-      "description": "Description:",
-      "configuration-properties": "Configuration Properties",
-      "localization-overrides": "Localization Overrides",
-      "search": "Search by key or value"
-    },
-    "empty": "No tenant configurations found. Create a new tenant by clicking the \"Create New Tenant\" button",
-    "reset-info": "Click this button to reset the value back to its original default value",
-    "properties": {
-      "reporting": "Reporting",
-      "datasources": "Data Sources",
-      "task": "Task",
-      "archive": "Archive",
-      "aggregator": "Aggregator"
-    },
-    "errors": {
-      "duplicate-key": "A tenant with the same tenant key or ID already exists",
-      "invalid-key": "The tenant key that was entered is not valid. Only alphanumeric characters, underscores ('_'), and hyphens ('-') are allowed",
-      "invalid-id": "The tenant id that was entered is not valid. Only alphanumeric characters, underscores ('_'), and hyphens ('-') are allowed",
-      "update": "An unknown error occurred when attempting to update the tenant",
-      "create": "An unknown error occurred when attempting to create the tenant",
-      "delete": "An unknown error occurred when attempting to delete the tenant"
-    }
-  },
   "embargo-alert": {
     "message": "Summative test results in your region of administration are not yet released. These results may be viewed online but not downloaded."
   },
@@ -1266,6 +1185,96 @@
       "StudentSSID": "Student SSID"
     },
     "submitted-message": "Creating report. Visit <a href=\"/reports\">My Reports</a> for status."
+  },
+  "sandbox-config": {
+    "title": "Sandbox Configuration",
+    "new-sandbox": {
+      "header": "Create New Sandbox"
+    },
+    "delete-modal": {
+      "header": "Delete <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to delete the sandbox <strong>{{label}}</strong>?",
+      "success": "Sandbox was successfully deleted"
+    },
+    "archive-modal": {
+      "header": "Archive <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to archive the sandbox <strong>{{label}}</strong>?"
+    },
+    "reset-modal": {
+      "header": "Reset data for <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to reset the data for the the sandbox <strong>{{label}}</strong>?",
+      "success": "Sandbox data was successfully reset"
+    },
+    "fields": {
+      "label": "Sandbox Name / Label:",
+      "description": "Description:",
+      "data-set": "Data Set:",
+      "configuration-properties": "Configuration Properties",
+      "localization-overrides": "Localization Overrides",
+      "search": "Search by key or value"
+    },
+    "actions": {
+      "reset": "Reset Data",
+      "archive": "Archive",
+      "delete": "Delete"
+    },
+    "config-properties": {
+      "modified": "Show modified properties only",
+      "empty": "No configuration properties found"
+    },
+    "empty": "No sandbox configurations found. Create a new tenant by clicking the \"Create New Sandbox\" button",
+    "errors": {
+      "reset": "An unknown error occurred when attempting to reset the sandbox data",
+      "update": "An unknown error occurred when attempting to update the sandbox",
+      "create": "An unknown error occurred when attempting to create the sandbox",
+      "delete": "An unknown error occurred when attempting to delete the sandbox"
+    }
+  },
+  "sandbox-login": {
+    "title": "Reporting System Sandbox Login",
+    "labels": {
+      "sandbox": "Sandbox",
+      "username": "User Name",
+      "role": "User Role"
+    },
+    "login": "Login"
+  },
+  "tenant-config": {
+    "title": "Tenant Configuration",
+    "new-tenant": {
+      "header": "Create New Tenant"
+    },
+    "delete-modal": {
+      "header": "Delete <strong>{{label}}</strong>?",
+      "body": "Are you sure you wish to delete the tenant <strong>{{label}}</strong>?",
+      "success": "Tenant was successfully deleted"
+    },
+    "fields": {
+      "id": "Tenant ID",
+      "key": "Tenant Key",
+      "label": "Tenant Name / Label:",
+      "description": "Description:",
+      "configuration-properties": "Configuration Properties",
+      "localization-overrides": "Localization Overrides",
+      "search": "Search by key or value"
+    },
+    "empty": "No tenant configurations found. Create a new tenant by clicking the \"Create New Tenant\" button",
+    "reset-info": "Click this button to reset the value back to its original default value",
+    "properties": {
+      "reporting": "Reporting",
+      "datasources": "Data Sources",
+      "task": "Task",
+      "archive": "Archive",
+      "aggregator": "Aggregator"
+    },
+    "errors": {
+      "duplicate-key": "A tenant with the same tenant key or ID already exists",
+      "invalid-key": "The tenant key that was entered is not valid. Only alphanumeric characters, underscores ('_'), and hyphens ('-') are allowed",
+      "invalid-id": "The tenant id that was entered is not valid. Only alphanumeric characters, underscores ('_'), and hyphens ('-') are allowed",
+      "update": "An unknown error occurred when attempting to update the tenant",
+      "create": "An unknown error occurred when attempting to create the tenant",
+      "delete": "An unknown error occurred when attempting to delete the tenant"
+    }
   },
   "user-query-table": {
     "column": {

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -760,6 +760,10 @@ aggregate-report-table {
   }
 }
 
+.sandbox-login {
+  display: flex;
+}
+
 .sandbox-config {
   .well-group .well {
     box-shadow: none;


### PR DESCRIPTION
This PR includes the basic frontend for sandbox login including a (currently stubbed) service for fetching general sandbox/role data. Additionally, there are some changes that were necessarily for publicly exposing a few APIs, and for returning/accepting anonymous application users.

Most of the APIs that required public exposure were related to translations/localization. In particular the following APIs are called by our frontend translation service:

`/api/reporting-service/subjects/` 
`/api/translations/`
`/api/settings/`
