### PR TITLE
RP-557: configure /configprops to unmask "key" properties

### DIFF
--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -8,6 +8,13 @@ management:
     db:
       enabled: false
 
+# configure actuator endpoints to unmask "key" properties, but mask "s3SecretKey"
+endpoints:
+  env:
+    keys-to-sanitize: password,secret,token,.*credentials.*,vcap_services,s3SecretKey
+  configprops:
+    keys-to-sanitize: password,secret,token,.*credentials.*,vcap_services,s3SecretKey
+
 #needed to disable auto-configurations for flyway
 flyway:
   enabled: false


### PR DESCRIPTION
I made changes to both configprops and env endpoints, because they deliver similar information. From what I could see s3SecretKey was already being masked in both endpoints because it ends with "key". The masking seems to ignore nulls though, so null masked values still show as null. 

I only observed one side effect to unmasking "key", and that was the redis key field in MetricExportProperties gets unmasked. I think that's probably fine. I believe the s3AccessKey will also become unmasked with this change. If that's not desired, then I can add it to the list explicitly.

My basic assumptions are:

1. This is the right place for this configuration, and I was wrong to guess that one of the rdw_config yaml files needed updating

2. All the other reporting services will need this same configuration

I'm stating those assumptions because I think it's possible that I've got them wrong. Maybe there is a way to apply this to all the services at once? Maybe rdw_config actually is involved?  I apologize for ignorance in this area, but there we are.
