### PR TITLE
RP-252: If the ISR report is empty, it should display as "No Results"

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportGenerationTemporaryStorage.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportGenerationTemporaryStorage.java
@@ -35,8 +35,13 @@ public class ArchiveBackedReportGenerationTemporaryStorage implements ReportGene
         final List<Supplier<InputStream>> chunkContents = new ArrayList<>();
         for (int i = 0; i < chunkCount; i++) {
             final int chunkIdx = i;
-            chunkContents.add(() ->
-                    archiveService.openResource(getChunkUri(reportId, chunkIdx)));
+            final String chunkUri = getChunkUri(reportId, chunkIdx);
+            if (archiveService.exists(chunkUri)) {
+                chunkContents.add(() ->
+                {
+                    return archiveService.openResource(chunkUri);
+                });
+            }
         }
         return chunkContents;
     }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdf.java
@@ -61,6 +61,12 @@ public class GeneratePdf {
             final List<Supplier<InputStream>> chunkPdfs = reportGenerationTemporaryStorage.getChunks(
                     report.getId(),
                     parseInt(report.getMetadata().get(FetchStudents.TotalChunk)));
+
+            if (chunkPdfs.isEmpty()) {
+                setNoContent(report);
+                return;
+            }
+
             final MergedReport mergedReport = pdfMerger.mergePdfs(report, chunkPdfs);
 
             logger.debug("Merged UserReport: {}", message.getReportId());
@@ -88,5 +94,12 @@ public class GeneratePdf {
         } catch (final IOException e) {
             throw new IllegalStateException("Unable to collate report: " + message.getReportId(), e);
         }
+    }
+
+    private void setNoContent(final UserReport report) {
+        userReportService.update(UserReport.builder()
+                .copy(report)
+                .status(ReportStatus.NO_RESULTS)
+                .build());
     }
 }

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessor.java
@@ -146,31 +146,39 @@ public class StudentReportProcessor {
                 .map(student -> studentReports.get(student.getId()))
                 .collect(Collectors.toList());
 
-        logger.debug("Processing report: {} chunk: {} writing html", report.getId(), payload.getIndex());
-        final byte[] html = writeReportHtml(orderedReports, (AbstractPrintableReportQuery) report.getQuery());
+        final boolean noReportsInChunk = orderedReports.stream()
+                .map(StudentCompositeReport::getReports)
+                .allMatch(List::isEmpty);
 
-        try {
-            retryTemplate.execute((RetryCallback<Void, IOException>) retryContext -> {
-                try (final InputStream pdfStream = htmlToPdfProcessor.process(html)) {
-                    //Store chunk PDF contents
-                    logger.debug("Processing report: {} chunk: {} writing pdf bytes", report.getId(), payload.getIndex());
-                    temporaryStorage.writeChunk(payload.getReportId(), payload.getIndex(), pdfStream);
-                }
-                return null;
-            }, retryContext -> {
-                logger.warn("Unable to convert report chunk HTML to PDF report: {} chunk: {}",
-                        report.getId(),
-                        payload.getIndex(),
-                        retryContext.getLastThrowable());
-                throw new IllegalStateException("Unable to convert report chunk HTML to PDF");
-            });
+        if (noReportsInChunk) {
+            logger.debug("No student reports for report: {} chunk: {}.", report.getId(), payload.getIndex());
+        } else {
+            logger.debug("Processing report: {} chunk: {} writing html", report.getId(), payload.getIndex());
+            final byte[] html = writeReportHtml(orderedReports, (AbstractPrintableReportQuery) report.getQuery());
 
-            logger.debug("UserReport: {} Chunk: {} complete", report.getId(), payload.getIndex());
-        } catch (final IOException e) {
-            throw new RuntimeException(
-                    "Failed to generate report chunk. ReportId: " + payload.getReportId() +
-                            " ChunkIdx: " + payload.getIndex(),
-                    e);
+            try {
+                retryTemplate.execute((RetryCallback<Void, IOException>) retryContext -> {
+                    try (final InputStream pdfStream = htmlToPdfProcessor.process(html)) {
+                        //Store chunk PDF contents
+                        logger.debug("Processing report: {} chunk: {} writing pdf bytes", report.getId(), payload.getIndex());
+                        temporaryStorage.writeChunk(payload.getReportId(), payload.getIndex(), pdfStream);
+                    }
+                    return null;
+                }, retryContext -> {
+                    logger.warn("Unable to convert report chunk HTML to PDF report: {} chunk: {}",
+                            report.getId(),
+                            payload.getIndex(),
+                            retryContext.getLastThrowable());
+                    throw new IllegalStateException("Unable to convert report chunk HTML to PDF");
+                });
+
+                logger.debug("UserReport: {} Chunk: {} complete", report.getId(), payload.getIndex());
+            } catch (final IOException e) {
+                throw new RuntimeException(
+                        "Failed to generate report chunk. ReportId: " + payload.getReportId() +
+                                " ChunkIdx: " + payload.getIndex(),
+                        e);
+            }
         }
 
         final UserReport completed = userReportService.completeChunk(report);

--- a/report-processor/src/main/resources/application.sql.yml
+++ b/report-processor/src/main/resources/application.sql.yml
@@ -301,7 +301,7 @@ sql:
       ${sql.reportProcessor.snippet.selectFromStudent}
       WHERE (:student_id is null or st.id = :student_id)
         AND (:school_year is null or e.school_year = :school_year)
-        AND (:subject_code is null or sub.code = :subject_code)
+        AND (:subject_code is null or sub.code = :subject_code) AND sat.printed_report=1
         AND (:grade_id is null or a.grade_id = :grade_id)
         AND (:assessment_type is null or a.type_id = :assessment_type)
         AND ${sql.reportProcessor.snippet.schoolFilter}
@@ -314,7 +314,7 @@ sql:
       WHERE $[groupFilterPlaceholder]
         AND (:student_id is null or st.id = :student_id)
         AND (:school_year is null or e.school_year = :school_year)
-        AND (:subject_code is null or sub.code = :subject_code)
+        AND (:subject_code is null or sub.code = :subject_code) AND sat.printed_report=1
         AND (:grade_id is null or a.grade_id = :grade_id)
         AND (:assessment_type is null or a.type_id = :assessment_type)
         AND ${sql.reportProcessor.snippet.schoolFilter}
@@ -367,6 +367,7 @@ sql:
             JOIN school s ON e.school_id = s.id
             JOIN school isch ON st.inferred_school_id = isch.id
             JOIN subject sub ON sub.id=a.subject_id
+            JOIN subject_asmt_type sat on a.subject_id=sat.subject_id and a.type_id=sat.asmt_type_id
 
       exportExamsFilter: >-
         e.school_year = :school_year

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportGenerationTemporaryStorageTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/service/ArchiveBackedReportGenerationTemporaryStorageTest.java
@@ -51,6 +51,7 @@ public class ArchiveBackedReportGenerationTemporaryStorageTest {
         data.add(chunk0);
         data.add(chunk1);
         data.add(chunk2);
+        when(archiveService.exists(anyString())).thenReturn(true);
         when(archiveService.openResource(anyString())).thenAnswer(invocation -> {
             final Matcher matcher = pathMatcher.matcher(invocation.getArgument(0));
             assertThat(matcher.matches()).isTrue();

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/GeneratePdfTest.java
@@ -8,16 +8,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.opentestsystem.rdw.reporting.common.model.AbstractBatchPrintableReportQuery;
-import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
-import org.opentestsystem.rdw.reporting.processor.model.UserReport;
-import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
-import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
-import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
-import org.opentestsystem.rdw.reporting.processor.service.ReportMergeService;
-import org.opentestsystem.rdw.reporting.processor.service.UserReportService;
 import org.springframework.http.MediaType;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -27,9 +20,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.opentestsystem.rdw.reporting.common.model.AbstractBatchPrintableReportQuery;
+import org.opentestsystem.rdw.reporting.common.model.ReportStatus;
+import org.opentestsystem.rdw.reporting.processor.model.MergedReport;
+import org.opentestsystem.rdw.reporting.processor.model.ReportRequestMessage;
+import org.opentestsystem.rdw.reporting.processor.model.UserReport;
+import org.opentestsystem.rdw.reporting.processor.service.ReportContentService;
+import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
+import org.opentestsystem.rdw.reporting.processor.service.ReportMergeService;
+import org.opentestsystem.rdw.reporting.processor.service.UserReportService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -78,15 +81,12 @@ public class GeneratePdfTest {
                 .build());
         when(userReportService.findOneById(ReportId)).thenReturn(Optional.of(report));
 
-        final List<Supplier<InputStream>> chunkContents = Collections.emptyList();
-        when(reportGenerationTemporaryStorage.getChunks(eq(ReportId), eq(3))).thenReturn(chunkContents);
-
         final File mergedContents = temporaryFolder.newFile();
         try (final FileOutputStream data = new FileOutputStream(mergedContents)) {
             data.write("PDF Content".getBytes());
         }
         mergedReport = new MergedReport(mergedContents, APPLICATION_PDF_UTF8);
-        when(pdfMerger.mergePdfs(eq(report), eq(chunkContents))).thenReturn(mergedReport);
+        when(pdfMerger.mergePdfs(eq(report), anyList())).thenReturn(mergedReport);
 
         final AbstractBatchPrintableReportQuery query = mock(AbstractBatchPrintableReportQuery.class);
         when(report.getQuery()).thenReturn(query);
@@ -109,6 +109,11 @@ public class GeneratePdfTest {
 
     @Test
     public void itShouldMergeAndStorePdfContents() throws Exception {
+        final InputStream chunk = new ByteArrayInputStream("mock pdf data".getBytes());
+
+        final List<Supplier<InputStream>> chunkContents = Collections.singletonList(() -> chunk);
+        when(reportGenerationTemporaryStorage.getChunks(eq(ReportId), eq(3))).thenReturn(chunkContents);
+
         final long mergedPdfLength = mergedReport.getFile().length();
 
         component.collateReportPdf(message);
@@ -116,9 +121,21 @@ public class GeneratePdfTest {
         assertThat(mergedReport.getFile().exists()).isFalse();
 
         verify(reportContentService).writeContent(eq(report), any(FileInputStream.class), eq(mergedPdfLength), eq(APPLICATION_PDF_UTF8));
-
         final ArgumentCaptor<UserReport> reportCaptor = ArgumentCaptor.forClass(UserReport.class);
         verify(userReportService).update(reportCaptor.capture());
         assertThat(reportCaptor.getValue().getReportResourceUri()).isEqualTo(URI.create("my_uri"));
+        assertThat(reportCaptor.getValue().getStatus()).isEqualTo(ReportStatus.COMPLETED);
+    }
+
+    @Test
+    public void itShouldReportNoResultsForEmptyPdf() {
+        when(reportGenerationTemporaryStorage.getChunks(eq(ReportId), eq(3))).thenReturn(Collections.emptyList());
+
+        component.collateReportPdf(message);
+
+        final ArgumentCaptor<UserReport> reportCaptor = ArgumentCaptor.forClass(UserReport.class);
+        verify(userReportService).update(reportCaptor.capture());
+        assertThat(reportCaptor.getValue().getReportResourceUri()).isNull();
+        assertThat(reportCaptor.getValue().getStatus()).isEqualTo(ReportStatus.NO_RESULTS);
     }
 }

--- a/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
+++ b/report-processor/src/test/java/org/opentestsystem/rdw/reporting/processor/stream/StudentReportProcessorTest.java
@@ -8,11 +8,31 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.opentestsystem.rdw.reporting.common.model.AbstractPrintableReportQuery;
 import org.opentestsystem.rdw.reporting.common.model.SubjectDefinition;
+import org.opentestsystem.rdw.reporting.common.security.User;
 import org.opentestsystem.rdw.reporting.common.service.SubjectDefinitionService;
 import org.opentestsystem.rdw.reporting.common.stream.MessageSecurityService;
-import org.opentestsystem.rdw.reporting.common.security.User;
 import org.opentestsystem.rdw.reporting.processor.model.AbstractExamReport;
 import org.opentestsystem.rdw.reporting.processor.model.ExamQueryParams;
 import org.opentestsystem.rdw.reporting.processor.model.IabReport;
@@ -26,28 +46,9 @@ import org.opentestsystem.rdw.reporting.processor.repository.SubjectRepository;
 import org.opentestsystem.rdw.reporting.processor.requesthandler.ExamQueryParamsParser;
 import org.opentestsystem.rdw.reporting.processor.service.HtmlToPdfProcessor;
 import org.opentestsystem.rdw.reporting.processor.service.ReportGenerationTemporaryStorage;
-import org.opentestsystem.rdw.reporting.processor.service.UserReportService;
 import org.opentestsystem.rdw.reporting.processor.service.ReportViewSupport;
 import org.opentestsystem.rdw.reporting.processor.service.TemplateProcessor;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.support.RetryTemplate;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.opentestsystem.rdw.reporting.processor.service.UserReportService;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -152,8 +153,17 @@ public class StudentReportProcessorTest {
                 .thenReturn(params);
         queryParamsParsers.add(accepting);
 
+        final SubjectDefinition subjectDefinition = mock(SubjectDefinition.class);
+
+        when(subjectDefinitionService.findAll()).thenReturn(Collections.singletonList(subjectDefinition));
+
+        final IabReport iabReport = IabReport.builder()
+                .subject("Math")
+                .assessmentType("iab")
+                .subjectDefinition(subjectDefinition).build();
+
         when(iabReportRepository.findAllForStudentsByExamFilter(any(User.class), anyCollection(), any(ExamQueryParams.class)))
-                .thenReturn(new HashMap<>());
+                .thenReturn(Collections.singletonMap(1L, Collections.singleton(iabReport)));
 
         when(icaReportRepository.findAllForStudentsByExamFilter(any(User.class), anyCollection(), any(ExamQueryParams.class)))
                 .thenReturn(new HashMap<>());


### PR DESCRIPTION
This one is tricky. The printed report is created in multiple asynchronous steps. The first pulls a list of students for the requested report, and if the list is size 0, it marks the status as "No Results" and stops processing. That much was working already.

However, for the scenario Nohemi calls out in the JIRA, there are 7 potential students. These are divided into chunks (just one in this case) and the chunks are re-queued. The next phase of processing handles each chunk by loading the relevant reports for each student based on the query parameters. In Nohemi's scenario, that meant loading just summative reports, and none of the 7 students had any to load. The processing continues regardless to produce a blank PDF file for the chunk. The file is not empty, but it does produce a blank page, or actually two blank pages. This file is then saved to a temp location by the archive service.

The final step assembles all the temporarily archived PDFs into a single master report, and then marks the report as complete. It is unaware that it has created a blank report.

I think the best way to fix this would be to move the report loading up into the fetch student step, and filter out any students that have no loaded reports. That seemed to me a pretty big structural change, which I wanted to avoid, so I looked for a workaround. 

I can't  just abort during the "chunk to PDF" phase, because in the general case it could happen that one chunk would be emtpy, but others have reports.  What I'm doing instead is suppressing the creation of the partial PDFs for chunks that would just create blank pages. Then, in the assemble phase, I prevent it from erroring on missing chunk PDF files, and if there are no PDFs at all to assemble, I mark the report as "No Results". This feels a little klugey, but it was relatively straightforward to implement, and does work. The JUnits were a little harder since I had to mock conditions that would create a non-empty report. All-in-all, I think it was much easier than restructuring the report processor.