### PR TITLE
RD-438: update LEPStatus to EnglishLearner for export

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/DimensionType.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/DimensionType.java
@@ -16,7 +16,7 @@ public enum DimensionType {
     Overall(-1, false, true, "Overall"),
     Gender(1, "Sex"),
     Ethnicity(2, "Ethnicity"),
-    LEP(3, "LEPStatus"),
+    LEP(3, "EnglishLearner"),
     ELAS(3, "EnglishLanguageAcquisitionStatus"),
     Language(4, true, false, "LanguageCode"),
     Section504(5, "Section504Status"),

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -812,7 +812,7 @@
     "language-code": "LanguageCode",
     "military-connected-code": "MilitaryConnectedStudentIndicator",
     "iep": "IDEAIndicator",
-    "limited-english": "LEPStatus",
+    "limited-english": "EnglishLearner",
     "migrant-status": "MigrantStatus",
     "scale-score": "ScaleScore",
     "school": "SchoolName",


### PR DESCRIPTION
Applies to Teacher Export and downloaded aggregate reports with LEP (English Learner) subgroups. Does not apply to District/School exports.

I'm a little concern about changing DimensionType, but I couldn't find another use for the "code" field that changed, so it should be all right. The district/school exports retain LEPStatus, which is good because I can't figure out where that's coming from. 