### PR TITLE
improves some back to foregrouned color ratios

### DIFF
--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-typeahead.component.less
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-typeahead.component.less
@@ -1,0 +1,3 @@
+.pointer-events-none {
+  pointer-events: none;
+}

--- a/webapp/src/main/webapp/src/app/shared/form/sb-button-typeahead.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/sb-button-typeahead.component.ts
@@ -38,13 +38,14 @@ import { Utils } from '../support/support';
           (click)="onButtonClickInternal()"
           [disabled]="buttonDisabledInternal"
         >
-          <span [ngClass]="{ gray: buttonDisabledInternal }"
+          <span [ngClass]="{ 'pointer-events-none': buttonDisabledInternal }"
             ><i class="fa fa-plus"></i> {{ buttonLabel }}</span
           >
         </button>
       </span>
     </span>
-  `
+  `,
+  styleUrls: ['./sb-button-typeahead.component.less']
 })
 export class SBButtonTypeahead extends SBTypeahead {
   @Output()

--- a/webapp/src/main/webapp/src/primeng-overrides.less
+++ b/webapp/src/main/webapp/src/primeng-overrides.less
@@ -13,10 +13,14 @@ body {
   button {
     font-size: @font-size-base;
   }
-}
 
-body .ui-table-scrollable-header.ui-widget-header {
-  border: none;
+  .dropdown-header {
+    color: @gray-dark;
+  }
+
+  .ui-table-scrollable-header.ui-widget-header {
+    border: none;
+  }
 }
 
 // Tables

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -60,6 +60,7 @@
 /**
  * Bootstrap additions
  */
+
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   background-color: #f0f0f0; /* was #f8f8f8 */


### PR DESCRIPTION
subtle grey text darkening to improve the color ratios - still not compliant though. basically the text needs to be very dark grey on white to be compliant which doesn't allow for any accenting with color (only size) so i think this may be a broader app style problem than any one page

before 

![image](https://user-images.githubusercontent.com/23462925/60922629-00720080-a252-11e9-958f-29344cbea43c.png)

after

![image](https://user-images.githubusercontent.com/23462925/60922657-1253a380-a252-11e9-96f0-f82dabd6d3d9.png)




