### PR TITLE
RP-461 Tenant Administration - DataSource password handling API

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
@@ -1,16 +1,18 @@
 package org.opentestsystem.rdw.admin;
 
+import org.opentestsystem.rdw.admin.client.DefaultConfigServerClient;
 import org.opentestsystem.rdw.admin.client.TenantConfigurationLookupClient;
 import org.opentestsystem.rdw.admin.client.TenantConfigurationLookupProperties;
 import org.opentestsystem.rdw.admin.service.impl.DefaultActuatorClientRdwService;
+
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
-import org.springframework.context.annotation.AdviceMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -56,6 +58,9 @@ import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @EnableConfigurationProperties
 public class ApplicationConfiguration {
+
+    @Value("${spring.cloud.config.uri}")
+    String configServerUri;
 
     @Bean
     public ReportingTenantIdResolver tenantIdResolver() {
@@ -140,8 +145,13 @@ public class ApplicationConfiguration {
     }
 
     @Bean
-    public DefaultActuatorClientRdwService defaultActuatorClientRdwService(){
+    public DefaultActuatorClientRdwService defaultActuatorClientRdwService() {
         return new DefaultActuatorClientRdwService(tenantConfigurationLookupClient());
+    }
+
+    @Bean
+    public DefaultConfigServerClient defaultConfigServerClient() {
+        return new DefaultConfigServerClient(configServerUri);
     }
 }
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/ConfigServerClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/ConfigServerClient.java
@@ -1,36 +1,37 @@
 package org.opentestsystem.rdw.admin.client;
 
-import org.checkerframework.checker.nullness.Opt;
-
-import java.util.Optional;
-
 /**
  * Client to the system's config Server
  */
 public interface ConfigServerClient {
     /**
-     *  Initiate a refresh of system properties by posting to the /monitor endpoint
-     *  atm refresh all reporting applications
+     * Initiate a refresh of system properties by posting to the /monitor endpoint
+     * atm refresh all reporting applications
+     *
+     * @throws IllegalArgumentException not able to call /monitor endpoint
      */
-    void postMonitor();
+    void postMonitor() throws IllegalArgumentException;
 
     /**
-     * @param service to search through for the dataSource's password
+     * @param service    to search through for the dataSource's password
      * @param dataSource of the password - need to be the property
      * @return the actual encrypted password of the dataSource for the service
+     * @throws IllegalArgumentException not able to to call service endpoint
      */
-    Optional<String> getActualServicePassword(String service, String dataSource);
+    String getActualServicePassword(String service, String dataSource) throws IllegalArgumentException;
 
     /**
      * @param password to encrypt
      * @return the encrypted password
+     * @throws IllegalArgumentException not able to call /encrypt endpoint
      */
-    Optional<String> encryptedPassword(String password);
+    String encryptPassword(String password) throws IllegalArgumentException;
 
     /**
-     * @param password encrypted
+     * @param password password to decrypt
      * @return the decrypted password
+     * @throws IllegalArgumentException not able to call /decrypt endpoint
      */
-    Optional<String> decryptedPassword(String password);
+    String decryptPassword(String password) throws IllegalArgumentException;
 
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/ConfigServerClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/ConfigServerClient.java
@@ -1,0 +1,36 @@
+package org.opentestsystem.rdw.admin.client;
+
+import org.checkerframework.checker.nullness.Opt;
+
+import java.util.Optional;
+
+/**
+ * Client to the system's config Server
+ */
+public interface ConfigServerClient {
+    /**
+     *  Initiate a refresh of system properties by posting to the /monitor endpoint
+     *  atm refresh all reporting applications
+     */
+    void postMonitor();
+
+    /**
+     * @param service to search through for the dataSource's password
+     * @param dataSource of the password - need to be the property
+     * @return the actual encrypted password of the dataSource for the service
+     */
+    Optional<String> getActualServicePassword(String service, String dataSource);
+
+    /**
+     * @param password to encrypt
+     * @return the encrypted password
+     */
+    Optional<String> encryptedPassword(String password);
+
+    /**
+     * @param password encrypted
+     * @return the decrypted password
+     */
+    Optional<String> decryptedPassword(String password);
+
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClient.java
@@ -13,12 +13,12 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Optional;
 
 /**
- * Client to retrieve the config server's uri to call the encrypt decrypt and monitor endpoints
+ * Client to retrieve the config server's uri to call the encrypt,decrypt, monitor (refresh) endpoints
+ * And call a service to retrieve the datasource's unmasked password
  */
 public class DefaultConfigServerClient implements ConfigServerClient {
     private static final Logger logger = LoggerFactory.getLogger(DefaultConfigServerClient.class);
 
-    //@Value("${spring.cloud.config.uri}")
     private String configServerUri;
     private RestTemplate restTemplate = new RestTemplate();
 
@@ -30,42 +30,47 @@ public class DefaultConfigServerClient implements ConfigServerClient {
     @Override
     public void postMonitor() {
         try {
-            // todo fix this
-            HttpHeaders headers = getHeaders();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
             HttpEntity<String> request = new HttpEntity<>("path=*", headers);
             ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/monitor", request, String.class);
-            logger.debug("Successfully called {}/encrypt returned {}.", configServerUri, responseEntity.getStatusCode());
+            logger.debug("Successfully called {}/monitor returned {}.", configServerUri, responseEntity.getStatusCode());
         } catch (Exception e) {
-            logger.debug("Cannot contact {}/monitor at this time.", configServerUri);
+            String errorMsg = String.format("Cannot contact %s/monitor at this time.", configServerUri);
+            logger.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg);
         }
     }
 
     @Override
-    public Optional<String> getActualServicePassword(final String service, final String dataSource) {
+    public String getActualServicePassword(final String service, final String dataSource) {
         // will need to know which service is being called - or I go get all of the passwords
         //todo work on this call
+
         try {
-            ResponseEntity<String> responseEntity = restTemplate.getForEntity(configServerUri + service +"/awsuat", String.class);
-            logger.debug("Successfully called {}/tbd returned {}.", configServerUri, responseEntity.getStatusCode());
-            return Optional.of(responseEntity.getBody());
+            ResponseEntity<String> responseEntity = restTemplate.getForEntity(configServerUri + service + "/awsuat", String.class);
+            logger.debug("Successfully called {}/{}/awsuat returned {}.", configServerUri, responseEntity.getStatusCode());
+            return responseEntity.getBody();
         } catch (Exception e) {
-            logger.debug("Cannot contact {}/tbd at this time.", configServerUri);
+            String errorMsg = String.format("Cannot contact %s/%s/awsuat at this time.", configServerUri, service);
+            logger.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg);
         }
-        return Optional.empty();
     }
 
     @Override
-    public Optional<String> encryptedPassword(final String encryptedPassword) {
+    public String encryptPassword(final String password) {
         try {
             HttpHeaders headers = getHeaders();
-            HttpEntity<String> request = new HttpEntity<>(encryptedPassword, headers);
+            HttpEntity<String> request = new HttpEntity<>(password, headers);
             ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/encrypt", request, String.class);
             logger.debug("Successfully called {}/encrypt returned {}.", configServerUri, responseEntity.getStatusCode());
-            return Optional.of(responseEntity.getBody());
+            return responseEntity.getBody();
         } catch (Exception e) {
-            logger.debug("Cannot contact {}/monitor at this time.", configServerUri);
+            String errorMsg = String.format("Cannot contact %s/encrypt at this time.", configServerUri);
+            logger.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg);
         }
-        return Optional.empty();
     }
 
     /**
@@ -78,18 +83,17 @@ public class DefaultConfigServerClient implements ConfigServerClient {
     }
 
     @Override
-    public Optional<String> decryptedPassword(final String password) {
-        // remove a {cipher} prefix if exists
-
+    public String decryptPassword(final String password) throws IllegalArgumentException {
         try {
             HttpHeaders headers = getHeaders();
             HttpEntity<String> request = new HttpEntity<>(password, headers);
             ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/decrypt", request, String.class);
             logger.debug("Successfully called {}/decrypt returned {}.", configServerUri, responseEntity.getStatusCode());
-            return Optional.of(responseEntity.getBody());
+            return responseEntity.getBody();
         } catch (Exception e) {
-            logger.debug("Cannot contact {} for /monitor at this time.", configServerUri);
+            String errorMsg = String.format("Cannot contact %s/decrypt at this time.", configServerUri);
+            logger.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg);
         }
-        return Optional.empty();
     }
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClient.java
@@ -1,0 +1,95 @@
+package org.opentestsystem.rdw.admin.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+/**
+ * Client to retrieve the config server's uri to call the encrypt decrypt and monitor endpoints
+ */
+public class DefaultConfigServerClient implements ConfigServerClient {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultConfigServerClient.class);
+
+    //@Value("${spring.cloud.config.uri}")
+    private String configServerUri;
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Autowired
+    public DefaultConfigServerClient(@Value("${spring.cloud.config.uri}") final String configServerUri) {
+        this.configServerUri = configServerUri;
+    }
+
+    @Override
+    public void postMonitor() {
+        try {
+            // todo fix this
+            HttpHeaders headers = getHeaders();
+            HttpEntity<String> request = new HttpEntity<>("path=*", headers);
+            ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/monitor", request, String.class);
+            logger.debug("Successfully called {}/encrypt returned {}.", configServerUri, responseEntity.getStatusCode());
+        } catch (Exception e) {
+            logger.debug("Cannot contact {}/monitor at this time.", configServerUri);
+        }
+    }
+
+    @Override
+    public Optional<String> getActualServicePassword(final String service, final String dataSource) {
+        // will need to know which service is being called - or I go get all of the passwords
+        //todo work on this call
+        try {
+            ResponseEntity<String> responseEntity = restTemplate.getForEntity(configServerUri + service +"/awsuat", String.class);
+            logger.debug("Successfully called {}/tbd returned {}.", configServerUri, responseEntity.getStatusCode());
+            return Optional.of(responseEntity.getBody());
+        } catch (Exception e) {
+            logger.debug("Cannot contact {}/tbd at this time.", configServerUri);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> encryptedPassword(final String encryptedPassword) {
+        try {
+            HttpHeaders headers = getHeaders();
+            HttpEntity<String> request = new HttpEntity<>(encryptedPassword, headers);
+            ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/encrypt", request, String.class);
+            logger.debug("Successfully called {}/encrypt returned {}.", configServerUri, responseEntity.getStatusCode());
+            return Optional.of(responseEntity.getBody());
+        } catch (Exception e) {
+            logger.debug("Cannot contact {}/monitor at this time.", configServerUri);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return httpHeaders for Text plain contentType
+     */
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        return headers;
+    }
+
+    @Override
+    public Optional<String> decryptedPassword(final String password) {
+        // remove a {cipher} prefix if exists
+
+        try {
+            HttpHeaders headers = getHeaders();
+            HttpEntity<String> request = new HttpEntity<>(password, headers);
+            ResponseEntity<String> responseEntity = restTemplate.postForEntity(configServerUri + "/decrypt", request, String.class);
+            logger.debug("Successfully called {}/decrypt returned {}.", configServerUri, responseEntity.getStatusCode());
+            return Optional.of(responseEntity.getBody());
+        } catch (Exception e) {
+            logger.debug("Cannot contact {} for /monitor at this time.", configServerUri);
+        }
+        return Optional.empty();
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/TenantConfigurationLookupClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/client/TenantConfigurationLookupClient.java
@@ -46,8 +46,8 @@ public class TenantConfigurationLookupClient {
             try {
                 ResponseEntity<String> responseEntity = restTemplate.getForEntity(url + "/configprops", String.class);
                 responses.add(responseEntity.getBody());
-            } catch(Exception e) {
-                logger.error("Cannot contact {} for configProps at this time.",url);
+            } catch (Exception e) {
+                logger.error("Cannot contact {} for configProps at this time.", url, e);
             }
         });
         return responses;
@@ -61,9 +61,9 @@ public class TenantConfigurationLookupClient {
 
         Map<String, ResponseEntity<String>> responseEntityMap = new HashMap<>();
         tenantConfigurationLookupProperties.getServices()
-                .forEach( (k,v) -> {
+                .forEach((k, v) -> {
                     ResponseEntity<String> responseEntity = restTemplate.getForEntity(v + "/configprops", String.class);
-                    if(responseEntity.getStatusCode().is2xxSuccessful()) {
+                    if (responseEntity.getStatusCode().is2xxSuccessful()) {
                         responseEntityMap.put(k, responseEntity);
                     }
                 });

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/TenantConfigService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/TenantConfigService.java
@@ -1,15 +1,14 @@
 package org.opentestsystem.rdw.admin.service;
 
-import java.util.Optional;
-
 /**
  * TenantConfigService to expose TenantConfigService features to the UI
  */
 public interface TenantConfigService {
     /**
      * give the ui the ability to decrypt a password so it can be displayed to a Tenant Admin user
+     *
      * @param encrypted password to decrypt
      * @return the decrypted password
      */
-    Optional<String> decrypt(String encrypted);
+    String decrypt(String encrypted) throws IllegalArgumentException;
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/TenantConfigService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/TenantConfigService.java
@@ -1,0 +1,15 @@
+package org.opentestsystem.rdw.admin.service;
+
+import java.util.Optional;
+
+/**
+ * TenantConfigService to expose TenantConfigService features to the UI
+ */
+public interface TenantConfigService {
+    /**
+     * give the ui the ability to decrypt a password so it can be displayed to a Tenant Admin user
+     * @param encrypted password to decrypt
+     * @return the decrypted password
+     */
+    Optional<String> decrypt(String encrypted);
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultTenantConfigService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultTenantConfigService.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.admin.service.impl;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
 import org.opentestsystem.rdw.admin.client.DefaultConfigServerClient;
 import org.opentestsystem.rdw.admin.service.TenantConfigService;
 
@@ -18,9 +17,9 @@ public class DefaultTenantConfigService implements TenantConfigService {
     }
 
     @Override
-    public Optional<String> decrypt(String encrypted) {
+    public String decrypt(String encrypted) throws IllegalArgumentException {
         // handle removing "{cipher}"
         final String cleanPassword = StringUtils.removeStart(encrypted, CIPHER);
-        return defaultConfigServerClient.decryptedPassword(encrypted);
+        return defaultConfigServerClient.decryptPassword(cleanPassword);
     }
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultTenantConfigService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultTenantConfigService.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import org.opentestsystem.rdw.admin.client.DefaultConfigServerClient;
+import org.opentestsystem.rdw.admin.service.TenantConfigService;
+
+@Service
+public class DefaultTenantConfigService implements TenantConfigService {
+
+    private DefaultConfigServerClient defaultConfigServerClient;
+    private final String CIPHER = "{cipher}";
+
+    public DefaultTenantConfigService(DefaultConfigServerClient defaultConfigServerClient) {
+        this.defaultConfigServerClient = defaultConfigServerClient;
+    }
+
+    @Override
+    public Optional<String> decrypt(String encrypted) {
+        // handle removing "{cipher}"
+        final String cleanPassword = StringUtils.removeStart(encrypted, CIPHER);
+        return defaultConfigServerClient.decryptedPassword(encrypted);
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TenantConfigController.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TenantConfigController.java
@@ -1,0 +1,28 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.opentestsystem.rdw.admin.service.impl.DefaultTenantConfigService;
+
+@RestController
+@RequestMapping("/config")
+public class TenantConfigController {
+    DefaultTenantConfigService service;
+
+    @Autowired
+    public TenantConfigController(DefaultTenantConfigService defaultTenantConfigService) {
+        this.service = defaultTenantConfigService;
+    }
+
+    @PostMapping(value = "/decrypt", consumes = MediaType.TEXT_PLAIN_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
+    String decrypt(@RequestBody final String encrypted) {
+        return service.decrypt(encrypted).orElseThrow(IllegalArgumentException::new);
+    }
+}
+
+

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TenantConfigController.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TenantConfigController.java
@@ -12,7 +12,7 @@ import org.opentestsystem.rdw.admin.service.impl.DefaultTenantConfigService;
 @RestController
 @RequestMapping("/config")
 public class TenantConfigController {
-    DefaultTenantConfigService service;
+    private DefaultTenantConfigService service;
 
     @Autowired
     public TenantConfigController(DefaultTenantConfigService defaultTenantConfigService) {
@@ -21,7 +21,7 @@ public class TenantConfigController {
 
     @PostMapping(value = "/decrypt", consumes = MediaType.TEXT_PLAIN_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
     String decrypt(@RequestBody final String encrypted) {
-        return service.decrypt(encrypted).orElseThrow(IllegalArgumentException::new);
+        return service.decrypt(encrypted);
     }
 }
 

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClientTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClientTest.java
@@ -1,0 +1,75 @@
+package org.opentestsystem.rdw.admin.client;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.springframework.test.annotation.IfProfileValue;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+// TODO RP-394 Move some integration test (IT) to End to End tests (ETE) and configure to run in CI
+//this test only runs against a local docker instance
+// set this property to run this test (or temporarily comment out this annotation)
+// java -Dtenant-client.docker-it-enable=true
+@Ignore
+@IfProfileValue(name = "tenant-client.docker-it-enable", value = "true")
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"spring.cloud.config"})
+@EnableConfigurationProperties
+public class DefaultConfigServerClientTest {
+
+    private RestTemplate restTemplate = new RestTemplate();
+    private DefaultConfigServerClient defaultConfigServerClient;
+    @Value("${spring.cloud.config.uri}")
+    private String configServerUri;
+    private String password = "thepassword";
+
+    @Before
+    public void setup() {
+        defaultConfigServerClient = new DefaultConfigServerClient(configServerUri);
+    }
+
+    @Ignore
+    @Test
+    public void itShouldLoadConfig() {
+        assertThat(configServerUri).isNotNull();
+    }
+
+    @Ignore
+    @Test
+    public void itShouldEncryptPasswordAndSuccessfullyDecryptIt() {
+        // the encryption returns a different cipher on each request - all decrypt to the expected password
+        final Optional<String> encrypted = defaultConfigServerClient.encryptedPassword(password);
+        assertThat(encrypted).isPresent();
+        final Optional<String> decryptedPassword = defaultConfigServerClient.decryptedPassword(encrypted.get());
+        assertThat(decryptedPassword).isPresent();
+        assertThat(decryptedPassword.get()).isEqualTo(password);
+    }
+
+    @Ignore
+    @Test
+    public void itShouldPostMonitor() {
+        defaultConfigServerClient.postMonitor();
+    }
+
+
+    @Ignore
+    @Test
+    public void itShouldCallConfigServerEndpointForRealPassword() {
+        final Optional<String> reporting_ro_json = defaultConfigServerClient.getActualServicePassword("rdw-reporting-service", "reporting_ro");
+        assertThat(reporting_ro_json).isPresent();
+    }
+
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClientTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/client/DefaultConfigServerClientTest.java
@@ -51,11 +51,10 @@ public class DefaultConfigServerClientTest {
     @Test
     public void itShouldEncryptPasswordAndSuccessfullyDecryptIt() {
         // the encryption returns a different cipher on each request - all decrypt to the expected password
-        final Optional<String> encrypted = defaultConfigServerClient.encryptedPassword(password);
-        assertThat(encrypted).isPresent();
-        final Optional<String> decryptedPassword = defaultConfigServerClient.decryptedPassword(encrypted.get());
-        assertThat(decryptedPassword).isPresent();
-        assertThat(decryptedPassword.get()).isEqualTo(password);
+        final String encrypted = defaultConfigServerClient.encryptPassword(password);
+        assertThat(encrypted).isNotNull();
+        final String decryptedPassword = defaultConfigServerClient.decryptPassword(encrypted);
+        assertThat(decryptedPassword).isNotNull().isEqualTo(password);
     }
 
     @Ignore
@@ -68,8 +67,8 @@ public class DefaultConfigServerClientTest {
     @Ignore
     @Test
     public void itShouldCallConfigServerEndpointForRealPassword() {
-        final Optional<String> reporting_ro_json = defaultConfigServerClient.getActualServicePassword("rdw-reporting-service", "reporting_ro");
-        assertThat(reporting_ro_json).isPresent();
+        final String reporting_ro_json = defaultConfigServerClient.getActualServicePassword("rdw-reporting-service", "reporting_ro");
+        assertThat(reporting_ro_json).isNotNull();
     }
 
 }

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/TenantConfigServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/TenantConfigServiceTest.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.admin.service.impl;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Optional;
 import org.opentestsystem.rdw.admin.client.DefaultConfigServerClient;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,20 +27,20 @@ public class TenantConfigServiceTest {
     @Test
     public void
     itShouldDecryptSuccessfully() {
-        when(defaultConfigServerClient.decryptedPassword(any())).thenReturn(Optional.of("decryptedResults"));
-        Optional<String> decrypted = service.decrypt("{cypher}BlahBlah");
-        assertThat(decrypted).isPresent();
-        assertThat(decrypted.get()).isEqualTo("decryptedResults");
-        verify(defaultConfigServerClient).decryptedPassword(any());
+        final String encryptedPassword = "DEADBEEF";
+        when(defaultConfigServerClient.decryptPassword(encryptedPassword)).thenReturn("decryptedResults");
+        String decrypted = service.decrypt("{cipher}" + encryptedPassword);
+        assertThat(decrypted).isNotNull().isEqualTo("decryptedResults");
+        verify(defaultConfigServerClient).decryptPassword(any());
     }
 
     @Test
     public void
     itShouldDecryptSuccessfullyWithNoCipher() {
-        when(defaultConfigServerClient.decryptedPassword(any())).thenReturn(Optional.of("decryptedResults"));
-        Optional<String> decrypted = service.decrypt("BlahBlah");
-        assertThat(decrypted).isPresent();
-        assertThat(decrypted.get()).isEqualTo("decryptedResults");
-        verify(defaultConfigServerClient).decryptedPassword(any());
+        final String encryptedPassword = "DEADBEEF";
+        when(defaultConfigServerClient.decryptPassword(encryptedPassword)).thenReturn("decryptedResults");
+        String decrypted = service.decrypt(encryptedPassword);
+        assertThat(decrypted).isNotNull().isEqualTo("decryptedResults");
+        verify(defaultConfigServerClient).decryptPassword(any());
     }
 }

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/TenantConfigServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/TenantConfigServiceTest.java
@@ -1,0 +1,47 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import org.opentestsystem.rdw.admin.client.DefaultConfigServerClient;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TenantConfigServiceTest {
+
+    private DefaultConfigServerClient defaultConfigServerClient;
+    private DefaultTenantConfigService service;
+
+    @Before
+    public void setUp() {
+        defaultConfigServerClient = mock(DefaultConfigServerClient.class);
+        service = new DefaultTenantConfigService(defaultConfigServerClient);
+    }
+
+    @Test
+    public void
+    itShouldDecryptSuccessfully() {
+        when(defaultConfigServerClient.decryptedPassword(any())).thenReturn(Optional.of("decryptedResults"));
+        Optional<String> decrypted = service.decrypt("{cypher}BlahBlah");
+        assertThat(decrypted).isPresent();
+        assertThat(decrypted.get()).isEqualTo("decryptedResults");
+        verify(defaultConfigServerClient).decryptedPassword(any());
+    }
+
+    @Test
+    public void
+    itShouldDecryptSuccessfullyWithNoCipher() {
+        when(defaultConfigServerClient.decryptedPassword(any())).thenReturn(Optional.of("decryptedResults"));
+        Optional<String> decrypted = service.decrypt("BlahBlah");
+        assertThat(decrypted).isPresent();
+        assertThat(decrypted.get()).isEqualTo("decryptedResults");
+        verify(defaultConfigServerClient).decryptedPassword(any());
+    }
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantConfigControllerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantConfigControllerTest.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import org.opentestsystem.rdw.admin.service.impl.DefaultTenantConfigService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = {TenantConfigController.class}, secure = false)
+public class TenantConfigControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    DefaultTenantConfigService service;
+
+    @Test
+    public void isShouldSuccessfullyCallDecrypt() throws Exception {
+        when(service.decrypt(any(String.class))).thenReturn(Optional.of("decryptedResults"));
+        String encrypted = "{Cipher}BlahBlah";
+        mvc.perform(post("/config/decrypt")
+                .content(encrypted)
+                .characterEncoding("UTF-8")
+                .contentType(MediaType.TEXT_PLAIN_VALUE)
+                .accept(MediaType.TEXT_PLAIN_VALUE))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantConfigControllerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantConfigControllerTest.java
@@ -9,10 +9,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
 import org.opentestsystem.rdw.admin.service.impl.DefaultTenantConfigService;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,8 +26,9 @@ public class TenantConfigControllerTest {
 
     @Test
     public void isShouldSuccessfullyCallDecrypt() throws Exception {
-        when(service.decrypt(any(String.class))).thenReturn(Optional.of("decryptedResults"));
         String encrypted = "{Cipher}BlahBlah";
+
+        when(service.decrypt(encrypted)).thenReturn("decryptedResults");
         mvc.perform(post("/config/decrypt")
                 .content(encrypted)
                 .characterEncoding("UTF-8")

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantControllerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/web/TenantControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 
 import com.google.common.collect.ImmutableSet;
-import com.jayway.jsonpath.JsonPath;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)

--- a/admin-service/src/test/resources/application-tenant_client_docker.yml
+++ b/admin-service/src/test/resources/application-tenant_client_docker.yml
@@ -12,8 +12,3 @@ tenant-configuration-lookup-test:
       url: http://localhost:8086
     reporting-service:
       url: http://localhost:8108
-
-spring:
-  cloud:
-    config:
-      uri: ${CONFIG_SERVICE_URL:http://localhost:8888}

--- a/admin-service/src/test/resources/application-tenant_client_docker.yml
+++ b/admin-service/src/test/resources/application-tenant_client_docker.yml
@@ -12,3 +12,8 @@ tenant-configuration-lookup-test:
       url: http://localhost:8086
     reporting-service:
       url: http://localhost:8108
+
+spring:
+  cloud:
+    config:
+      uri: ${CONFIG_SERVICE_URL:http://localhost:8888}


### PR DESCRIPTION
Part one of the changes needed, this will unblock UI dev
New service to expose decrypt API endpoint, this handles and expected encrypted string values created from the configServer's envrypt function/endpoint.  It will also handle removing the {cipher} prefix from the encrpyted string if it exists.
Created ConfigServerClient that will call the config server's enpoint for encrypt and decrypt, monitor and to retrieve the unmasked passwords.
the client pulls inthe uri from the spring.cloud.config.uri endpoint
TODO complete the work for the monitor and unmasked passwords in a TenantConfiguration