### PR TITLE
make json resource translation provider tenant-aware

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
@@ -139,7 +139,7 @@ public interface ReportingSystemProperties {
      */
     List<String> getEffectiveReportLanguages();
 
-    public static class StateProperties {
+    class StateProperties {
 
         private String name;
         private String code;
@@ -176,7 +176,7 @@ public interface ReportingSystemProperties {
 
     }
 
-    public static class TargetReportProperties {
+    class TargetReportProperties {
 
         private Double insufficientDataCutoff;
         private Integer minNumberOfStudents;

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/JsonResourceTranslationProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/JsonResourceTranslationProvider.java
@@ -16,6 +16,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import org.opentestsystem.rdw.multitenant.TenantContextHolder;
+import org.opentestsystem.rdw.reporting.common.multitenant.StaticTenantIdUtil;
 
 /**
  * This translation provider accepts a location accessible via {@link ResourceLoader}
@@ -26,13 +28,13 @@ import java.util.stream.Collectors;
 public class JsonResourceTranslationProvider implements TranslationProvider {
     private static final Logger logger = LoggerFactory.getLogger(JsonResourceTranslationProvider.class);
 
-    private final String translationLocation;
+    private final TranslationProperties settings;
     private final ResourceLoader resourceLoader;
     private final JavaPropsMapper propertiesMapper;
 
-    public JsonResourceTranslationProvider(final String translationLocation,
+    public JsonResourceTranslationProvider(final TranslationProperties settings,
                                            final ResourceLoader resourceLoader) {
-        this.translationLocation = translationLocation;
+        this.settings = settings;
         this.resourceLoader = resourceLoader;
         this.propertiesMapper = new JavaPropsMapper();
     }
@@ -42,8 +44,13 @@ public class JsonResourceTranslationProvider implements TranslationProvider {
         if (locale == null) {
             return Collections.emptyMap();
         }
+        final String location = settings.getTranslationLocation();
+        if (location == null || location.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        final String resource = location + locale.getLanguage() + ".json";
 
-        final ObjectNode objectNode = loadJson(locale);
+        final ObjectNode objectNode = loadJson(resource);
         final Properties properties = new Properties();
         try {
             final JavaPropsGenerator generator = propertiesMapper.getFactory().createGenerator(properties);
@@ -60,11 +67,11 @@ public class JsonResourceTranslationProvider implements TranslationProvider {
         }
     }
 
-    private ObjectNode loadJson(final Locale locale) {
+    private ObjectNode loadJson(final String resource) {
         final ObjectMapper objectMapper = new ObjectMapper();
-        final Resource externalMessages = resourceLoader.getResource(getExternalLocation(locale));
+        final Resource externalMessages = resourceLoader.getResource(resource);
         if (!externalMessages.exists()) {
-            logger.debug("Unable to find translation json at: {}", getExternalLocation(locale));
+            logger.debug("Unable to find translation json at: {}", resource);
             return objectMapper.createObjectNode();
         }
 
@@ -74,9 +81,5 @@ public class JsonResourceTranslationProvider implements TranslationProvider {
             logger.warn("Unable to open translation resource: {}", externalMessages);
             return objectMapper.createObjectNode();
         }
-    }
-
-    private String getExternalLocation(final Locale locale) {
-        return translationLocation + locale.getLanguage() + ".json";
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationConfiguration.java
@@ -11,7 +11,6 @@ import org.springframework.core.io.ResourceLoader;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
  * This configuration registers:
@@ -30,14 +29,11 @@ public class TranslationConfiguration {
                                                    final @Qualifier("reportingSystemPropertiesResolver") ReportingSystemProperties settings) {
         final List<TranslationProvider> providers = newArrayList();
         //Add embedded translations
-        providers.add(new JsonResourceTranslationProvider("classpath:/i18n/", resourceLoader));
+        providers.add(new JsonResourceTranslationProvider(new StaticTranslationProperties("classpath:/i18n/"), resourceLoader));
         //Add repository translations
         providers.add(translationRepository);
-
-        if (isNotBlank(settings.getTranslationLocation())) {
-            //Add external translations
-            providers.add(new JsonResourceTranslationProvider(settings.getTranslationLocation(), resourceLoader));
-        }
+        //Add external translations
+        providers.add(new JsonResourceTranslationProvider(new TranslationPropertiesResolver(settings), resourceLoader));
 
         return new CompositeTranslationProvider(providers);
     }
@@ -47,5 +43,38 @@ public class TranslationConfiguration {
         final TranslationProviderMessageSource messageSource = new TranslationProviderMessageSource(translationProvider);
         messageSource.setUseCodeAsDefaultMessage(true);
         return messageSource;
+    }
+
+    /**
+     * A TranslationProperties implementation the returns the same static value.
+     */
+    public static class StaticTranslationProperties implements TranslationProperties {
+        private final String location;
+
+        StaticTranslationProperties(final String location) {
+            this.location = location;
+        }
+
+        @Override
+        public String getTranslationLocation() {
+            return location;
+        }
+    }
+
+    /**
+     * Cheating a bit here: since ReportingSystemProperties is already multi-tenant aware
+     * use it to get the resolved translation-location value.
+     */
+    public static class TranslationPropertiesResolver implements TranslationProperties {
+        private final ReportingSystemProperties settings;
+
+        TranslationPropertiesResolver(final ReportingSystemProperties settings) {
+            this.settings = settings;
+        }
+
+        @Override
+        public String getTranslationLocation() {
+            return settings.getTranslationLocation();
+        }
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/i18n/TranslationProperties.java
@@ -1,0 +1,13 @@
+package org.opentestsystem.rdw.reporting.common.i18n;
+
+public interface TranslationProperties {
+
+    /**
+     * This is the location/prefix of translation files
+     * (es.json to provide Spanish, en.json to override display values, etc)
+     * (ex: 'binary-${spring.cloud.config.uri}/*&#47;*&#47;master/')
+     *
+     * @return The prefix for translation resources.
+     */
+    String getTranslationLocation();
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/JsonResourceTranslationProviderTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/JsonResourceTranslationProviderTest.java
@@ -20,6 +20,8 @@ public class JsonResourceTranslationProviderTest {
 
     @Mock
     private ResourceLoader resourceLoader;
+    @Mock
+    private TranslationProperties settings;
 
     private JsonResourceTranslationProvider service;
 
@@ -29,8 +31,9 @@ public class JsonResourceTranslationProviderTest {
            final String location = invocation.getArgument(0);
            return new ClassPathResource(location);
         });
+        when(settings.getTranslationLocation()).thenReturn("/test_");
 
-        service = new JsonResourceTranslationProvider("/test_", resourceLoader);
+        service = new JsonResourceTranslationProvider(settings, resourceLoader);
     }
 
     @Test

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/MessageFormattingTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/i18n/MessageFormattingTest.java
@@ -52,8 +52,10 @@ public class MessageFormattingTest {
             final String location = invocation.getArgument(0);
             return new ClassPathResource(location);
         });
+        final TranslationProperties settings = mock(TranslationProperties.class);
+        when(settings.getTranslationLocation()).thenReturn("/i18n/");
 
-        provider = new JsonResourceTranslationProvider("/i18n/", resourceLoader);
+        provider = new JsonResourceTranslationProvider(settings, resourceLoader);
         source = new TranslationProviderMessageSource(provider);
     }
 
@@ -62,7 +64,7 @@ public class MessageFormattingTest {
      * Unformatted messages do not require escaping single apostrophes.
      * This test asserts after processing of messages, there is no instance of consecutive apostrophes in the message.
      *
-     * @throws Exception
+     * @throws Exception it's a test
      */
     @Test
     public void itShouldNotShowConsecutiveApostrophes() throws Exception {


### PR DESCRIPTION
The JsonResourceTranslationProvider used to take a string that was the resource location; set during bean creation. Changed things so it resolves the location dynamically, so it uses any tenant-overridden configuration based on the session.