### PR TITLE
Feature/rp 494 dataset configuration reporting

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/ApplicationConfiguration.java
@@ -10,6 +10,7 @@ import org.opentestsystem.rdw.admin.service.impl.DefaultActuatorClientRdwService
 import org.opentestsystem.rdw.multitenant.messaging.TenantChannelInterceptor;
 import org.opentestsystem.rdw.multitenant.messaging.TenantMessageRequestResolver;
 import org.opentestsystem.rdw.reporting.common.multitenant.ReportingTenantMessageRequestResolver;
+import org.opentestsystem.rdw.reporting.common.multitenant.SandboxDataSets;
 import org.opentestsystem.rdw.reporting.common.stream.DefaultMessageSecurityService;
 import org.opentestsystem.rdw.reporting.common.stream.MessageSecurityService;
 import org.opentestsystem.rdw.reporting.common.web.security.jwt.JwtService;
@@ -174,6 +175,13 @@ public class ApplicationConfiguration {
     @GlobalChannelInterceptor(patterns = {"Report*", "Aggregate*", "UserReport*", "tenant-*"})
     public TenantChannelInterceptor getTenantChannelInterceptor(TenantMessageRequestResolver getTenantMessageRequestResolver) {
         return new TenantChannelInterceptor(getTenantMessageRequestResolver);
+    }
+
+    @Bean
+    @ConfigurationProperties("sandbox-datasets")
+    @RefreshScope
+    public SandboxDataSets sandboxDatasets() {
+        return new SandboxDataSets();
     }
 }
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationPackage.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationPackage.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.admin.model;
 
 import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.reporting.common.multitenant.DataSet;
 
 import java.util.Set;
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/SandboxConfigurationStubs.java
@@ -1,13 +1,10 @@
 package org.opentestsystem.rdw.admin.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingPropertiesTenant;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
 
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Set;
+import org.opentestsystem.rdw.reporting.common.multitenant.DataSet;
+
 
 /**
  * SandboxConfigurationPackage and Sandbox configurations used for testing
@@ -43,6 +40,7 @@ public class SandboxConfigurationStubs {
 
         return dataSets;
     }
+
     public static SandboxConfiguration getCaInterimSandboxConfiguration() {
         SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
         sandboxConfiguration.setSandbox(getSandboxCAInfo());
@@ -57,6 +55,7 @@ public class SandboxConfigurationStubs {
         applicationSandboxConfiguration.setAggregateReportingPropertiesTenant(TenantConfigurationStubs.getAggregrateReportingProperties());
         return applicationSandboxConfiguration;
     }
+
     public static SandboxConfiguration getMiInterimSandboxConfiguration() {
         SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
         sandboxConfiguration.setSandbox(getSandboxMIInfo());

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TenantConfiguration.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TenantConfiguration.java
@@ -1,12 +1,10 @@
 package org.opentestsystem.rdw.admin.model;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.opentestsystem.rdw.admin.web.RawJsonDeserializer;
 import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.reporting.common.multitenant.SandboxDataSets;
 
 /**
  * This contains tenant specific configuration, tenant, properties and localization for a tenant.
@@ -22,6 +20,7 @@ public class TenantConfiguration {
     @JsonDeserialize(using = RawJsonDeserializer.class)
     @JsonRawValue
     private String localization;
+    private SandboxDataSets sandboxDatasets;
 
     public TenantConfiguration() { }
 
@@ -49,158 +48,11 @@ public class TenantConfiguration {
         this.localization = localization;
     }
 
+    public SandboxDataSets getSandboxDatasets() {
+        return sandboxDatasets;
+    }
 
-    // parse out the Json String into service specific properties
-    /*  Sample Json expectations
-{
-   "applicationTenantConfiguration":{
-      "datasources":{
-         "reporting_ro":{
-            "url-server":"rdw-aurora-",
-            "username":"sbac",
-            "password":"****",
-            "initialSize":"1",
-            "maxActive":"2"
-         },
-         "warehouse_rw":{
-            "url-server":"rdw-aurora-",
-            "username":"sbac",
-            "password":"****",
-            "initialSize":"1",
-            "maxActive":"2"
-         },
-         "olap_ro":{
-            "url-server":"rdw-aurora-",
-            "username":"sbac",
-            "password":"****",
-            "initialSize":"1",
-            "maxActive":"2"
-         },
-         "reporting_rw":{
-            "url-server":"rdw-aurora-",
-            "username":"sbac",
-            "password":"****",
-            "initialSize":"1",
-            "maxActive":"2"
-         }
-      },
-      "reporting":{
-         "school-year":"2018",
-         "transfer-access-enabled":"true",
-         "translation-location":"binary-",
-         "analytics-tracking-id":"UA-102446884-4",
-         "interpretive-guide-url":"https://portal.smarterbalanced.org/library/en/reporting-system-interpretive-guide.pdf",
-         "user-guide-url":"https://portal.smarterbalanced.org/library/en/reporting-system-user-guide.pdf",
-         "access-denied-url":"forward:/assets/public/access-denied.html",
-         "landing-page-url":"forward:/landing.html",
-         "percentile-display-enabled":"true",
-         "report-languages":"es",
-         "ui-languages":"es",
-         "student-fields":{
-            "EconomicDisadvantage":"disabled",
-            "LimitedEnglishProficiency":"disabled",
-            "MigrantStatus":"enabled",
-            "EnglishLanguageAcquisitionStatus":"enabled",
-            "PrimaryLanguage":"enabled",
-            "Ethnicity":"enabled",
-            "Gender":"admin",
-            "IndividualEducationPlan":"admin",
-            "Section504":"admin"
-         },
-         "state":{
-            "code":"CA",
-            "name":"California"
-         }
-      },
-      "archive":{
-         "uri-root":"s3://default-archive",
-         "path-prefix":"default-prefix",
-         "s3-access-key":"default_access_key",
-         "s3-secret-key":"default_secret_key",
-         "s3-region-static":"us-west-2",
-         "s3-sse":"default"
-      },
-      "aggregator":{
-         "assessment-types":[
-            "ica",
-            "sum",
-            "iab"
-         ],
-         "statewide-user-assessment-types":"sum",
-         "state-aggregate-assessment-types":"sum"
-      }
-   },
-   "tenants":[
-      {
-         "tenant":{
-            "id":"CA",
-            "key":"CA",
-            "name":"California",
-            "description":"This is a description"
-         },
-         "applicationTenantConfiguration":{
-            "datasources":{
-               "reporting_ro":{
-                  "initialSize":"1",
-                  "maxActive":"2"
-               },
-               "warehouse_rw":{
-                  "initialSize":"1",
-                  "maxActive":"2"
-               },
-               "olap_ro":{
-                  "initialSize":"1",
-                  "maxActive":"2"
-               },
-               "reporting_rw":{
-                  "initialSize":"1",
-                  "maxActive":"2"
-               }
-            },
-            "reporting":{
-               "percentile-display-enabled":"false",
-               "student-fields":{
-                  "EconomicDisadvantage":"enabled"
-               },
-               "state":{
-                  "code":"CA",
-                  "name":"California"
-               }
-            },
-            "archive":{
-               "uri-root":"s3://ca-archive",
-               "path-prefix":"ca",
-               "s3-access-key":"ca_access_key",
-               "s3-secret-key":"ca_secret_key",
-               "s3-sse":"ca"
-            },
-            "aggregator":{
-               "statewide-user-assessment-types":"iab",
-               "state-aggregate-assessment-types":"sum"
-            }
-         },
-         "localizationProperties":{
-              "common" : {
-                "ethnicity": {
-                  "AmericanIndianOrAlaskaNative": "American Indian or Alaska Native",
-                  "Asian": "Asian",
-                  "BlackOrAfricanAmerican": "Black or African American",
-                  "DemographicRaceTwoOrMoreRaces": "Demographic Race of Two or More",
-                  "Filipino": "Filipino",
-                  "HispanicOrLatinoEthnicity": "Hispanic/Latino",
-                  "NativeHawaiianOrOtherPacificIslander": "Native Hawaiian or Pacific Islander",
-                  "White": "White"
-                },
-                "gender": {
-                    "Female": "Female",
-                    "Male": "Male",
-                    "Nonbinary": "Nonbinary",
-                    "undefined": "Not Stated"
-                  }
-	          }
-         }
-      }
-   ]
-}
-*/
+    public void setSandboxDatasets(final SandboxDataSets sandboxDatasets) {
+        this.sandboxDatasets = sandboxDatasets;
+    }
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/database/impl/DefaultTenantDatabaseCreationService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/database/impl/DefaultTenantDatabaseCreationService.java
@@ -47,7 +47,7 @@ public class DefaultTenantDatabaseCreationService implements TenantDatabaseCreat
     public void createSandboxDatabases(TenantConfiguration tenantConfiguration) {
         Set<DatabaseInformation> databaseInformationSet = gatherDatabaseInformation(tenantConfiguration);
         createDatabasesCore(databaseInformationSet);
-        runDatasetLoad(databaseInformationSet, tenantConfiguration.getTenant().getSandboxDataset());
+//        runDatasetLoad(databaseInformationSet, tenantConfiguration.getTenant().getSandboxDataset());
     }
 
     private void createDatabasesCore(Set<DatabaseInformation> databaseInformationSet) {
@@ -258,7 +258,7 @@ public class DefaultTenantDatabaseCreationService implements TenantDatabaseCreat
             RdwDatabaseType dbType = dataSourceNameToRdwDatabaseType(key);
             String name;
             if (dbType.isOlap) {
-                name = value.getSchemaSearchPath();
+                name = "prefix"; // TODO FIX value.getSchemaSearchPath();
             } else {
                 name = value.getUrlParts().getDatabase();
             }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxService.java
@@ -4,20 +4,20 @@ import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfiguration;
 import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
 import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
 import org.opentestsystem.rdw.admin.model.SandboxConfigurationPackage;
-import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
 import org.opentestsystem.rdw.admin.model.TenantConfigurationStubs;
 import org.opentestsystem.rdw.admin.repository.impl.InMemorySandboxConfigurationRepository;
 import org.opentestsystem.rdw.admin.service.SandboxService;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
-import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingPropertiesTenant;
-import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
 import org.opentestsystem.rdw.reporting.common.multitenant.ReportingTenantIdResolver;
+import org.opentestsystem.rdw.reporting.common.multitenant.SandboxDataSets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -32,32 +32,17 @@ public class DefaultSandboxService implements SandboxService {
     private ReportingTenantIdResolver reportingTenantIdResolver;
     private DefaultTenantConfigPropsService defaultTenantConfigPropsService;
     private TenantProperties tenantProperties;
-
+    private SandboxDataSets sandboxDatasets;
 
     @Autowired
     DefaultSandboxService(InMemorySandboxConfigurationRepository inMemorySandboxConfigurationRepository,
                           ReportingTenantIdResolver reportingTenantIdResolver, DefaultTenantConfigPropsService defaultTenantConfigPropsService,
-                          TenantProperties tenantProperties) {
+                          TenantProperties tenantProperties, SandboxDataSets sandboxDatasets) {
         this.inMemorySandboxConfigurationRepository = inMemorySandboxConfigurationRepository;
         this.reportingTenantIdResolver = reportingTenantIdResolver;
         this.defaultTenantConfigPropsService = defaultTenantConfigPropsService;
         this.tenantProperties = tenantProperties;
-        // todo: remove mock - Populate with mock sandboxConfigurations at service start
-        addMockData();
-    }
-
-    /**
-     * TODO remove once retrieving real data
-     */
-    private void addMockData() {
-        if(inMemorySandboxConfigurationRepository.getAll().isEmpty()) {
-            SandboxConfiguration caSandbox = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
-            caSandbox.getSandbox().setTenantKey(getCurrentTenantKey());
-            SandboxConfiguration miSandbox = SandboxConfigurationStubs.getMiInterimSandboxConfiguration();
-            miSandbox.getSandbox().setTenantKey(getCurrentTenantKey());
-            inMemorySandboxConfigurationRepository.create(caSandbox);
-            inMemorySandboxConfigurationRepository.create(miSandbox);
-        }
+        this.sandboxDatasets = sandboxDatasets;
     }
 
     @Override
@@ -82,6 +67,7 @@ public class DefaultSandboxService implements SandboxService {
         sandboxConfiguration.getSandbox().setId(newId);
         sandboxConfiguration.getSandbox().setTenantKey(getCurrentTenantKey());
         validateNewSandbox(sandboxConfiguration);
+        // TODO actually all the sandbox creation
         return inMemorySandboxConfigurationRepository.create(sandboxConfiguration);
     }
 
@@ -89,44 +75,38 @@ public class DefaultSandboxService implements SandboxService {
     public SandboxConfiguration update(final SandboxConfiguration sandboxConfiguration) {
         logger.debug("Updating with sandbox with key = {}", sandboxConfiguration.getSandbox().getKey());
         validateExistingSandbox(sandboxConfiguration);
+        // TODO actually all the sandbox update
         return inMemorySandboxConfigurationRepository.update(sandboxConfiguration);
     }
 
     @Override
     public void delete(final String key) {
-        logger.debug("removing the sandbox key {}",key);
+        logger.debug("removing the sandbox key {}", key);
+        // TODO actually all the sandbox delete
         inMemorySandboxConfigurationRepository.delete(key);
     }
 
     @Override
     public void resetDataSet(String key) {
-        logger.info("Resetting the DataSet for the Sandbox key {}",key);
+        logger.info("Resetting the DataSet for the Sandbox key {}", key);
         // todo actually reset the data - just calling a inMemory func for now
         inMemorySandboxConfigurationRepository.reset(key);
     }
 
+    /**
+     * @return SandboxConfigurationPackage containing the default sandbox properties, the datasets and the list of current sandboxes
+     */
     private SandboxConfigurationPackage getCurrentDefaultSandboxPackage() {
         defaultTenantConfigPropsService.servicesPropertiesRefresh();
         final SandboxConfigurationPackage sandboxConfigurationPackage = new SandboxConfigurationPackage();
         ApplicationSandboxConfiguration applicationSandboxConfiguration = defaultTenantConfigPropsService.getDefaultApplicationSandboxConfiguration();
-        // TODO remove mock
-        if(applicationSandboxConfiguration.getReporting() == null) {
-            logger.error("Cannot retrieve the current reporting system settings :: Using MOCK Data");
-            applicationSandboxConfiguration.setReporting(
-                    SandboxConfigurationStubs.getApplicationSandboxConfigurationDefault().getApplicationSandboxConfiguration().getReporting());
-        }
-        if(applicationSandboxConfiguration.getAggregateReportingPropertiesTenant() == null) {
-            logger.error("Cannot retrieve the current AggregateReportingProperties :: Using MOCK Data");
-            applicationSandboxConfiguration.setAggregateReportingPropertiesTenant(
-                    SandboxConfigurationStubs.getApplicationSandboxConfigurationDefault()
-                            .getApplicationSandboxConfiguration().getAggregateReportingPropertiesTenant());
 
-        }
-        //TODO Replace with real dataSets call
-        sandboxConfigurationPackage.setDataSets(SandboxConfigurationStubs.getDataSets());
+        // Add the preconfigured DatSets to default package
+        sandboxConfigurationPackage.setDataSets(new HashSet<>(sandboxDatasets.getSandboxDatasets()));
+
         sandboxConfigurationPackage.setApplicationSandboxConfiguration(applicationSandboxConfiguration);
         final Optional<Tenant> tenant = tenantProperties.findTenantById(getCurrentTenantKey());
-        if(tenant.isPresent()) {
+        if (tenant.isPresent()) {
             sandboxConfigurationPackage.setTenant(tenant.get());
         } else {
             logger.error("Cannot retrieve the current Tenant Info, only setting key & Id, and the rest with mock CA data");
@@ -152,11 +132,15 @@ public class DefaultSandboxService implements SandboxService {
     }
 
     /**
-     * @return the current TenantKey - and if null the mock tenant for now.
+     * @return the current TenantKey
      */
     private String getCurrentTenantKey() {
-        // todo replace else with something else
-        return reportingTenantIdResolver.getTenantId().orElse(SandboxConfigurationStubs.getSandboxCAInfo().getTenantKey());
+        if(reportingTenantIdResolver.getTenantId().isPresent()) {
+            return reportingTenantIdResolver.getTenantId().get();
+        }
+        String errorMsg = "A Tenant must be configured to create a Sandbox.";
+        logger.error(errorMsg);
+        throw new IllegalArgumentException(errorMsg);
     }
 
     /**
@@ -173,12 +157,12 @@ public class DefaultSandboxService implements SandboxService {
     }
 
     /**
-     * @return a tenant based ID - using a hash of the current time
+     * @return a tenant based ID - using a hash of the current time TODO Update or remove
      */
     private String generateId(String tenantId) {
         String ms = String.valueOf(System.currentTimeMillis());
         String ts = String.valueOf(ms.substring(7, 10).hashCode());
-        logger.debug("hasCode is = {}", ts );
+        logger.debug("hasCode is = {}", ts);
         return tenantId + "-" + ts;
     }
 }

--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -207,3 +207,10 @@ tenant-configuration-lookup:
       url: http://localhost:8086
     reporting-service:
       url: http://localhost:8108
+
+sandbox-datasets:
+  sandbox-datasets:
+    - label: Demo Dataset
+      id: demo-dataset
+    - label: SBAC Dataset
+      id: sbac-dataset

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultSandboxServiceTest.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.admin.service.impl;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.opentestsystem.rdw.admin.model.ApplicationSandboxConfigurations;
 import org.opentestsystem.rdw.admin.model.SandboxConfiguration;
 import org.opentestsystem.rdw.admin.model.SandboxConfigurationStubs;
@@ -12,7 +13,10 @@ import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingPropertiesTenant;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
 import org.opentestsystem.rdw.reporting.common.multitenant.ReportingTenantIdResolver;
+import org.opentestsystem.rdw.reporting.common.multitenant.SandboxDataSets;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -31,7 +35,7 @@ public class DefaultSandboxServiceTest {
     private ReportingTenantIdResolver reportingTenantIdResolver;
     private DefaultTenantConfigPropsService defaultTenantConfigPropsService;
     private TenantProperties tenantProperties;
-
+    private SandboxDataSets sandboxDataSets;
 
     @Before
     public void setup() {
@@ -39,13 +43,15 @@ public class DefaultSandboxServiceTest {
         reportingTenantIdResolver = mock(ReportingTenantIdResolver.class);
         defaultTenantConfigPropsService = mock(DefaultTenantConfigPropsService.class);
         tenantProperties = mock(TenantProperties.class);
+        sandboxDataSets = mock(SandboxDataSets.class); //
+        when(sandboxDataSets.getSandboxDatasets()).thenReturn(new ArrayList<>(SandboxConfigurationStubs.getDataSets()));
         when(reportingTenantIdResolver.getTenantId()).thenReturn(
                 Optional.of(SandboxConfigurationStubs.getSandboxCAInfo().getKey()));
-        service = new DefaultSandboxService(inMemorySandboxConfigurationRepository, reportingTenantIdResolver, defaultTenantConfigPropsService, tenantProperties );
+        service = new DefaultSandboxService(inMemorySandboxConfigurationRepository, reportingTenantIdResolver, defaultTenantConfigPropsService, tenantProperties, sandboxDataSets);
     }
 
     @Test
-    public void itShouldRetrieveAllSandboxes(){
+    public void itShouldRetrieveAllSandboxes() {
         SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
         SandboxConfiguration sandboxConfigurationMi = SandboxConfigurationStubs.getMiInterimSandboxConfiguration();
         Set<SandboxConfiguration> sandboxConfigurations = ImmutableSet.of(sandboxConfigurationCa, sandboxConfigurationMi);
@@ -55,12 +61,12 @@ public class DefaultSandboxServiceTest {
                 .thenReturn(SandboxConfigurationStubs.getApplicationSandboxConfigurationDefault().getApplicationSandboxConfiguration());
         when(tenantProperties.findTenantById(any())).thenReturn(Optional.of(TenantConfigurationStubs.getTenantCA()));
 
-
         ApplicationSandboxConfigurations applicationSandboxConfigurations = service.getAll();
 
-        verify(inMemorySandboxConfigurationRepository,times(2)).getAll();
+        verify(inMemorySandboxConfigurationRepository).getAll();
         verify(defaultTenantConfigPropsService).getDefaultApplicationSandboxConfiguration();
         verify(tenantProperties).findTenantById(any());
+        verify(sandboxDataSets).getSandboxDatasets();
 
         assertThat(applicationSandboxConfigurations).isNotNull();
         assertThat(applicationSandboxConfigurations.getSandboxConfigurationPackage()).isNotNull();
@@ -69,13 +75,13 @@ public class DefaultSandboxServiceTest {
 
         Optional<SandboxConfiguration> sandboxCa = getSandboxConfigurationFromKey(applicationSandboxConfigurations, sandboxConfigurationCa.getSandbox().getKey());
         assertThat(sandboxCa).isPresent();
-        if(sandboxCa.isPresent()) {
+        if (sandboxCa.isPresent()) {
             verifySandboxes(sandboxCa.get(), sandboxConfigurationCa);
         }
 
         Optional<SandboxConfiguration> sandboxMi = getSandboxConfigurationFromKey(applicationSandboxConfigurations, sandboxConfigurationMi.getSandbox().getKey());
         assertThat(sandboxMi).isPresent();
-        if(sandboxMi.isPresent()) {
+        if (sandboxMi.isPresent()) {
             verifySandboxes(sandboxMi.get(), sandboxConfigurationMi);
         }
     }
@@ -121,7 +127,7 @@ public class DefaultSandboxServiceTest {
         verify(inMemorySandboxConfigurationRepository).reset(key);
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void itShouldNotCreateSandbox() {
         SandboxConfiguration sandboxConfigurationCa = SandboxConfigurationStubs.getCaInterimSandboxConfiguration();
         when(inMemorySandboxConfigurationRepository.create(sandboxConfigurationCa)).thenReturn(sandboxConfigurationCa);
@@ -154,7 +160,8 @@ public class DefaultSandboxServiceTest {
 
     /**
      * the aggregator property lists can be null
-     * @param aggregateProperties retrieved properties
+     *
+     * @param aggregateProperties         retrieved properties
      * @param expectedAggregateProperties expected properties
      */
     private void verifyAggregatorProperties(AggregateReportingPropertiesTenant aggregateProperties, AggregateReportingPropertiesTenant expectedAggregateProperties) {
@@ -162,6 +169,7 @@ public class DefaultSandboxServiceTest {
         assertThat(aggregateProperties.getStateAggregateAssessmentTypes().size()).isEqualTo(expectedAggregateProperties.getStateAggregateAssessmentTypes().size());
         assertThat(aggregateProperties.getStatewideUserAssessmentTypes().size()).isEqualTo(expectedAggregateProperties.getStatewideUserAssessmentTypes().size());
     }
+
     private void verifyLocalization(final String localization, final String expectedLocalization) {
         assertThat(localization).isEqualTo(expectedLocalization);
     }
@@ -191,8 +199,9 @@ public class DefaultSandboxServiceTest {
 
     /**
      * Lookup the given key in the ApplicationSandboxConfigurations sandbox list
+     *
      * @param applicationSandboxConfigurations contains the list of sandboxes to look through
-     * @param key The key of the sandbox to find
+     * @param key                              The key of the sandbox to find
      * @return SandboxConfiguration if key is found
      */
     private Optional<SandboxConfiguration> getSandboxConfigurationFromKey(final ApplicationSandboxConfigurations applicationSandboxConfigurations, String key) {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/DataSet.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/DataSet.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.admin.model;
+package org.opentestsystem.rdw.reporting.common.multitenant;
 
 /**
  * DataSet is a preconfigured set of metadata the Sandbox uses.
@@ -6,11 +6,11 @@ package org.opentestsystem.rdw.admin.model;
 public class DataSet {
     private String label;
     /**
-     * unique id for the DataSet
+     * unique id for the DataSet, it's the directory
      */
     private String id;
 
-    DataSet() {}
+    public DataSet() {}
 
     public String getLabel() {
         return label;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/SandboxDataSets.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/SandboxDataSets.java
@@ -1,0 +1,21 @@
+package org.opentestsystem.rdw.reporting.common.multitenant;
+
+import java.util.List;
+
+/**
+ * Container for the collection of Sandbox DataSets
+ */
+public class SandboxDataSets {
+    private List<DataSet> sandboxDatasets;
+
+    public SandboxDataSets() {
+    }
+
+    public List<DataSet> getSandboxDatasets() {
+        return sandboxDatasets;
+    }
+
+    public void setSandboxDatasets(final List<DataSet> sandboxDatasets) {
+        this.sandboxDatasets = sandboxDatasets;
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/multitenant/SandboxDataSetsTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/multitenant/SandboxDataSetsTest.java
@@ -1,0 +1,49 @@
+package org.opentestsystem.rdw.reporting.common.multitenant;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// TODO RP-394 Move some integration test (IT) to End to End tests (ETE) and configure to run in CI
+//this test only runs against a local docker instance
+// set this property to run this test (or temporarily comment out this annotation)
+// java -Dtenant-client.docker-it-enable=true
+@Ignore
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"sandbox_datasets"})
+@EnableConfigurationProperties
+public class SandboxDataSetsTest {
+
+    @Autowired
+    SandboxDataSets sandboxDataSets;
+
+    @Ignore
+    @Test
+    public void itShouldLoadSandboxDataSets() {
+        assertThat(sandboxDataSets).isNotNull();
+        assertThat(sandboxDataSets.getSandboxDatasets()).isNotEmpty();
+        assertThat(sandboxDataSets.getSandboxDatasets().size()).isEqualTo(2);
+    }
+
+    @Ignore
+    @Configuration
+    static class Config {
+
+        @Bean
+        @ConfigurationProperties("sandbox-properties")
+        public SandboxDataSets sandboxDatasets() {
+            return new SandboxDataSets();
+        }
+    }
+}

--- a/common/src/test/resources/application-sandbox_datasets.yml
+++ b/common/src/test/resources/application-sandbox_datasets.yml
@@ -1,0 +1,10 @@
+logging:
+  level:
+    org.opentestsystem.rdw.admin: debug
+
+sandbox-properties:
+  sandboxDatasets:
+    - label: Demo Dataset
+      id: demo-dataset
+    - label: SBAC Dataset
+      id: sbac-dataset


### PR DESCRIPTION
RP-495 RP-494 Dataset Configuration
Remove Sandbox mock data.
Update sandbox service to call new SandboxDataSets with the preconfigured datasets.
move the datasets to the reporting common. 