### PR TITLE
RD-509: Improperly displaying LEP filters when LEP disabled.

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/aggregate-report-summary.component.ts
@@ -392,6 +392,7 @@ export class AggregateReportSummary {
         });
       }
       if (
+        options.dimensionTypes.includes('LEP') &&
         !equalSize(
           optionFilters.limitedEnglishProficiencies,
           settingFilters.limitedEnglishProficiencies


### PR DESCRIPTION
I can't fully test this until it's deployed to QA. I did at least test that it doesn't blow up.