### PR TITLE
Defect/479 button contrast

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/ingest-pipeline/page/pipeline/pipeline.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/ingest-pipeline/page/pipeline/pipeline.component.ts
@@ -76,6 +76,13 @@ function createItem<T>(type: ItemType, value: T, changed = false): Item<T> {
   };
 }
 
+function isTestLoadedAndInvalid(
+  test: PipelineTest,
+  inputType: string
+): boolean {
+  return test.input != null && !isValidPipelineTest(test, inputType);
+}
+
 @Component({
   selector: 'pipeline',
   templateUrl: './pipeline.component.html',
@@ -570,9 +577,12 @@ export class PipelineComponent implements ComponentCanDeactivate, OnDestroy {
     // dont run
     const hasInvalidTests =
       this.selectedItem.type === 'Test'
-        ? !isValidPipelineTest(this.selectedItem.value, this.pipeline.inputType)
-        : tests.some(
-            ({ value }) => !isValidPipelineTest(value, this.pipeline.inputType)
+        ? isTestLoadedAndInvalid(
+            this.selectedItem.value,
+            this.pipeline.inputType
+          )
+        : tests.some(({ value }) =>
+            isTestLoadedAndInvalid(value, this.pipeline.inputType)
           );
 
     this.testButtonDisabled =

--- a/webapp/src/main/webapp/src/btn-outlined.less
+++ b/webapp/src/main/webapp/src/btn-outlined.less
@@ -47,12 +47,10 @@
   fieldset[disabled] {
     border-color: @disabled-color;
     color: @disabled-color;
-    //opacity: 0.75;
     &:hover,
     &:focus,
     &.focus {
       background-color: @color;
-      border-color: darken(@background, 25%);
     }
   }
 }

--- a/webapp/src/main/webapp/src/btn-outlined.less
+++ b/webapp/src/main/webapp/src/btn-outlined.less
@@ -3,6 +3,8 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
+@disabled-color: #555;
+
 .btn-outlined(@color; @background; @border) {
   color: @background;
   background-color: transparent;
@@ -22,7 +24,7 @@
   }
   &:active,
   &.active,
-  .open > .dropdown-toggle& {
+  .open > .dropdown-toggle {
     color: @background;
     background-color: darken(@color, 10%);
     border-color: darken(@background, 12%);
@@ -37,17 +39,20 @@
   }
   &:active,
   &.active,
-  .open > .dropdown-toggle& {
+  .open > .dropdown-toggle {
     background-image: none;
   }
   &.disabled,
   &[disabled],
-  fieldset[disabled] & {
+  fieldset[disabled] {
+    border-color: @disabled-color;
+    color: @disabled-color;
+    //opacity: 0.75;
     &:hover,
     &:focus,
     &.focus {
       background-color: @color;
-      border-color: @background;
+      border-color: darken(@background, 25%);
     }
   }
 }


### PR DESCRIPTION
Tried different things but what ended up working the best was just making all the buttons grey when disabled which actually kind of makes sense anyway.

https://webaim.org/resources/contrastchecker/?fcolor=555555&bcolor=F8F8F8

![image](https://user-images.githubusercontent.com/23462925/60912656-b7fb1880-a23a-11e9-959f-3a05485e012b.png)

![image](https://user-images.githubusercontent.com/23462925/60912663-bb8e9f80-a23a-11e9-8037-f8bbe2a52e70.png)
