### PR TITLE
Fixing bug with null config property values

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-sandbox.component.html
@@ -56,6 +56,7 @@
           <property-override-tree-table
             [form]="sandboxForm"
             [configurationProperties]="configurationProperties"
+            [readonly]="false"
             propertiesArrayName="configurationProperties"
           >
           </property-override-tree-table>
@@ -69,6 +70,7 @@
           <property-override-table
             [form]="sandboxForm"
             [configurationProperties]="localizationOverrides"
+            [readonly]="false"
             propertiesArrayName="localizationOverrides"
           >
           </property-override-table>

--- a/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.html
+++ b/webapp/src/main/webapp/src/app/admin/sandbox-tenants/pages/new-tenant.component.html
@@ -92,6 +92,7 @@
           <property-override-tree-table
             [form]="tenantForm"
             [configurationProperties]="configurationProperties"
+            [readonly]="false"
             propertiesArrayName="configurationProperties"
           >
           </property-override-tree-table>
@@ -105,6 +106,7 @@
           <property-override-table
             [form]="tenantForm"
             [configurationProperties]="localizationOverrides"
+            [readonly]="false"
             propertiesArrayName="localizationOverrides"
           >
           </property-override-table>

--- a/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
@@ -55,7 +55,8 @@ describe('Utils', () => {
       foo: 'bar',
       state: {
         code: 'CA',
-        label: 'California'
+        label: 'California',
+        description: null
       },
       languages: ['en', 'es']
     };
@@ -63,6 +64,7 @@ describe('Utils', () => {
       foo: 'bar',
       'state.code': 'CA',
       'state.label': 'California',
+      'state.description': null,
       languages: 'en,es'
     });
   });

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -366,6 +366,8 @@ export function flattenJsonObject(ob: any): any {
     if (typeof ob[i] == 'object') {
       if (Array.isArray(ob[i])) {
         toReturn[i] = ob[i].join();
+      } else if (ob[i] == null) {
+        toReturn[i] = null;
       } else {
         const flatObject = flattenJsonObject(ob[i]);
         for (const x in flatObject) {


### PR DESCRIPTION
Snuck in a quick regression bug fix for making config properties *not* read only for the "create new tenants" screens