### PR TITLE
Feature/598 tenant form

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
@@ -1,74 +1,55 @@
-<!-- TODO extract -->
-<div class="controls">
-  <input
-    id="search"
-    name="search"
-    type="text"
-    placeholder="{{
-      'tenant-form.field.localizations.control.search.placeholder' | translate
-    }}"
-    class="form-control"
-    (input)="table.filterGlobal($event, 'contains')"
-  />
-  <label>
-    <input
-      id="modified"
-      name="modified"
-      type="checkbox"
-      [(ngModel)]="modified"
-      (ngModelChange)="updatePropertiesFilter()"
-    />
-    {{ 'tenant-form.field.localizations.control.modified.label' | translate }}
-  </label>
-</div>
-
-<div [formGroup]="form">
-  <div [formArrayName]="propertiesArrayName">
-    <p-table
-      #table
-      [value]="filteredConfigurationProperties"
-      dataKey="key"
-      [globalFilterFields]="['key', 'value']"
-      styleClass="table table-striped table-hover overflow rdw-scrollable-table"
-      [paginator]="true"
-      [(first)]="first"
-      [alwaysShowPaginator]="false"
-      [rows]="20"
-      [rowTrackBy]="rowTrackBy"
-    >
-      <ng-template pTemplate="header">
-        <tr>
-          <th>
-            {{ 'tenant-localization-form.column.key.label' | translate }}
-          </th>
-          <th>
-            {{ 'tenant-localization-form.column.value.label' | translate }}
-          </th>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="body" let-overrides>
-        <tr
-          *ngIf="!readonly"
-          [ngClass]="{
-            modified: overrides.value !== overrides.originalValue
-          }"
-          (click)="overrideInput.focus()"
-        >
-          <td [title]="overrides.key">{{ overrides.key }}</td>
-          <td>
+<ng-container [formGroup]="formGroup">
+  <p-table
+    #table
+    [value]="properties"
+    dataKey="key"
+    [globalFilterFields]="['key', 'value']"
+    [paginator]="true"
+    [(first)]="first"
+    [alwaysShowPaginator]="false"
+    [rows]="20"
+    [rowTrackBy]="rowTrackBy"
+    styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+  >
+    <ng-template pTemplate="header">
+      <tr>
+        <th>
+          {{ 'tenant-localization-form.column.key.label' | translate }}
+        </th>
+        <th>
+          {{ 'tenant-localization-form.column.value.label' | translate }}
+        </th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-property>
+      <tr
+        [ngClass]="{
+          modified: property.defaultValue !== formGroup.value[property.key]
+        }"
+      >
+        <td [title]="property.key">
+          {{ property.key }}
+        </td>
+        <td>
+          <ng-container *ngIf="readonly; else writableValue">
+            <span>
+              {{ property.value }}
+            </span>
+          </ng-container>
+          <ng-template #writableValue>
             <input
-              #overrideInput
               type="text"
-              [value]="overrides.value"
-              [formControlName]="overrides.key"
+              [formControlName]="property.key"
               class="property-input"
-              (change)="updateOverride(overrides)"
             />
             <div class="icon-container">
               <i
                 class="fa fa-undo fa-md"
-                *ngIf="overrides.value !== overrides.originalValue && !readonly"
-                (click)="resetClicked(overrides)"
+                *ngIf="
+                  property.defaultValue !== formGroup.value[property.key] &&
+                  !readonly
+                "
+                (click)="onResetButtonClick(property)"
                 popover="{{
                   'tenant-configuration-form.popover.reset' | translate
                 }}"
@@ -77,29 +58,16 @@
                 triggers="mouseenter:mouseleave"
               ></i>
             </div>
-          </td>
-        </tr>
-        <tr
-          *ngIf="readonly"
-          [ngClass]="{
-            modified: overrides.value !== overrides.originalValue
-          }"
-        >
-          <td [title]="overrides.key">{{ overrides.key }}</td>
-          <td>
-            <span>
-              {{ overrides.value }}
-            </span>
-          </td>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="emptymessage">
-        <tr>
-          <td colspan="2">
-            {{ 'tenant-localization-form.no-results' | translate }}
-          </td>
-        </tr>
-      </ng-template>
-    </p-table>
-  </div>
-</div>
+          </ng-template>
+        </td>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="emptymessage">
+      <tr>
+        <td colspan="2">
+          {{ 'tenant-localization-form.no-results' | translate }}
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+</ng-container>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
@@ -1,73 +1,73 @@
-<ng-container [formGroup]="formGroup">
-  <p-table
-    #table
-    [value]="properties"
-    dataKey="key"
-    [globalFilterFields]="['key', 'value']"
-    [paginator]="true"
-    [(first)]="first"
-    [alwaysShowPaginator]="false"
-    [rows]="20"
-    [rowTrackBy]="rowTrackBy"
-    styleClass="table table-striped table-hover overflow rdw-scrollable-table"
-  >
-    <ng-template pTemplate="header">
-      <tr>
-        <th>
-          {{ 'tenant-localization-form.column.key.label' | translate }}
-        </th>
-        <th>
-          {{ 'tenant-localization-form.column.value.label' | translate }}
-        </th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-property>
-      <tr
-        [ngClass]="{
-          modified: property.defaultValue !== formGroup.value[property.key]
-        }"
-      >
-        <td [title]="property.key">
-          {{ property.key }}
-        </td>
-        <td>
-          <ng-container *ngIf="readonly; else writableValue">
-            <span>
-              {{ property.value }}
-            </span>
-          </ng-container>
-          <ng-template #writableValue>
-            <input
-              type="text"
-              [formControlName]="property.key"
-              class="property-input"
-            />
-            <div class="icon-container">
-              <i
-                class="fa fa-undo fa-md"
-                *ngIf="
-                  property.defaultValue !== formGroup.value[property.key] &&
-                  !readonly
-                "
-                (click)="onResetButtonClick(property)"
-                popover="{{
-                  'tenant-configuration-form.popover.reset' | translate
-                }}"
-                placement="left"
-                container="body"
-                triggers="mouseenter:mouseleave"
-              ></i>
-            </div>
-          </ng-template>
-        </td>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="emptymessage">
-      <tr>
-        <td colspan="2">
-          {{ 'tenant-localization-form.no-results' | translate }}
-        </td>
-      </tr>
-    </ng-template>
-  </p-table>
+<ng-container
+  *ngIf="properties != null && properties.length === 0; else hasResults"
+>
+  {{ 'tenant-localization-form.no-results' | translate }}
 </ng-container>
+<ng-template #hasResults>
+  <ng-container [formGroup]="formGroup">
+    <p-table
+      #table
+      [value]="properties"
+      dataKey="key"
+      [globalFilterFields]="['key', 'value']"
+      [paginator]="true"
+      [(first)]="first"
+      [alwaysShowPaginator]="false"
+      [rows]="20"
+      [rowTrackBy]="rowTrackBy"
+      styleClass="table table-striped table-hover overflow rdw-scrollable-table"
+    >
+      <ng-template pTemplate="header">
+        <tr>
+          <th>
+            {{ 'tenant-localization-form.column.key.label' | translate }}
+          </th>
+          <th>
+            {{ 'tenant-localization-form.column.value.label' | translate }}
+          </th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-property>
+        <tr
+          [ngClass]="{
+            modified: property.defaultValue !== formGroup.value[property.key]
+          }"
+        >
+          <td [title]="property.key">
+            {{ property.key }}
+          </td>
+          <td>
+            <ng-container *ngIf="readonly; else writableValue">
+              <span>
+                {{ property.value }}
+              </span>
+            </ng-container>
+            <ng-template #writableValue>
+              <input
+                type="text"
+                [formControlName]="property.key"
+                class="property-input"
+              />
+              <div class="icon-container">
+                <i
+                  class="fa fa-undo fa-md"
+                  *ngIf="
+                    property.defaultValue !== formGroup.value[property.key] &&
+                    !readonly
+                  "
+                  (click)="onResetButtonClick(property)"
+                  popover="{{
+                    'tenant-configuration-form.popover.reset' | translate
+                  }}"
+                  placement="left"
+                  container="body"
+                  triggers="mouseenter:mouseleave"
+                ></i>
+              </div>
+            </ng-template>
+          </td>
+        </tr>
+      </ng-template>
+    </p-table>
+  </ng-container>
+</ng-template>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
@@ -1,13 +1,11 @@
-<ng-container
-  *ngIf="properties != null && properties.length === 0; else hasResults"
->
+<ng-container *ngIf="rows != null && rows.length === 0; else hasResults">
   {{ 'tenant-localization-form.no-results' | translate }}
 </ng-container>
 <ng-template #hasResults>
   <ng-container [formGroup]="formGroup">
     <p-table
       #table
-      [value]="properties"
+      [value]="rows"
       dataKey="key"
       [globalFilterFields]="['key', 'value']"
       [paginator]="true"

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
@@ -1,15 +1,15 @@
-<ng-container *ngIf="rows != null && rows.length === 0; else hasResults">
+<ng-container *ngIf="_rows != null && _rows.length === 0; else hasResults">
   {{ 'tenant-localization-form.no-results' | translate }}
 </ng-container>
 <ng-template #hasResults>
   <ng-container [formGroup]="formGroup">
     <p-table
       #table
-      [value]="rows"
+      [value]="_rows"
       dataKey="key"
       [globalFilterFields]="['key', 'value']"
       [paginator]="true"
-      [(first)]="first"
+      [(first)]="_first"
       [alwaysShowPaginator]="false"
       [rows]="20"
       [rowTrackBy]="rowTrackBy"
@@ -43,8 +43,8 @@
             <ng-template #writableValue>
               <input
                 type="text"
+                class="form-control"
                 [formControlName]="property.key"
-                class="property-input"
               />
               <div class="icon-container">
                 <i

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.html
@@ -5,8 +5,7 @@
     name="search"
     type="text"
     placeholder="{{
-      'tenant-form.field.localizationOverrides.control.search.placeholder'
-        | translate
+      'tenant-form.field.localizations.control.search.placeholder' | translate
     }}"
     class="form-control"
     (input)="table.filterGlobal($event, 'contains')"
@@ -19,10 +18,7 @@
       [(ngModel)]="modified"
       (ngModelChange)="updatePropertiesFilter()"
     />
-    {{
-      'tenant-form.field.localizationOverrides.control.modified.label'
-        | translate
-    }}
+    {{ 'tenant-form.field.localizations.control.modified.label' | translate }}
   </label>
 </div>
 
@@ -43,14 +39,10 @@
       <ng-template pTemplate="header">
         <tr>
           <th>
-            {{
-              'tenant-localization-override-form.column.key.label' | translate
-            }}
+            {{ 'tenant-localization-form.column.key.label' | translate }}
           </th>
           <th>
-            {{
-              'tenant-localization-override-form.column.value.label' | translate
-            }}
+            {{ 'tenant-localization-form.column.value.label' | translate }}
           </th>
         </tr>
       </ng-template>
@@ -78,7 +70,7 @@
                 *ngIf="overrides.value !== overrides.originalValue && !readonly"
                 (click)="resetClicked(overrides)"
                 popover="{{
-                  'tenant-configuration-override-form.popover.reset' | translate
+                  'tenant-configuration-form.popover.reset' | translate
                 }}"
                 placement="left"
                 container="body"
@@ -104,7 +96,7 @@
       <ng-template pTemplate="emptymessage">
         <tr>
           <td colspan="2">
-            {{ 'tenant-localization-override-form.no-results' | translate }}
+            {{ 'tenant-localization-form.no-results' | translate }}
           </td>
         </tr>
       </ng-template>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.less
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.less
@@ -5,11 +5,3 @@
     }
   }
 }
-
-.controls {
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  align-items: center;
-  gap: 15px;
-  margin-bottom: 15px;
-}

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
@@ -67,6 +67,9 @@ export class PropertyOverrideTableComponent implements ControlValueAccessor {
   @Input()
   readonly = true;
 
+  // TODO still need this?
+  first = 0;
+
   constructor(public controlContainer: ControlContainer) {}
 
   get formGroup(): FormGroup {

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
@@ -2,8 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   forwardRef,
-  Input,
-  SimpleChanges
+  Input
 } from '@angular/core';
 import { OldConfigProp } from '../../model/old-config-prop';
 import {
@@ -11,11 +10,9 @@ import {
   ControlValueAccessor,
   FormControl,
   FormGroup,
-  NG_VALIDATORS,
   NG_VALUE_ACCESSOR
 } from '@angular/forms';
 import { Property } from '../../model/property';
-import { propertyValidators } from '../../model/properties';
 
 export function localizationsFormGroup(
   defaults: any,
@@ -47,14 +44,8 @@ function rowTrackBy(index: number, value: OldConfigProp) {
       useExisting: forwardRef(() => PropertyOverrideTableComponent),
       multi: true
     }
-    // {
-    //   provide: NG_VALIDATORS,
-    //   useExisting: forwardRef(() => PropertyOverrideTableComponent),
-    //   multi: true
-    // }
   ]
 })
-//TODO: Implement ControlValueAccessor
 export class PropertyOverrideTableComponent implements ControlValueAccessor {
   readonly rowTrackBy = rowTrackBy;
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
@@ -4,7 +4,6 @@ import {
   forwardRef,
   Input
 } from '@angular/core';
-import { OldConfigProp } from '../../model/old-config-prop';
 import {
   ControlContainer,
   ControlValueAccessor,
@@ -22,14 +21,14 @@ export function localizationsFormGroup(
     Object.entries(defaults).reduce((controlsByName, [key, defaultValue]) => {
       const overrideValue = overrides[key];
       const value = overrideValue != null ? overrideValue : defaultValue;
-      const validators = []; // TODO?
+      const validators = []; // TODO? do localizations need validation?
       controlsByName[key] = new FormControl(value, validators);
       return controlsByName;
     }, {})
   );
 }
 
-function rowTrackBy(index: number, value: OldConfigProp) {
+function rowTrackBy(index: number, value: Property) {
   return value.key;
 }
 
@@ -53,15 +52,19 @@ export class PropertyOverrideTableComponent implements ControlValueAccessor {
   defaults: any;
 
   @Input()
-  rows: Property[];
-
-  @Input()
   readonly = true;
 
-  // TODO still need this?
-  first = 0;
+  _rows: Property[];
+  _first = 0;
 
   constructor(public controlContainer: ControlContainer) {}
+
+  @Input()
+  set rows(values: Property[]) {
+    this._rows = values;
+    // reset the page back to the first page when the search changes
+    this._first = 0;
+  }
 
   get formGroup(): FormGroup {
     return this.controlContainer.control as FormGroup;

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
@@ -2,7 +2,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   forwardRef,
-  Input
+  Input,
+  SimpleChanges
 } from '@angular/core';
 import { OldConfigProp } from '../../model/old-config-prop';
 import {
@@ -14,8 +15,9 @@ import {
   NG_VALUE_ACCESSOR
 } from '@angular/forms';
 import { Property } from '../../model/property';
+import { propertyValidators } from '../../model/properties';
 
-export function localizationOverridesFormGroup(
+export function localizationsFormGroup(
   defaults: any,
   overrides: any
 ): FormGroup {
@@ -23,12 +25,8 @@ export function localizationOverridesFormGroup(
     Object.entries(defaults).reduce((controlsByName, [key, defaultValue]) => {
       const overrideValue = overrides[key];
       const value = overrideValue != null ? overrideValue : defaultValue;
-
-      // TODO apply metadata
-      const validators = [];
-
+      const validators = []; // TODO?
       controlsByName[key] = new FormControl(value, validators);
-
       return controlsByName;
     }, {})
   );
@@ -64,23 +62,15 @@ export class PropertyOverrideTableComponent implements ControlValueAccessor {
   defaults: any;
 
   @Input()
-  properties: Property[];
+  rows: Property[];
 
   @Input()
   readonly = true;
-
-  first = 0;
 
   constructor(public controlContainer: ControlContainer) {}
 
   get formGroup(): FormGroup {
     return this.controlContainer.control as FormGroup;
-  }
-
-  onResetButtonClick(property: Property): void {
-    this.formGroup.patchValue({
-      [property.key]: property.defaultValue
-    });
   }
 
   // control value accessor implementation:
@@ -103,5 +93,13 @@ export class PropertyOverrideTableComponent implements ControlValueAccessor {
 
   setDisabledState?(isDisabled: boolean): void {
     isDisabled ? this.formGroup.disable() : this.formGroup.enable();
+  }
+
+  // internals
+
+  onResetButtonClick(property: Property): void {
+    this.formGroup.patchValue({
+      [property.key]: property.defaultValue
+    });
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-table/property-override-table.component.ts
@@ -1,6 +1,30 @@
 import { Component, Input } from '@angular/core';
 import { ConfigurationProperty } from '../../model/configuration-property';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
+
+export function localizationOverridesFormGroup(
+  defaults: any,
+  overrides: any
+): FormGroup {
+  const flattenedDefaults = defaults;
+  const flattenedOverrides = overrides;
+  return new FormGroup(
+    Object.entries(flattenedDefaults).reduce(
+      (controlsByName, [key, defaultValue]) => {
+        const overrideValue = flattenedOverrides[key];
+        const value = overrideValue != null ? overrideValue : defaultValue;
+
+        // TODO apply metadata
+        const validators = [];
+
+        controlsByName[key] = new FormControl(value, validators);
+
+        return controlsByName;
+      },
+      {}
+    )
+  );
+}
 
 function rowTrackBy(index: number, value: ConfigurationProperty) {
   return value.key;

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -1,42 +1,13 @@
-<!-- TODO extract -->
-<div class="controls">
-  <input
-    id="search"
-    name="search"
-    type="text"
-    placeholder="{{
-      'tenant-form.field.configurations.control.search.placeholder' | translate
-    }}"
-    class="form-control"
-    (input)="table.filterGlobal($event.target.value, 'contains')"
-  />
-
-  <label>
-    <input
-      id="required"
-      name="required"
-      type="checkbox"
-      [(ngModel)]="required"
-    />
-    {{ 'tenant-form.field.configurations.control.required.label' | translate }}
-  </label>
-
-  <label>
-    <input
-      id="modified"
-      name="modified"
-      type="checkbox"
-      [(ngModel)]="modified"
-    />
-    {{ 'tenant-form.field.configurations.control.modified.label' | translate }}
-  </label>
-</div>
-
-<div [formGroup]="form">
-  <div [formArrayName]="propertiesArrayName">
+<ng-container
+  *ngIf="properties != null && properties.length === 0; else hasResults"
+>
+  {{ 'tenant-configuration-form.no-results' | translate }}
+</ng-container>
+<ng-template #hasResults>
+  <ng-container [formGroup]="formGroup">
     <p-treeTable
       #table
-      [value]="configurationPropertiesTreeNodes"
+      [value]="tree"
       dataKey="key"
       [globalFilterFields]="['key', 'value']"
       styleClass="table table-striped table-hover"
@@ -60,10 +31,6 @@
                 [ngClass]="{
                   leaf: node.leaf
                 }"
-                [hidden]="
-                  (modified && !hasModifiedDescendant(node)) ||
-                  (required && !hasRequiredDescendant(node))
-                "
                 [ttRow]="rowNode"
                 (click)="onRowClick(rowNode, $event)"
               >
@@ -73,13 +40,14 @@
                   [ngClass]="{ 'group-node': data.groupNode }"
                 >
                   <p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
-                  <ng-container *ngIf="data.groupNode; else notGroupNode">
+                  <ng-container *ngIf="node.leaf; else parentNode">
+                    {{ data.key }}
+                  </ng-container>
+                  <ng-template #parentNode>
+                    <!-- TODO this should just be for first layer -->
                     {{
                       'tenant-configuration-form.group.' + data.key | translate
                     }}
-                  </ng-container>
-                  <ng-template #notGroupNode>
-                    {{ data.key }}
                   </ng-template>
                 </td>
               </tr>
@@ -87,14 +55,10 @@
             <ng-template #leafNode>
               <ng-container *ngIf="data.readonly; else writableNode">
                 <tr
-                  [hidden]="
-                    (modified && data.originalValue === data.value) ||
-                    (required && !data.required)
-                  "
                   [ttRow]="rowNode"
                   [ngClass]="{
                     leaf: node.leaf,
-                    modified: data.value !== data.originalValue
+                    modified: data.defaultValue !== formGroup.value[data.key]
                   }"
                 >
                   <td [title]="data.key">
@@ -108,21 +72,11 @@
               </ng-container>
               <ng-template #writableNode>
                 <tr
-                  [hidden]="
-                    (modified && data.originalValue === data.value) ||
-                    (required && !data.required)
-                  "
                   [ttRow]="rowNode"
                   [ngClass]="{
                     leaf: node.leaf,
-                    modified: data.modified,
-                    required:
-                      form.get(propertiesArrayName) != null &&
-                      form.get(propertiesArrayName).get(data.formControlName) !=
-                        null &&
-                      showErrors(
-                        form.get(propertiesArrayName).get(data.formControlName)
-                      )
+                    modified: data.defaultValue !== formGroup.value[data.key],
+                    required: showErrors(formGroup.controls[data.key])
                   }"
                 >
                   <td [title]="data.key">
@@ -135,17 +89,17 @@
                     <input
                       #overrideInput
                       [type]="
-                        data.secure && !data.showSecure ? 'password' : 'text'
+                        data.password && !data.showSecure ? 'password' : 'text'
                       "
                       data-lpignore="true"
                       [value]="data.value"
-                      [formControlName]="data.formControlName"
+                      [formControlName]="data.key"
                       class="property-input"
                       [ngClass]="{ 'text-lowercase': data.lowercase }"
                     />
                     <div class="icon-container">
                       <a
-                        *ngIf="data.value !== data.originalValue"
+                        *ngIf="data.defaultValue !== formGroup.value[data.key]"
                         href="javascript:void(0)"
                         (click)="onResetButtonClick(data)"
                         popover="{{
@@ -158,7 +112,7 @@
                         <i class="fa fa-undo fa-md"></i>
                       </a>
                       <a
-                        *ngIf="data.secure"
+                        *ngIf="data.password"
                         href="javascript:void(0)"
                         (click)="data.showSecure = !data.showSecure"
                       >
@@ -188,7 +142,7 @@
                         *ngIf="data.required"
                         href="javascript:void(0)"
                         popover="{{
-                          data.key.endsWith('password')
+                          data.password
                             ? ('tenant-configuration-form.popover.password'
                               | translate)
                             : null
@@ -207,13 +161,6 @@
           </ng-container>
         </ng-container>
       </ng-template>
-      <ng-template pTemplate="emptymessage">
-        <tr>
-          <td colspan="2">
-            {{ 'tenant-configuration-form.no-results' | translate }}
-          </td>
-        </tr>
-      </ng-template>
     </p-treeTable>
-  </div>
-</div>
+  </ng-container>
+</ng-template>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -84,72 +84,89 @@
                     {{ data.segment }}
                   </td>
                   <td>
-                    <input
-                      #overrideInput
-                      [type]="
-                        data.password && !data.showSecure ? 'password' : 'text'
-                      "
-                      data-lpignore="true"
-                      [formControlName]="data.key"
-                      class="property-input"
-                      [ngClass]="{ 'text-lowercase': data.lowercase }"
-                    />
-                    <div class="icon-container">
-                      <a
-                        *ngIf="data.defaultValue !== formGroup.value[data.key]"
-                        href="javascript:void(0)"
-                        (click)="onResetButtonClick(data)"
-                        popover="{{
-                          'tenant-configuration-form.popover.reset' | translate
-                        }}"
-                        placement="left"
-                        container="body"
-                        triggers="mouseenter:mouseleave"
-                      >
-                        <i class="fa fa-undo fa-md"></i>
-                      </a>
-                      <a
-                        *ngIf="data.password"
-                        href="javascript:void(0)"
-                        (click)="data.showSecure = !data.showSecure"
-                      >
-                        <i
-                          class="fa fa-md"
-                          [ngClass]="{
-                            'fa-eye-slash': data.showSecure,
-                            'fa-eye': !data.showSecure
-                          }"
-                        ></i>
-                      </a>
-                      <a
-                        *ngIf="data.encrypted"
-                        href="javascript:void(0)"
-                        (click)="onDecryptButtonClick(data)"
-                        popover="{{
-                          'tenant-configuration-form.popover.decrypt'
-                            | translate
-                        }}"
-                        placement="left"
-                        container="body"
-                        triggers="mouseenter:mouseleave"
-                      >
-                        <i class="fa fa-unlock fa-md"></i>
-                      </a>
-                      <a
-                        *ngIf="data.required"
-                        href="javascript:void(0)"
-                        popover="{{
-                          data.password
-                            ? ('tenant-configuration-form.popover.password'
-                              | translate)
-                            : null
-                        }}"
-                        placement="left"
-                        container="body"
-                        triggers="mouseenter:mouseleave"
-                      >
-                        <i class="fa fa-asterisk fa-md"></i>
-                      </a>
+                    <div
+                      class="form-group"
+                      [ngClass]="{
+                        'has-error': showErrors(formGroup.controls[data.key])
+                      }"
+                    >
+                      <input
+                        [type]="
+                          data.password && !data.showSecure
+                            ? 'password'
+                            : 'text'
+                        "
+                        [formControlName]="data.key"
+                        data-lpignore="true"
+                        class="form-control"
+                        [ngClass]="{ 'text-lowercase': data.lowercase }"
+                      />
+                      <div class="icon-container">
+                        <a
+                          *ngIf="
+                            data.defaultValue !== formGroup.value[data.key]
+                          "
+                          href="javascript:void(0)"
+                          (click)="onResetButtonClick(data)"
+                          popover="{{
+                            'tenant-configuration-form.popover.reset'
+                              | translate
+                          }}"
+                          placement="left"
+                          container="body"
+                          triggers="mouseenter:mouseleave"
+                        >
+                          <i class="fa fa-undo fa-md"></i>
+                        </a>
+                        <a
+                          *ngIf="data.password"
+                          href="javascript:void(0)"
+                          (click)="data.showSecure = !data.showSecure"
+                        >
+                          <i
+                            class="fa fa-md"
+                            [ngClass]="{
+                              'fa-eye-slash': data.showSecure,
+                              'fa-eye': !data.showSecure
+                            }"
+                          ></i>
+                        </a>
+                        <a
+                          *ngIf="data.encrypted"
+                          href="javascript:void(0)"
+                          (click)="onDecryptButtonClick(data)"
+                          popover="{{
+                            'tenant-configuration-form.popover.decrypt'
+                              | translate
+                          }}"
+                          placement="left"
+                          container="body"
+                          triggers="mouseenter:mouseleave"
+                        >
+                          <i
+                            class="fa fa-md"
+                            [ngClass]="{
+                              'fa-lock': hasCipher(formGroup.value[data.key]),
+                              'fa-unlock': hasCipher(formGroup.value[data.key])
+                            }"
+                          ></i>
+                        </a>
+                        <a
+                          *ngIf="data.required"
+                          href="javascript:void(0)"
+                          popover="{{
+                            data.password
+                              ? ('tenant-configuration-form.popover.password'
+                                | translate)
+                              : null
+                          }}"
+                          placement="left"
+                          container="body"
+                          triggers="mouseenter:mouseleave"
+                        >
+                          <i class="fa fa-asterisk fa-md"></i>
+                        </a>
+                      </div>
                     </div>
                   </td>
                 </tr>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -5,8 +5,7 @@
     name="search"
     type="text"
     placeholder="{{
-      'tenant-form.field.configurationOverrides.control.search.placeholder'
-        | translate
+      'tenant-form.field.configurations.control.search.placeholder' | translate
     }}"
     class="form-control"
     (input)="table.filterGlobal($event.target.value, 'contains')"
@@ -19,10 +18,7 @@
       type="checkbox"
       [(ngModel)]="required"
     />
-    {{
-      'tenant-form.field.configurationOverrides.control.required.label'
-        | translate
-    }}
+    {{ 'tenant-form.field.configurations.control.required.label' | translate }}
   </label>
 
   <label>
@@ -32,10 +28,7 @@
       type="checkbox"
       [(ngModel)]="modified"
     />
-    {{
-      'tenant-form.field.configurationOverrides.control.modified.label'
-        | translate
-    }}
+    {{ 'tenant-form.field.configurations.control.modified.label' | translate }}
   </label>
 </div>
 
@@ -52,15 +45,10 @@
       <ng-template pTemplate="header">
         <tr>
           <th>
-            {{
-              'tenant-configuration-override-form.column.key.label' | translate
-            }}
+            {{ 'tenant-configuration-form.column.key.label' | translate }}
           </th>
           <th>
-            {{
-              'tenant-configuration-override-form.column.value.label'
-                | translate
-            }}
+            {{ 'tenant-configuration-form.column.value.label' | translate }}
           </th>
         </tr>
       </ng-template>
@@ -87,8 +75,7 @@
                   <p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
                   <ng-container *ngIf="data.groupNode; else notGroupNode">
                     {{
-                      'tenant-configuration-override-form.group.' + data.key
-                        | translate
+                      'tenant-configuration-form.group.' + data.key | translate
                     }}
                   </ng-container>
                   <ng-template #notGroupNode>
@@ -163,8 +150,7 @@
                         href="javascript:void(0)"
                         (click)="onResetButtonClick(data)"
                         popover="{{
-                          'tenant-configuration-override-form.popover.reset'
-                            | translate
+                          'tenant-configuration-form.popover.reset' | translate
                         }}"
                         placement="left"
                         container="body"
@@ -190,7 +176,7 @@
                         href="javascript:void(0)"
                         (click)="onDecryptButtonClick(data)"
                         popover="{{
-                          'tenant-configuration-override-form.popover.decrypt'
+                          'tenant-configuration-form.popover.decrypt'
                             | translate
                         }}"
                         placement="left"
@@ -204,7 +190,7 @@
                         href="javascript:void(0)"
                         popover="{{
                           data.key.endsWith('password')
-                            ? ('tenant-configuration-override-form.popover.password'
+                            ? ('tenant-configuration-form.popover.password'
                               | translate)
                             : null
                         }}"
@@ -225,7 +211,7 @@
       <ng-template pTemplate="emptymessage">
         <tr>
           <td colspan="2">
-            {{ 'tenant-configuration-override-form.no-results' | translate }}
+            {{ 'tenant-configuration-form.no-results' | translate }}
           </td>
         </tr>
       </ng-template>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -140,7 +140,6 @@
                       data-lpignore="true"
                       [value]="data.value"
                       [formControlName]="data.formControlName"
-                      (change)="updateOverride(data)"
                       class="property-input"
                       [ngClass]="{ 'text-lowercase': data.lowercase }"
                     />

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -1,6 +1,4 @@
-<ng-container
-  *ngIf="properties != null && properties.length === 0; else hasResults"
->
+<ng-container *ngIf="tree != null && tree.length === 0; else hasResults">
   {{ 'tenant-configuration-form.no-results' | translate }}
 </ng-container>
 <ng-template #hasResults>
@@ -37,17 +35,17 @@
                 <td
                   [title]="data.key"
                   colspan="2"
-                  [ngClass]="{ 'group-node': data.groupNode }"
+                  [ngClass]="{ 'group-node': data.depth === 0 }"
                 >
                   <p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
-                  <ng-container *ngIf="node.leaf; else parentNode">
-                    {{ data.key }}
-                  </ng-container>
-                  <ng-template #parentNode>
-                    <!-- TODO this should just be for first layer -->
+                  <ng-container *ngIf="data.depth === 0; else notRootNode">
                     {{
-                      'tenant-configuration-form.group.' + data.key | translate
+                      'tenant-configuration-form.group.' + data.segment
+                        | translate
                     }}
+                  </ng-container>
+                  <ng-template #notRootNode>
+                    {{ data.segment }}
                   </ng-template>
                 </td>
               </tr>
@@ -65,7 +63,7 @@
                     <p-treeTableToggler
                       [rowNode]="rowNode"
                     ></p-treeTableToggler>
-                    {{ data.key }}
+                    {{ data.segment }}
                   </td>
                   <td>{{ data.value }}</td>
                 </tr>
@@ -83,7 +81,7 @@
                     <p-treeTableToggler
                       [rowNode]="rowNode"
                     ></p-treeTableToggler>
-                    {{ data.key }}
+                    {{ data.segment }}
                   </td>
                   <td>
                     <input
@@ -92,7 +90,6 @@
                         data.password && !data.showSecure ? 'password' : 'text'
                       "
                       data-lpignore="true"
-                      [value]="data.value"
                       [formControlName]="data.key"
                       class="property-input"
                       [ngClass]="{ 'text-lowercase': data.lowercase }"

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.ts
@@ -21,6 +21,26 @@ import { NotificationService } from '../../../../shared/notification/notificatio
 import { ConfigurationProperty } from '../../model/configuration-property';
 import { showErrors } from '../../../../shared/form/forms';
 import { DecryptionService } from '../../service/decryption.service';
+import { flattenJsonObject } from '../../../../shared/support/support';
+
+export function configurationsFormGroup(
+  defaults: any,
+  overrides: any
+): FormGroup {
+  return new FormGroup(
+    Object.entries(defaults).reduce((controlsByName, [key, defaultValue]) => {
+      const overrideValue = overrides[key];
+      const value = overrideValue != null ? overrideValue : defaultValue;
+
+      // TODO apply metadata
+      const validators = [];
+
+      controlsByName[key] = new FormControl(value, validators);
+
+      return controlsByName;
+    }, {})
+  );
+}
 
 function passwordValidators(): ValidatorFn[] {
   return [

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.ts
@@ -1,42 +1,19 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  forwardRef,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  ViewChild
-} from '@angular/core';
+import { Component, forwardRef, Input, ViewChild } from '@angular/core';
 import {
   ControlContainer,
   ControlValueAccessor,
   FormControl,
   FormGroup,
   NG_VALUE_ACCESSOR,
-  ValidatorFn,
-  Validators
+  ValidatorFn
 } from '@angular/forms';
 import { TreeNode } from 'primeng/api';
 import { TreeTable, TreeTableToggler } from 'primeng/primeng';
 import { NotificationService } from '../../../../shared/notification/notification.service';
-import { OldConfigProp } from '../../model/old-config-prop';
 import { showErrors } from '../../../../shared/form/forms';
 import { DecryptionService } from '../../service/decryption.service';
-import {
-  propertyValidators,
-  toConfigurationProperty,
-  toProperty
-} from '../../model/properties';
+import { hasCipher, propertyValidators } from '../../model/properties';
 import { ConfigurationProperty } from '../../model/property';
-import { unflatten } from '../../../../shared/support/support';
-
-const cipherPattern = /^{cipher}.+/;
-
-function hasCipher(value: string): boolean {
-  return typeof value === 'string' && cipherPattern.test(value);
-}
 
 export function configurationsFormGroup(
   defaults: any,
@@ -52,10 +29,6 @@ export function configurationsFormGroup(
     }, {}),
     validators
   );
-}
-
-function rowTrackBy(index: number, { node }: any): string {
-  return node.key;
 }
 
 function addTreeNodesRecursively(
@@ -115,6 +88,10 @@ export function toTreeNodes(value: any, expanded: boolean = false): TreeNode[] {
   const nodes = [];
   addTreeNodesRecursively(nodes, value, '', expanded);
   return nodes;
+}
+
+function rowTrackBy(index: number, { node }: any): string {
+  return node.key;
 }
 
 @Component({

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -262,12 +262,8 @@
       <app-toggle-label
         [open]="configurationOpen"
         (openChange)="configurationOpen = $event"
-        openLabel="{{
-          'tenant-form.field.configurationOverrides.label' | translate
-        }}"
-        closedLabel="{{
-          'tenant-form.field.configurationOverrides.label' | translate
-        }}"
+        openLabel="{{ 'tenant-form.field.configurations.label' | translate }}"
+        closedLabel="{{ 'tenant-form.field.configurations.label' | translate }}"
       ></app-toggle-label>
 
       <span class="text-danger" *ngIf="showErrors(formGroup)">
@@ -275,7 +271,7 @@
           *ngIf="formGroup.errors && formGroup.errors.onePasswordPerUser"
         >
           {{
-            'tenant-form.field.configurationOverrides.error.onePasswordPerUser'
+            'tenant-form.field.configurations.error.onePasswordPerUser'
               | translate: formGroup.errors
           }}
         </ng-container>
@@ -283,33 +279,27 @@
 
       <div class="form-group" [hidden]="!configurationOpen">
         <property-override-tree-table
-          [form]="formGroup"
-          [configurationProperties]="configurationOverrides"
+          formControlName="configurations"
+          [defaults]="configurationDefaults"
           [readonly]="!writable"
           [readonlyGroups]="readonlyGroups"
           [required]="requiredConfiguration"
           [expanded]="requiredConfiguration"
-          propertiesArrayName="configurationProperties"
         ></property-override-tree-table>
       </div>
 
       <app-toggle-label
         [open]="localizationOpen"
         (openChange)="localizationOpen = $event"
-        openLabel="{{
-          'tenant-form.field.localizationOverrides.label' | translate
-        }}"
-        closedLabel="{{
-          'tenant-form.field.localizationOverrides.label' | translate
-        }}"
+        openLabel="{{ 'tenant-form.field.localizations.label' | translate }}"
+        closedLabel="{{ 'tenant-form.field.localizations.label' | translate }}"
       ></app-toggle-label>
 
       <div class="form-group" [hidden]="!localizationOpen">
         <property-override-table
-          [form]="formGroup"
-          [configurationProperties]="localizationOverrides"
+          formControlName="localizations"
+          [defaults]="localizationDefaults"
           [readonly]="!writable"
-          propertiesArrayName="localizationOverrides"
         ></property-override-table>
       </div>
     </div>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -278,14 +278,15 @@
       </span>
 
       <div class="form-group" [hidden]="!configurationOpen">
-        <property-override-tree-table
-          formControlName="configurations"
-          [defaults]="configurationDefaults"
-          [readonly]="!writable"
-          [readonlyGroups]="readonlyGroups"
-          [required]="requiredConfiguration"
-          [expanded]="requiredConfiguration"
-        ></property-override-tree-table>
+        TODO
+        <!--        <property-override-tree-table-->
+        <!--          formGroupName="configurations"-->
+        <!--          [defaults]="configurationDefaults"-->
+        <!--          [readonly]="!writable"-->
+        <!--          [readonlyGroups]="readonlyGroups"-->
+        <!--          [required]="requiredConfiguration"-->
+        <!--          [expanded]="requiredConfiguration"-->
+        <!--        ></property-override-tree-table>-->
       </div>
 
       <app-toggle-label
@@ -295,9 +296,38 @@
         closedLabel="{{ 'tenant-form.field.localizations.label' | translate }}"
       ></app-toggle-label>
 
-      <div class="form-group" [hidden]="!localizationOpen">
+      <div class="form-group">
+        <!--      <div class="form-group" [hidden]="!localizationOpen">-->
+        <div class="controls">
+          <form [formGroup]="localizationFormGroup">
+            <input
+              id="localizationSearch"
+              name="localizationSearch"
+              formControlName="search"
+              type="text"
+              placeholder="{{
+                'tenant-form.field.localizations.control.search.placeholder'
+                  | translate
+              }}"
+              class="form-control"
+            />
+            <label>
+              <input
+                id="localizationModified"
+                name="localizationModified"
+                formControlName="modified"
+                type="checkbox"
+              />
+              {{
+                'tenant-form.field.localizations.control.modified.label'
+                  | translate
+              }}
+            </label>
+          </form>
+        </div>
         <property-override-table
-          formControlName="localizations"
+          formGroupName="localizations"
+          [properties]="localizations$ | async"
           [defaults]="localizationDefaults"
           [readonly]="!writable"
         ></property-override-table>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -1,8 +1,4 @@
-<form
-  *ngIf="formGroup"
-  [formGroup]="formGroup"
-  (ngSubmit)="onSaveButtonClick()"
->
+<form *ngIf="formGroup" [formGroup]="formGroup" (ngSubmit)="onSubmit()">
   <page-heading>
     <h1 class="h2" heading>
       <ng-container *ngIf="mode === 'create'; else updateModeHeading">
@@ -21,11 +17,7 @@
         <li>
           <div class="btn-group">
             <div class="btn-group">
-              <button
-                type="submit"
-                class="btn btn-primary"
-                [disabled]="formGroup.invalid"
-              >
+              <button type="submit" class="btn btn-primary">
                 <ng-container
                   *ngIf="mode === 'create'; else updateSubmitButton"
                 >
@@ -341,6 +333,7 @@
         <div class="localization-controls">
           <ng-container [formGroup]="localizationControlsFormGroup">
             <input
+              formnovalidate
               id="localizationSearch"
               name="localizationSearch"
               formControlName="search"

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -278,15 +278,55 @@
       </span>
 
       <div class="form-group" [hidden]="!configurationOpen">
-        TODO
-        <!--        <property-override-tree-table-->
-        <!--          formGroupName="configurations"-->
-        <!--          [defaults]="configurationDefaults"-->
-        <!--          [readonly]="!writable"-->
-        <!--          [readonlyGroups]="readonlyGroups"-->
-        <!--          [required]="requiredConfiguration"-->
-        <!--          [expanded]="requiredConfiguration"-->
-        <!--        ></property-override-tree-table>-->
+        <!-- TODO extract -->
+        <div class="configuration-controls">
+          <ng-container [formGroup]="configurationControlsFormGroup">
+            <input
+              id="configurationSearch"
+              name="configurationSearch"
+              type="text"
+              class="form-control"
+              placeholder="{{
+                'tenant-form.field.configurations.control.search.placeholder'
+                  | translate
+              }}"
+            />
+
+            <label>
+              <input
+                id="configurationRequired"
+                name="configurationRequired"
+                formControlName="required"
+                type="checkbox"
+              />
+              {{
+                'tenant-form.field.configurations.control.required.label'
+                  | translate
+              }}
+            </label>
+
+            <label>
+              <input
+                id="configurationModified"
+                name="configurationModified"
+                formControlName="modified"
+                type="checkbox"
+              />
+              {{
+                'tenant-form.field.configurations.control.modified.label'
+                  | translate
+              }}
+            </label>
+          </ng-container>
+        </div>
+        <property-override-tree-table
+          formGroupName="configurations"
+          [tree]="configurations$ | async"
+          [readonlyGroups]="readonlyGroups"
+          [defaults]="configurationDefaults"
+          [readonly]="!writable"
+          [expanded]="requiredConfiguration"
+        ></property-override-tree-table>
       </div>
 
       <app-toggle-label
@@ -296,20 +336,19 @@
         closedLabel="{{ 'tenant-form.field.localizations.label' | translate }}"
       ></app-toggle-label>
 
-      <div class="form-group">
-        <!--      <div class="form-group" [hidden]="!localizationOpen">-->
-        <div class="controls">
-          <form [formGroup]="localizationFormGroup">
+      <div class="form-group" [hidden]="!localizationOpen">
+        <div class="localization-controls">
+          <ng-container [formGroup]="localizationControlsFormGroup">
             <input
               id="localizationSearch"
               name="localizationSearch"
               formControlName="search"
               type="text"
+              class="form-control"
               placeholder="{{
                 'tenant-form.field.localizations.control.search.placeholder'
                   | translate
               }}"
-              class="form-control"
             />
             <label>
               <input
@@ -323,11 +362,11 @@
                   | translate
               }}
             </label>
-          </form>
+          </ng-container>
         </div>
         <property-override-table
           formGroupName="localizations"
-          [properties]="localizations$ | async"
+          [rows]="localizations$ | async"
           [defaults]="localizationDefaults"
           [readonly]="!writable"
         ></property-override-table>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -266,17 +266,6 @@
         closedLabel="{{ 'tenant-form.field.configurations.label' | translate }}"
       ></app-toggle-label>
 
-      <span class="text-danger" *ngIf="showErrors(formGroup)">
-        <ng-container
-          *ngIf="formGroup.errors && formGroup.errors.onePasswordPerUser"
-        >
-          {{
-            'tenant-form.field.configurations.error.onePasswordPerUser'
-              | translate: formGroup.errors
-          }}
-        </ng-container>
-      </span>
-
       <div class="form-group" [hidden]="!configurationOpen">
         <!-- TODO extract -->
         <div class="configuration-controls">
@@ -284,6 +273,7 @@
             <input
               id="configurationSearch"
               name="configurationSearch"
+              formControlName="search"
               type="text"
               class="form-control"
               placeholder="{{
@@ -319,13 +309,24 @@
             </label>
           </ng-container>
         </div>
+
+        <ng-container *ngIf="formGroup.controls.configurations as control">
+          <span class="text-danger" *ngIf="showErrors(control)">
+            <ng-container *ngIf="control.errors.onePasswordPerUser">
+              {{
+                'tenant-form.field.configurations.error.onePasswordPerUser'
+                  | translate: control.errors.onePasswordPerUser
+              }}
+            </ng-container>
+          </span>
+        </ng-container>
+
         <property-override-tree-table
           formGroupName="configurations"
           [tree]="configurations$ | async"
           [readonlyGroups]="readonlyGroups"
           [defaults]="configurationDefaults"
           [readonly]="!writable"
-          [expanded]="requiredConfiguration"
         ></property-override-tree-table>
       </div>
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.less
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.less
@@ -16,3 +16,11 @@
 .toggles {
   margin-top: 15px;
 }
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+  gap: 15px;
+  margin-bottom: 15px;
+}

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.less
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.less
@@ -17,7 +17,15 @@
   margin-top: 15px;
 }
 
-.controls {
+.configuration-controls {
+  display: grid;
+  grid-template-columns: 1fr max-content max-content;
+  align-items: center;
+  gap: 15px;
+  margin-bottom: 15px;
+}
+
+.localization-controls {
   display: grid;
   grid-template-columns: 1fr max-content;
   align-items: center;

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.ts
@@ -24,7 +24,11 @@ import {
   valued
 } from '../../../../shared/support/support';
 import { Property } from '../../model/property';
-import { toConfigurationProperty, toProperty } from '../../model/properties';
+import {
+  lowercase,
+  toConfigurationProperty,
+  toProperty
+} from '../../model/properties';
 import { TreeNode } from 'primeng/api';
 import { keyBy } from 'lodash';
 import {
@@ -32,6 +36,7 @@ import {
   onePasswordPerUser,
   tenantKey
 } from './tenant-form.validators';
+import { create } from 'domain';
 
 export type FormMode = 'create' | 'update';
 const keyboardDebounceInMilliseconds = 300;
@@ -200,7 +205,7 @@ export class TenantFormComponent implements OnChanges, OnDestroy {
 
   onSubmit(): void {
     const {
-      value: { type },
+      value: { code: tenantCode, id: tenantId, type },
       formGroup: {
         invalid,
         value: {
@@ -220,19 +225,18 @@ export class TenantFormComponent implements OnChanges, OnDestroy {
       validate(this.formGroup);
       return;
     }
-
-    const emitter = this.mode === 'create' ? this.create : this.update;
+    const createMode = this.mode === 'create';
+    const emitter = createMode ? this.create : this.update;
     const updated: TenantConfiguration = {
       type,
-      code,
-      id,
+      code: createMode ? code : tenantCode,
+      id: createMode ? id : tenantId,
       label,
       description,
       parentTenantCode: (tenant || <any>{}).code,
       dataSet,
-      // TODO apply lowercase requirement?
-      configurations: valued(
-        rightDifference(this.configurationDefaults, configurations)
+      configurations: lowercase(
+        valued(rightDifference(this.configurationDefaults, configurations))
       ),
       localizations: valued(
         rightDifference(this.localizationDefaults, localizations)

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { DataSet, TenantConfiguration } from '../../model/tenant-configuration';
-import { Forms, showErrors, validate } from '../../../../shared/form/forms';
+import { showErrors, validate } from '../../../../shared/form/forms';
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { debounceTime, map, mergeMap, startWith } from 'rxjs/operators';
 import {
@@ -302,8 +302,7 @@ export class TenantFormComponent implements OnChanges, OnDestroy {
               );
               const flattened = keyBy(properties, ({ key }) => key);
               const unflattened = unflatten(flattened);
-              const tree = toTreeNodes(unflattened, hasSearch);
-              return tree;
+              return toTreeNodes(unflattened, hasSearch);
             })
           )
         )
@@ -340,7 +339,7 @@ export class TenantFormComponent implements OnChanges, OnDestroy {
     });
   }
 
-  // TODO apply default usernames
+  // TODO apply default usernames - this can be done by checking pristine() form control state
   onKeyChange(code: string): void {
     // apply default passwords for sandboxes based on key
     // const key = (code || '').toLowerCase();

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.validators.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.validators.ts
@@ -1,0 +1,61 @@
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  FormGroup,
+  Validators
+} from '@angular/forms';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export const tenantKey = Validators.pattern(/^\w+$/);
+
+export function available(
+  isAvailable: (value: string) => Observable<boolean>
+): AsyncValidatorFn {
+  return function(
+    control: AbstractControl
+  ): Observable<{ unavailable: boolean } | null> {
+    return isAvailable(control.value).pipe(
+      map(available => (available ? null : { unavailable: true }))
+    );
+  };
+}
+
+const passwordKeyExpression = /(.+)\.password$/;
+
+export function onePasswordPerUser(
+  formGroup: FormGroup
+): { onePasswordPerUser: { usernames: string[] } } | null {
+  const controlNames = Object.keys(formGroup.controls);
+
+  const passwordKeys = controlNames.filter(controlName =>
+    passwordKeyExpression.test(controlName)
+  );
+
+  const passwordsByUsername: {
+    [username: string]: string[];
+  } = passwordKeys.reduce((byUsername, passwordKey) => {
+    // assumes username of same base path for every password
+    const usernameKey = `${
+      passwordKeyExpression.exec(passwordKey)[1]
+    }.username`;
+    // this is being run on every form control addition so we need to defensively set this
+    const username = (formGroup.controls[usernameKey] || <any>{}).value;
+    const password = (formGroup.controls[passwordKey] || <any>{}).value;
+    const passwords = byUsername[username];
+    if (passwords != null) {
+      if (!passwords.includes(password)) {
+        passwords.push(password);
+      }
+    } else {
+      byUsername[username] = [password];
+    }
+    return byUsername;
+  }, {});
+
+  const usernames = Object.entries(passwordsByUsername)
+    .filter(([, passwords]) => passwords.length > 1)
+    .map(([username]) => username);
+
+  return usernames.length > 0 ? { onePasswordPerUser: { usernames } } : null;
+}

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/old-config-prop.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/old-config-prop.ts
@@ -1,4 +1,4 @@
-export class ConfigurationProperty {
+export class OldConfigProp {
   key: string;
   originalValue: string;
   value: string;

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.spec.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.spec.ts
@@ -1,0 +1,59 @@
+import { passwordValidators } from './properties';
+import { AbstractControl, ValidationErrors, Validators } from '@angular/forms';
+
+describe('passwordValidators', () => {
+  const validator = Validators.compose(passwordValidators());
+
+  [
+    {
+      name: 'should accept cipher despite missing other criteria',
+      value: '{cipher}afakljsfd',
+      expectation: (x: jasmine.Matchers<ValidationErrors>) => x.toBeNull()
+    },
+    {
+      name: 'should accept if meeting criteria',
+      value: 'abCD1234$!',
+      expectation: x => x.toBeNull()
+    },
+    {
+      name: 'should not accept when missing lowercase',
+      value: 'abCD1234!$'.toUpperCase(),
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when missing uppercase',
+      value: 'abCD1234!$'.toLowerCase(),
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when missing characters',
+      value: '234234231234!$',
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when missing symbol',
+      value: 'abCD1234',
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when missing numbers',
+      value: 'asfsEERWR!$',
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when too short',
+      value: 'aE1!',
+      expectation: x => x.toBeDefined()
+    },
+    {
+      name: 'should not accept when too long',
+      value:
+        'aasfasfeawqewrqwerqwasdfasfdqwerwer@#$#@ewfefsdfasfewrERWRWEFSDFWERDFSFWREWWERWRWRE1!',
+      expectation: x => x.toBeDefined()
+    }
+  ].forEach(({ name, value, expectation }) => {
+    it(name, () => {
+      expectation(expect(validator(<AbstractControl>{ value })));
+    });
+  });
+});

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
@@ -7,6 +7,11 @@ const passwordFields = ['password'];
 const encryptedFields = ['password', 's3SecretKey'];
 // These fields should be lowercase for consistency with existing usernames and schema names in the database
 const lowercaseFields = ['urlParts.database', 'username'];
+const cipherPattern = /^{cipher}.+/;
+
+export function hasCipher(value: string): boolean {
+  return typeof value === 'string' && cipherPattern.test(value);
+}
 
 export function passwordValidators(): ValidatorFn[] {
   return [
@@ -15,7 +20,7 @@ export function passwordValidators(): ValidatorFn[] {
     Validators.maxLength(64),
     Validators.pattern(
       '(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*()-+])[A-Za-z].{8,}|^{cipher}.+'
-    ) // TODO test these
+    )
   ];
 }
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
@@ -1,4 +1,5 @@
 import { ConfigurationProperty, Property } from './property';
+import { ValidatorFn, Validators } from '@angular/forms';
 
 // TODO have metadata mappings for each prop
 const requiredFields = ['username', 'password'];
@@ -6,6 +7,15 @@ const passwordFields = ['password'];
 const encryptedFields = ['password', 's3SecretKey'];
 // These fields should be lowercase for consistency with existing usernames and schema names in the database
 const lowercaseFields = ['urlParts.database', 'username'];
+
+export function passwordValidators(): ValidatorFn[] {
+  return [
+    Validators.required,
+    Validators.minLength(8),
+    Validators.maxLength(64),
+    Validators.pattern('(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[A-Za-zd].{8,}')
+  ];
+}
 
 export function toProperty(key: string, defaultValue: any): Property {
   return {
@@ -25,4 +35,10 @@ export function toConfigurationProperty(
     encrypted: encryptedFields.some(matcher => key.includes(matcher)),
     lowercase: lowercaseFields.some(matcher => key.includes(matcher))
   };
+}
+
+export function propertyValidators(key: string): ValidatorFn[] {
+  return passwordFields.some(matcher => key.includes(matcher))
+    ? passwordValidators()
+    : [];
 }

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
@@ -1,0 +1,28 @@
+import { ConfigurationProperty, Property } from './property';
+
+// TODO have metadata mappings for each prop
+const requiredFields = ['username', 'password'];
+const passwordFields = ['password'];
+const encryptedFields = ['password', 's3SecretKey'];
+// These fields should be lowercase for consistency with existing usernames and schema names in the database
+const lowercaseFields = ['urlParts.database', 'username'];
+
+export function toProperty(key: string, defaultValue: any): Property {
+  return {
+    key,
+    defaultValue
+  };
+}
+
+export function toConfigurationProperty(
+  key: string,
+  defaultValue: any
+): ConfigurationProperty {
+  return {
+    ...toProperty(key, defaultValue),
+    required: requiredFields.some(matcher => key.includes(matcher)),
+    password: passwordFields.some(matcher => key.includes(matcher)),
+    encrypted: encryptedFields.some(matcher => key.includes(matcher)),
+    lowercase: lowercaseFields.some(matcher => key.includes(matcher))
+  };
+}

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
@@ -49,3 +49,17 @@ export function propertyValidators(key: string): ValidatorFn[] {
     ? passwordValidators()
     : [];
 }
+
+export function lowercase(values: {
+  [key: string]: any;
+}): { [key: string]: any } {
+  return Object.entries(values).reduce((lowercased, [key, value]) => {
+    lowercased[key] =
+      lowercaseFields.some(matcher => key.includes(matcher)) &&
+      value != null &&
+      typeof value === 'string'
+        ? value.toLowerCase()
+        : value;
+    return lowercased;
+  }, {});
+}

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/properties.ts
@@ -13,7 +13,9 @@ export function passwordValidators(): ValidatorFn[] {
     Validators.required,
     Validators.minLength(8),
     Validators.maxLength(64),
-    Validators.pattern('(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[A-Za-zd].{8,}')
+    Validators.pattern(
+      '(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*()-+])[A-Za-z].{8,}|^{cipher}.+'
+    ) // TODO test these
   ];
 }
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/property.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/property.ts
@@ -1,0 +1,11 @@
+export interface Property {
+  key: string;
+  defaultValue: any;
+}
+
+export interface ConfigurationProperty extends Property {
+  required?: boolean;
+  password?: boolean;
+  encrypted?: boolean;
+  lowercase?: boolean;
+}

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
@@ -1,4 +1,3 @@
-import { OldConfigProp } from './old-config-prop';
 import { TenantStatus } from './tenant-status';
 import { TenantType } from './tenant-type';
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
@@ -1,4 +1,4 @@
-import { ConfigurationProperty } from './configuration-property';
+import { OldConfigProp } from './old-config-prop';
 import { TenantStatus } from './tenant-status';
 import { TenantType } from './tenant-type';
 
@@ -34,7 +34,7 @@ export interface TenantConfiguration {
   /**
    * The map containing text/i18n overrides
    */
-  localizationOverrides?: ConfigurationProperty[];
+  localizationOverrides?: OldConfigProp[];
 
   /**
    * The JSON containing configuration properties

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
@@ -32,19 +32,9 @@ export interface TenantConfiguration {
   description?: string;
 
   /**
-   * The map containing text/i18n overrides
+   * The parent tenant code this sandbox is for.
    */
-  localizationOverrides?: OldConfigProp[];
-
-  /**
-   * The JSON containing configuration properties
-   */
-  configurationProperties?: any;
-
-  /**
-   * The current status of this tenant.
-   */
-  status?: TenantStatus;
+  parentTenantCode?: string;
 
   /**
    * The data template initially used to create the sandbox
@@ -52,9 +42,19 @@ export interface TenantConfiguration {
   dataSet?: DataSet;
 
   /**
-   * The parent tenant code this sandbox is for.
+   * Flat map of localization codes to messages
    */
-  parentTenantCode?: string;
+  localizations: { [key: string]: string };
+
+  /**
+   * Flat map of configuration properties to values
+   */
+  configurations: { [key: string]: string | boolean | number };
+
+  /**
+   * The current status of this tenant.
+   */
+  status?: TenantStatus;
 }
 
 export interface DataSet {

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-statuses.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-statuses.ts
@@ -1,0 +1,1 @@
+export const completedTenantStatuses = ['ACTIVE', 'FAILED'];

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.data.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.data.ts
@@ -1,0 +1,235 @@
+import { DataSet } from './tenant-configuration';
+
+export const dataSets: DataSet[] = [
+  {
+    label: 'ds1',
+    id: 'DS1'
+  },
+  {
+    label: 'ds2',
+    id: 'DS2'
+  }
+];
+
+export const activeSandbox = {
+  tenant: {
+    id: 'TS_S001',
+    key: 'TS_S001',
+    name: 'Test Tenant Sandbox 001',
+    description: null,
+    sandbox: true,
+    sandboxDataset: 'DS1'
+  },
+  parentTenantKey: 'TS',
+  localization: null,
+  administrationStatus: { tenantAdministrationStatus: 'ACTIVE' },
+  reporting: {
+    analyticsTrackingId: null,
+    interpretiveGuideUrl: null,
+    accessDeniedUrl: null,
+    landingPageUrl: null,
+    irisVendorId: null,
+    minItemDataYear: null,
+    percentileDisplayEnabled: null,
+    reportLanguages: [],
+    schoolYear: null,
+    state: { name: 'Test State', code: 'TS' },
+    transferAccessEnabled: null,
+    translationLocation: null,
+    uiLanguages: [],
+    userGuideUrl: null,
+    targetReport: {},
+    studentFields: {
+      EnglishLanguageAcquisitionStatus: 'Enabled',
+      EconomicDisadvantage: 'Enabled',
+      Section504: 'Enabled',
+      Ethnicity: 'Enabled',
+      MigrantStatus: 'Enabled',
+      IndividualEducationPlan: 'Enabled',
+      MilitaryStudentIdentifier: 'Enabled',
+      LimitedEnglishProficiency: 'Disabled',
+      PrimaryLanguage: 'Enabled',
+      Gender: 'Enabled'
+    },
+    effectiveReportLanguages: ['en']
+  },
+  datasources: {},
+  archive: null,
+  aggregate: null
+};
+
+export const failedTenant = {
+  tenant: {
+    id: '',
+    key: '',
+    name: '',
+    description: '',
+    sandbox: false,
+    sandboxDataset: null
+  },
+  parentTenantKey: null,
+  localization: null,
+  administrationStatus: {
+    tenantConfiguration: {
+      tenant: {
+        id: '',
+        key: '',
+        name: '',
+        description: '',
+        sandbox: false,
+        sandboxDataset: null
+      },
+      parentTenantKey: null,
+      localization: null,
+      administrationStatus: null,
+      reporting: null,
+      datasources: {},
+      archive: null,
+      aggregate: null
+    },
+    tenantAdministrationStatus: 'FAILED',
+    message: 'stack trace...'
+  },
+  reporting: null,
+  datasources: {},
+  archive: null,
+  aggregate: null
+};
+
+export const activeTenant = {
+  tenant: {
+    id: 'CA',
+    key: 'CA',
+    name: 'California',
+    description: null,
+    sandbox: false,
+    sandboxDataset: null
+  },
+  parentTenantKey: null,
+  localization: {
+    'aggregate-report-form': {
+      field: {
+        'summative-administration-condition-info':
+          'For summative assessments, a test is noted as invalid if an appeal is submitted  to invalidate the test due to a test irregularity or breach. Note: Not applicable for ELPAC.'
+      }
+    },
+    common: {
+      'completeness-form-control': {
+        info:
+          'A test is considered complete when the student provides an answer for every question. Note: Not applicable for ELPAC.'
+      },
+      filters: {
+        status: {
+          'summative-info':
+            'For summative assessments, a test is noted as invalid if an appeal is submitted  to invalidate the test due to a test irregularity or breach. Note: Not applicable for ELPAC.'
+        }
+      },
+      info: {
+        claim:
+          'Claims are a way of classifying test content. The claim is the major topic area. For example, in English language arts, reading is a claim and in Math, Concepts and Procedures is a claim. For the ELPAC, claims are the same as domains.'
+      },
+      results: {
+        assessment: {
+          'no-instruct-found': 'Resources not available in the CA Sandbox'
+        },
+        'assessment-exam-columns': {
+          'score-info':
+            "This is the student's test score and error band based on the Standard Error of Measurement (SEM) associated with that score. Test scores are on a vertical scale, meaning that scores for all grades are reported on a single continuous scale to reflect the increased expectations as students advance through the grades. The error band is included because test scores are estimates of student performance/achievement and come with a certain amount of measurement error. See the Interpretive Guide for additional information."
+        }
+      }
+    }
+  },
+  administrationStatus: { tenantAdministrationStatus: 'ACTIVE' },
+  reporting: {
+    analyticsTrackingId: null,
+    interpretiveGuideUrl: null,
+    accessDeniedUrl: null,
+    landingPageUrl: null,
+    irisVendorId: null,
+    minItemDataYear: null,
+    percentileDisplayEnabled: null,
+    reportLanguages: [],
+    schoolYear: null,
+    state: { name: 'California', code: 'CA' },
+    transferAccessEnabled: null,
+    translationLocation:
+      'binary-http://config-server:8888/*/*/master/tenant-CA/',
+    uiLanguages: [],
+    userGuideUrl: null,
+    targetReport: {},
+    studentFields: {
+      EnglishLanguageAcquisitionStatus: 'Enabled',
+      EconomicDisadvantage: 'Disabled',
+      Section504: 'Disabled',
+      Ethnicity: 'Enabled',
+      MigrantStatus: 'Enabled',
+      IndividualEducationPlan: 'Disabled',
+      MilitaryStudentIdentifier: 'Disabled',
+      LimitedEnglishProficiency: 'Disabled',
+      PrimaryLanguage: 'Enabled',
+      Gender: 'Disabled'
+    },
+    effectiveReportLanguages: ['en']
+  },
+  datasources: {
+    reporting_rw: {
+      url: null,
+      urlParts: { database: 'reporting' },
+      jdbcInterceptors: null,
+      username: null,
+      password: null,
+      schemaSearchPath: null,
+      testWhileIdle: null,
+      validationQuery: null,
+      validationQueryTimeout: null,
+      driverClassName: null,
+      initialSize: null,
+      maxActive: null,
+      minIdle: null,
+      maxIdle: null,
+      removeAbandoned: null,
+      removeAbandonedTimeout: null,
+      logAbandoned: null
+    },
+    reporting_ro: {
+      url: null,
+      urlParts: { database: 'reporting' },
+      jdbcInterceptors: null,
+      username: null,
+      password: null,
+      schemaSearchPath: null,
+      testWhileIdle: null,
+      validationQuery: null,
+      validationQueryTimeout: null,
+      driverClassName: null,
+      initialSize: null,
+      maxActive: null,
+      minIdle: null,
+      maxIdle: null,
+      removeAbandoned: null,
+      removeAbandonedTimeout: null,
+      logAbandoned: null
+    },
+    warehouse_rw: {
+      url: null,
+      urlParts: { database: 'warehouse' },
+      jdbcInterceptors: null,
+      username: null,
+      password: null,
+      schemaSearchPath: null,
+      testWhileIdle: null,
+      validationQuery: null,
+      validationQueryTimeout: null,
+      driverClassName: null,
+      initialSize: null,
+      maxActive: null,
+      minIdle: null,
+      maxIdle: null,
+      removeAbandoned: null,
+      removeAbandonedTimeout: null,
+      logAbandoned: null
+    }
+  },
+  archive: null,
+  aggregate: null
+};

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
@@ -49,7 +49,7 @@ const tenantUIModel: TenantConfiguration = {
   description: 'AZ description',
   id: '34',
   status: 'ACTIVE',
-  configurationProperties: {
+  configurations: {
     datasources: {
       reporting_rw: [
         {
@@ -102,14 +102,13 @@ describe('Tenant mapper', () => {
     expect(actual.description).toBe('ca description');
     expect(actual.id).toBe('CA');
     expect(actual.status).toBe('ACTIVE');
-    expect(actual.localizationOverrides).toBeDefined();
-    expect(actual.configurationProperties).toBeDefined();
+    expect(actual.localizations).toBeDefined();
+    expect(actual.configurations).toBeDefined();
   });
 
   it('should merge tenant and default configurations', () => {
     const actual = toTenant(tenantApiModel, defaultsApiModel);
-    const reporting_rw =
-      actual.configurationProperties.datasources.reporting_rw;
+    const reporting_rw = actual.configurations.datasources.reporting_rw;
     const actualOverride: OldConfigProp = reporting_rw.find(
       x => x.key === 'urlParts.database'
     );
@@ -154,13 +153,13 @@ describe('Tenant mapper', () => {
     expect(actual.code).toBe('CA_S132');
     expect(actual.description).toBe('ca description');
     expect(actual.id).toBe('CA');
-    expect(actual.localizationOverrides).toBeDefined();
-    expect(actual.configurationProperties).toBeDefined();
+    expect(actual.localizations).toBeDefined();
+    expect(actual.configurations).toBeDefined();
   });
 
   it('should merge sandbox and default configurations', () => {
     const actual = toTenant(sandboxApiModel, defaultsApiModel, dataSets);
-    const reporting = actual.configurationProperties.reporting;
+    const reporting = actual.configurations.reporting;
 
     const actualOverride: OldConfigProp = reporting.find(
       x => x.key === 'schoolYear'
@@ -177,7 +176,7 @@ describe('Tenant mapper', () => {
 
   it('should not map sandbox dataset configurations', () => {
     const actual = toTenant(sandboxApiModel, defaultsApiModel, dataSets);
-    expect(actual.configurationProperties.datasources).toBeUndefined();
+    expect(actual.configurations.datasources).toBeUndefined();
   });
 
   it('should map a sandbox ui model to an api model', () => {
@@ -204,9 +203,7 @@ describe('Tenant mapper', () => {
   });
 
   it('should get modified config properties', () => {
-    const actual = getModifiedConfigProperties(
-      tenantUIModel.configurationProperties
-    );
+    const actual = getModifiedConfigProperties(tenantUIModel.configurations);
 
     const actualReportingDatasource = actual.datasources.reporting_rw;
     expect(actualReportingDatasource.length).toBe(1);

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
@@ -2,7 +2,7 @@ import { ConfigurationProperty } from '../model/configuration-property';
 import { TenantConfiguration } from '../model/tenant-configuration';
 import {
   toTenant,
-  toTenantApiModel,
+  toServerTenant,
   getModifiedConfigProperties
 } from './tenants';
 
@@ -125,7 +125,7 @@ describe('Tenant mapper', () => {
   });
 
   it('should map a tenant ui model to an api model', () => {
-    const actual = toTenantApiModel(tenantUIModel);
+    const actual = toServerTenant(tenantUIModel);
 
     expect(actual.tenant.name).toBe('Arizona');
     expect(actual.tenant.id).toBe('34');
@@ -134,7 +134,7 @@ describe('Tenant mapper', () => {
   });
 
   it('should map tenant ui config props to api config props', () => {
-    const actual = toTenantApiModel(tenantUIModel);
+    const actual = toServerTenant(tenantUIModel);
 
     expect(actual.datasources.reporting_rw.urlParts.database).toBe(
       'new-reporting'
@@ -181,7 +181,7 @@ describe('Tenant mapper', () => {
   });
 
   it('should map a sandbox ui model to an api model', () => {
-    const actual = toTenantApiModel(sandboxUIModel);
+    const actual = toServerTenant(sandboxUIModel);
 
     expect(actual.tenant.sandboxDataset).toBe('ca-demo-data');
     expect(actual.tenant.name).toBe('Arizona');
@@ -191,7 +191,7 @@ describe('Tenant mapper', () => {
   });
 
   it('should map sandbox ui config props to api config props', () => {
-    const actual = toTenantApiModel(sandboxUIModel);
+    const actual = toServerTenant(sandboxUIModel);
 
     expect(actual.datasources.reporting_rw.urlParts.database).toBe(
       'new-reporting'

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
@@ -1,4 +1,4 @@
-import { ConfigurationProperty } from '../model/configuration-property';
+import { OldConfigProp } from './old-config-prop';
 import { TenantConfiguration } from '../model/tenant-configuration';
 import {
   toTenant,
@@ -110,14 +110,14 @@ describe('Tenant mapper', () => {
     const actual = toTenant(tenantApiModel, defaultsApiModel);
     const reporting_rw =
       actual.configurationProperties.datasources.reporting_rw;
-    const actualOverride: ConfigurationProperty = reporting_rw.find(
+    const actualOverride: OldConfigProp = reporting_rw.find(
       x => x.key === 'urlParts.database'
     );
 
     expect(actualOverride.value).toBe('reporting');
     expect(actualOverride.originalValue).toBe('not_a_schema');
 
-    const actualDefault: ConfigurationProperty = reporting_rw.find(
+    const actualDefault: OldConfigProp = reporting_rw.find(
       x => x.key === 'urlParts.protocol'
     );
     expect(actualDefault.value).toBe('jdbc:mysql:');
@@ -162,13 +162,13 @@ describe('Tenant mapper', () => {
     const actual = toTenant(sandboxApiModel, defaultsApiModel, dataSets);
     const reporting = actual.configurationProperties.reporting;
 
-    const actualOverride: ConfigurationProperty = reporting.find(
+    const actualOverride: OldConfigProp = reporting.find(
       x => x.key === 'schoolYear'
     );
     expect(actualOverride.value).toBe('2015');
     expect(actualOverride.originalValue).toBe('2018');
 
-    const actualDefault: ConfigurationProperty = reporting.find(
+    const actualDefault: OldConfigProp = reporting.find(
       x => x.key === 'state.name'
     );
     expect(actualDefault.value).toBe('CA');

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.spec.ts
@@ -1,228 +1,104 @@
-import { OldConfigProp } from './old-config-prop';
-import { TenantConfiguration } from '../model/tenant-configuration';
-import {
-  toTenant,
-  toServerTenant,
-  getModifiedConfigProperties
-} from './tenants';
+import { joinIfArrayOfPrimitives, toConfigurations, toTenant } from './tenants';
+import { activeSandbox, activeTenant, dataSets } from './tenants.spec.data';
+import { flatten } from '../../../shared/support/support';
+import { TenantConfiguration } from './tenant-configuration';
+import { TenantStatus } from './tenant-status';
 
-const tenantApiModel = {
-  tenant: {
-    id: 'CA',
-    description: 'ca description',
-    key: 'CALICODE',
-    name: 'California',
-    sandbox: false
-  },
-  administrationStatus: { tenantAdministrationStatus: 'ACTIVE' },
-  datasources: { reporting_rw: { urlParts: { database: 'reporting' } } }
-};
-const sandboxApiModel = {
-  tenant: {
-    id: 'CA',
-    sandboxDataset: 'ca-demo-data',
-    description: 'ca description',
-    key: 'CA_S132',
-    name: 'CA-Sandbox',
-    sandbox: true
-  },
-  administrationStatus: 'ACTIVE',
-  reporting: { schoolYear: '2015' }
-};
-const defaultsApiModel = {
-  reporting: { schoolYear: '2018', state: { name: 'CA' } },
-  datasources: {
-    reporting_rw: {
-      urlParts: { database: 'not_a_schema', protocol: 'jdbc:mysql:' }
-    }
-  }
-};
-
-const dataSets = [
-  { id: 'ca-demo-data', label: 'CA Demo Data' },
-  { id: 'az-demo-data', label: 'AZ Demo Data' }
-];
-
-const tenantUIModel: TenantConfiguration = {
-  label: 'Arizona',
-  code: 'AZ',
-  description: 'AZ description',
-  id: '34',
-  status: 'ACTIVE',
-  configurations: {
-    datasources: {
-      reporting_rw: [
+describe('toConfigurations', () => {
+  it('should prune based on tenant type SANDBOX', () => {
+    expect(
+      toConfigurations(
         {
-          key: 'urlParts.database',
-          value: 'new-reporting',
-          originalValue: 'not_a_schema',
-          group: 'reporting_rw',
-          formControlName: 'reporting_rw.urlParts.database'
+          irrelevant: {},
+          archive: {},
+          aggregate: {},
+          datasources: {},
+          reporting: {}
         },
+        'SANDBOX'
+      )
+    ).toEqual({
+      aggregate: {},
+      reporting: {}
+    });
+  });
+
+  it('should prune based on tenant type TENANT', () => {
+    expect(
+      toConfigurations(
         {
-          key: 'urlParts.protocol',
-          value: 'jdbc:mysql:',
-          originalValue: 'jdbc:mysql:',
-          group: 'reporting_rw',
-          formControlName: 'reporting_rw.urlParts.protocol'
-        }
-      ]
-    },
-    reporting: [
-      {
-        key: 'state.name',
-        originalValue: 'California',
-        value: 'Florida',
-        formControlName: 'reporting'
-      }
-    ],
-    archive: [
-      {
-        key: 'prefix',
-        originalValue: 's3://',
-        value: 's3://',
-        formControlName: 'archive'
-      }
-    ]
-  }
-};
-
-const sandboxUIModel: TenantConfiguration = {
-  ...tenantUIModel,
-  parentTenantCode: 'CA_001',
-  dataSet: dataSets[0]
-};
-
-describe('Tenant mapper', () => {
-  it('should map a tenant from the api', () => {
-    const actual = toTenant(tenantApiModel, {});
-
-    expect(actual.label).toBe('California');
-    expect(actual.code).toBe('CALICODE');
-    expect(actual.description).toBe('ca description');
-    expect(actual.id).toBe('CA');
-    expect(actual.status).toBe('ACTIVE');
-    expect(actual.localizations).toBeDefined();
-    expect(actual.configurations).toBeDefined();
-  });
-
-  it('should merge tenant and default configurations', () => {
-    const actual = toTenant(tenantApiModel, defaultsApiModel);
-    const reporting_rw = actual.configurations.datasources.reporting_rw;
-    const actualOverride: OldConfigProp = reporting_rw.find(
-      x => x.key === 'urlParts.database'
-    );
-
-    expect(actualOverride.value).toBe('reporting');
-    expect(actualOverride.originalValue).toBe('not_a_schema');
-
-    const actualDefault: OldConfigProp = reporting_rw.find(
-      x => x.key === 'urlParts.protocol'
-    );
-    expect(actualDefault.value).toBe('jdbc:mysql:');
-    expect(actualDefault.originalValue).toBe('jdbc:mysql:');
-  });
-
-  it('should map a tenant ui model to an api model', () => {
-    const actual = toServerTenant(tenantUIModel);
-
-    expect(actual.tenant.name).toBe('Arizona');
-    expect(actual.tenant.id).toBe('34');
-    expect(actual.tenant.description).toBe('AZ description');
-    expect(actual.tenant.key).toBe('AZ');
-  });
-
-  it('should map tenant ui config props to api config props', () => {
-    const actual = toServerTenant(tenantUIModel);
-
-    expect(actual.datasources.reporting_rw.urlParts.database).toBe(
-      'new-reporting'
-    );
-
-    //TODO: Should we be sending back unchanged values?
-    expect(actual.datasources.reporting_rw.urlParts.protocol).toBe(
-      'jdbc:mysql:'
-    );
-  });
-
-  it('should map a sandbox from the api', () => {
-    const actual = toTenant(sandboxApiModel, {}, dataSets);
-    expect(actual.dataSet.label).toBe('CA Demo Data');
-
-    expect(actual.label).toBe('CA-Sandbox');
-    expect(actual.code).toBe('CA_S132');
-    expect(actual.description).toBe('ca description');
-    expect(actual.id).toBe('CA');
-    expect(actual.localizations).toBeDefined();
-    expect(actual.configurations).toBeDefined();
-  });
-
-  it('should merge sandbox and default configurations', () => {
-    const actual = toTenant(sandboxApiModel, defaultsApiModel, dataSets);
-    const reporting = actual.configurations.reporting;
-
-    const actualOverride: OldConfigProp = reporting.find(
-      x => x.key === 'schoolYear'
-    );
-    expect(actualOverride.value).toBe('2015');
-    expect(actualOverride.originalValue).toBe('2018');
-
-    const actualDefault: OldConfigProp = reporting.find(
-      x => x.key === 'state.name'
-    );
-    expect(actualDefault.value).toBe('CA');
-    expect(actualDefault.originalValue).toBe('CA');
-  });
-
-  it('should not map sandbox dataset configurations', () => {
-    const actual = toTenant(sandboxApiModel, defaultsApiModel, dataSets);
-    expect(actual.configurations.datasources).toBeUndefined();
-  });
-
-  it('should map a sandbox ui model to an api model', () => {
-    const actual = toServerTenant(sandboxUIModel);
-
-    expect(actual.tenant.sandboxDataset).toBe('ca-demo-data');
-    expect(actual.tenant.name).toBe('Arizona');
-    expect(actual.tenant.id).toBe('34');
-    expect(actual.tenant.description).toBe('AZ description');
-    expect(actual.tenant.key).toBe('AZ');
-  });
-
-  it('should map sandbox ui config props to api config props', () => {
-    const actual = toServerTenant(sandboxUIModel);
-
-    expect(actual.datasources.reporting_rw.urlParts.database).toBe(
-      'new-reporting'
-    );
-
-    //TODO: Should we be sending back unchanged values?
-    expect(actual.datasources.reporting_rw.urlParts.protocol).toBe(
-      'jdbc:mysql:'
-    );
-  });
-
-  it('should get modified config properties', () => {
-    const actual = getModifiedConfigProperties(tenantUIModel.configurations);
-
-    const actualReportingDatasource = actual.datasources.reporting_rw;
-    expect(actualReportingDatasource.length).toBe(1);
-
-    const actualDatabase = actualReportingDatasource[0];
-    expect(actualDatabase.key).toBe('urlParts.database');
-    expect(actualDatabase.value).toBe('new-reporting');
-    expect(actualDatabase.originalValue).toBe('not_a_schema');
-    expect(actualDatabase.group).toBe('reporting_rw');
-
-    const actualReporting = actual.reporting;
-    expect(actualReporting.length).toBe(1);
-
-    const actualStateName = actualReporting[0];
-    expect(actualStateName.key).toBe('state.name');
-    expect(actualStateName.value).toBe('Florida');
-    expect(actualStateName.originalValue).toBe('California');
-    expect(actualStateName.formControlName).toBe('reporting');
-
-    expect(actual.archive).toBeUndefined();
+          irrelevant: {},
+          archive: {},
+          aggregate: {},
+          datasources: {},
+          reporting: {}
+        },
+        'TENANT'
+      )
+    ).toEqual({
+      archive: {},
+      aggregate: {},
+      datasources: {},
+      reporting: {}
+    });
   });
 });
+
+describe('toTenant', () => {
+  it('should correctly map SANDBOX without error', () => {
+    const expected: TenantConfiguration = {
+      id: activeSandbox.tenant.id,
+      code: activeSandbox.tenant.key,
+      label: activeSandbox.tenant.name,
+      description: activeSandbox.tenant.description,
+      type: 'SANDBOX',
+      status: <TenantStatus>(
+        activeSandbox.administrationStatus.tenantAdministrationStatus
+      ),
+      parentTenantCode: activeSandbox.parentTenantKey,
+      dataSet: {
+        id: activeSandbox.tenant.sandboxDataset,
+        label: 'ds1'
+      },
+      configurations: flatten(
+        {
+          aggregate: activeSandbox.aggregate,
+          reporting: activeSandbox.reporting
+        },
+        joinIfArrayOfPrimitives
+      ),
+      localizations: flatten(activeSandbox.localization || {})
+    };
+
+    expect(toTenant(activeSandbox, {}, dataSets)).toEqual(expected);
+  });
+
+  it('should correctly map TENANT without error', () => {
+    const expected: TenantConfiguration = {
+      id: activeTenant.tenant.id,
+      code: activeTenant.tenant.key,
+      label: activeTenant.tenant.name,
+      description: activeTenant.tenant.description,
+      type: 'TENANT',
+      status: <TenantStatus>(
+        activeTenant.administrationStatus.tenantAdministrationStatus
+      ),
+      parentTenantCode: null,
+      dataSet: undefined,
+      configurations: flatten(
+        {
+          archive: activeTenant.archive,
+          aggregate: activeTenant.aggregate,
+          datasources: activeTenant.datasources,
+          reporting: activeTenant.reporting
+        },
+        joinIfArrayOfPrimitives
+      ),
+      localizations: flatten(activeTenant.localization || {})
+    };
+
+    expect(toTenant(activeTenant, {}, dataSets)).toEqual(expected);
+  });
+});
+
+describe('toServerTenant', () => {});

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
@@ -1,20 +1,50 @@
-import { ConfigurationProperty } from '../model/configuration-property';
-import { flattenJsonObject } from '../../../shared/support/support';
-import { forOwn, get, isString } from 'lodash';
 import { DataSet, TenantConfiguration } from '../model/tenant-configuration';
-import { object as expand } from 'dot-object';
 import { TenantType } from '../model/tenant-type';
+import {
+  flatten,
+  FlattenCustomizer,
+  unflatten,
+  UnflattenCustomizer
+} from '../../../shared/support/support';
+
+const joinIfArrayOfPrimitives: FlattenCustomizer = (
+  result,
+  object,
+  property
+) => {
+  if (Array.isArray(object) && object.every(value => Object(value) !== value)) {
+    result[property] = object.join(',');
+    return true;
+  }
+  return false;
+};
+
+const splitIfNonPasswordCommaJoinedString: UnflattenCustomizer = (
+  value,
+  key
+) => {
+  if (
+    !key.includes('password') &&
+    typeof value === 'string' &&
+    value.includes(',')
+  ) {
+    const array = value.split(',');
+    if (array.every(element => Object(element) !== element)) {
+      return array.map(element =>
+        typeof element === 'string' ? element.trim() : element
+      );
+    }
+  }
+  return value;
+};
 
 export function defaultTenant(
   type: TenantType,
   configurationProperties: any,
-  localization: any,
+  localizationOverrides: any,
   tenant?: TenantConfiguration,
   dataSet?: DataSet
 ) {
-  const localizationOverrides = localizationToConfigurationProperties(
-    localization
-  );
   return type === 'SANDBOX'
     ? {
         type,
@@ -47,7 +77,7 @@ export function toTenant(
     },
     administrationStatus: { tenantAdministrationStatus: status },
     parentTenantKey: parentTenantCode,
-    localization
+    localization: localizationOverrides
   } = serverTenant;
 
   const type = sandbox ? 'SANDBOX' : 'TENANT';
@@ -58,35 +88,41 @@ export function toTenant(
     description,
     type,
     status,
-    configurationProperties: toConfigurationProperties(
-      toConfigurationOverrides(defaults, type),
-      toConfigurationOverrides(serverTenant, type)
-    ),
-    localizationOverrides: localizationToConfigurationProperties(localization),
+    configurationProperties: toConfigurations(serverTenant, type),
+    localizationOverrides,
     parentTenantCode,
     dataSet: (dataSets || []).find(dataSet => dataSetId === dataSet.id)
   };
 }
 
-// helper to return only the config props of an api model.
-export function toConfigurationOverrides(
+/**
+ * This method filters out irrelevant fields and flattens the tree structure provided by the API
+ *
+ * @param properties
+ * @param type
+ */
+export function toConfigurations(
   { archive, aggregate, datasources, reporting }: any,
   type
 ): any {
-  return type === 'SANDBOX'
-    ? {
-        aggregate,
-        reporting
-      }
-    : {
-        archive,
-        datasources,
-        aggregate,
-        reporting
-      };
+  return flatten(
+    type === 'SANDBOX'
+      ? {
+          aggregate,
+          reporting
+        }
+      : {
+          archive,
+          datasources,
+          aggregate,
+          reporting
+        },
+    joinIfArrayOfPrimitives
+  );
 }
 
-export function toTenantApiModel(tenant: TenantConfiguration): any {
+// DO this at form submit time
+export function toServerTenant(tenant: TenantConfiguration): any {
   const {
     code: key,
     id,
@@ -96,7 +132,7 @@ export function toTenantApiModel(tenant: TenantConfiguration): any {
     parentTenantCode: parentTenantKey,
     dataSet: { id: sandboxDataset } = <any>{},
     configurationProperties,
-    localizationOverrides
+    localizationOverrides: localization
   } = tenant;
 
   return {
@@ -109,188 +145,189 @@ export function toTenantApiModel(tenant: TenantConfiguration): any {
       sandboxDataset
     },
     parentTenantKey,
-    ...toConfigurationPropertiesApiModel(configurationProperties),
-    localization: toLocalizationOverridesApiModel(localizationOverrides)
+    // this should be mapped back at form submit time
+    ...unflatten(configurationProperties, splitIfNonPasswordCommaJoinedString),
+    localization
   };
 }
 
-/**
- * Maps configuration properties back to the server side representation
- *
- * TODO this impl assumes max depth of props
- *
- * @param configProperties
- */
-function toConfigurationPropertiesApiModel(configProperties: any): any {
-  const mappedGroup = {};
-
-  forOwn(configProperties, (group, groupKey) => {
-    if (groupKey === 'datasources') {
-      const datasourceGroup = {};
-
-      forOwn(group, (configurationProperties, datasourceKey) => {
-        const configGroup = {};
-        configurationProperties.forEach(
-          configurationProperty =>
-            (configGroup[configurationProperty.key] =
-              configurationProperty.value)
-        );
-        datasourceGroup[datasourceKey] = expand(configGroup);
-      });
-
-      mappedGroup[groupKey] = datasourceGroup;
-    } else {
-      const configGroup = {};
-      // group is the list of configuration properties
-      group.forEach(configurationProperty => {
-        if (
-          isString(configurationProperty.value) &&
-          configurationProperty.value.indexOf(',') > -1
-        ) {
-          configGroup[
-            configurationProperty.key
-          ] = configurationProperty.value.split(',');
-        } else {
-          configGroup[configurationProperty.key] = configurationProperty.value;
-        }
-      });
-      mappedGroup[groupKey] = configGroup;
-    }
-  });
-
-  return mappedGroup;
-}
-
-/**
- * This creates configuration property models for each default property and applies the provided override on top of that
- *
- * TODO i feel it would be best to do this in the view as this is a view behavior concern and not a data modeling concern
- *
- * @param defaults
- * @param overrides
- */
-export function toConfigurationProperties(
-  defaults: any,
-  overrides: any = {}
-): any {
-  const groupedProperties = {};
-
-  forOwn(defaults, (configGroup, groupKey) => {
-    if (groupKey !== 'datasources') {
-      const configProps: ConfigurationProperty[] = [];
-
-      forOwn(flattenJsonObject(configGroup), (value, key) => {
-        const defaultVal = joinIfArray(value);
-        if (!overrides) {
-          configProps.push(
-            new ConfigurationProperty(key, defaultVal, groupKey)
-          );
-        } else {
-          const groupOverrides = overrides[groupKey] || {};
-          const override = get(groupOverrides, key);
-          if (override) {
-            configProps.push(
-              new ConfigurationProperty(
-                key,
-                joinIfArray(override),
-                groupKey,
-                defaultVal
-              )
-            );
-          } else {
-            configProps.push(
-              new ConfigurationProperty(key, defaultVal, groupKey)
-            );
-          }
-        }
-      });
-
-      groupedProperties[groupKey] = configProps;
-    } else {
-      // current group is datasources
-      const databaseProps = {};
-
-      // Iterate over the group of databases
-      forOwn(configGroup, (databaseProperties, databaseName) => {
-        const configProps: ConfigurationProperty[] = [];
-
-        forOwn(flattenJsonObject(databaseProperties), (value, key) => {
-          const defaultVal = key === 'password' ? '' : joinIfArray(value);
-          if (!overrides) {
-            configProps.push(
-              new ConfigurationProperty(key, defaultVal, databaseName)
-            );
-          } else {
-            const groupOverrides = overrides[groupKey] || {};
-            const override = get(groupOverrides, `${databaseName}.${key}`);
-            if (override) {
-              configProps.push(
-                new ConfigurationProperty(
-                  key,
-                  joinIfArray(override),
-                  databaseName,
-                  defaultVal
-                )
-              );
-            } else {
-              configProps.push(
-                new ConfigurationProperty(key, defaultVal, databaseName)
-              );
-            }
-          }
-        });
-
-        databaseProps[databaseName] = configProps;
-      });
-
-      groupedProperties[groupKey] = databaseProps;
-    }
-  });
-  return groupedProperties;
-}
-
-export function getModifiedConfigProperties(configProperties: any): any {
-  const modifiedProperties = {};
-  forOwn(configProperties, (group, key) => {
-    const props = <ConfigurationProperty[]>group;
-    if (props.some !== undefined) {
-      if (props.some(x => x.originalValue !== x.value)) {
-        modifiedProperties[key] = props.filter(
-          x => x.originalValue !== x.value
-        );
-      }
-    } else {
-      // Not an array of config props, must be a sub group, i.e. datasources.reporting_rw
-      modifiedProperties[key] = getModifiedConfigProperties(group);
-    }
-  });
-  return modifiedProperties;
-}
-
-function localizationToConfigurationProperties(
-  overrides: any
-): ConfigurationProperty[] {
-  const flattenedOverrides = flattenJsonObject(overrides);
-  const configProperties: ConfigurationProperty[] = [];
-  forOwn(flattenedOverrides, (value, key) =>
-    configProperties.push(new ConfigurationProperty(key, value))
-  );
-  return configProperties;
-}
-
-function toLocalizationOverridesApiModel(
-  overrides: ConfigurationProperty[]
-): any {
-  const flattenedOverrides = overrides
-    ? overrides.reduce((localizationOverrides, { key, value }) => {
-        localizationOverrides[key] = value;
-        return localizationOverrides;
-      }, {})
-    : [];
-
-  return expand(flattenedOverrides);
-}
-
-function joinIfArray(value: any): string {
-  return Array.isArray(value) ? value.join(',') : value;
-}
+// /**
+//  * Maps configuration properties back to the server side representation
+//  *
+//  * TODO this impl assumes max depth of props
+//  *
+//  * @param configProperties
+//  */
+// function toConfigurationPropertiesApiModel(configProperties: any): any {
+//   const mappedGroup = {};
+//
+//   forOwn(configProperties, (group, groupKey) => {
+//     if (groupKey === 'datasources') {
+//       const datasourceGroup = {};
+//
+//       forOwn(group, (configurationProperties, datasourceKey) => {
+//         const configGroup = {};
+//         configurationProperties.forEach(
+//           configurationProperty =>
+//             (configGroup[configurationProperty.key] =
+//               configurationProperty.value)
+//         );
+//         datasourceGroup[datasourceKey] = expand(configGroup);
+//       });
+//
+//       mappedGroup[groupKey] = datasourceGroup;
+//     } else {
+//       const configGroup = {};
+//       // group is the list of configuration properties
+//       group.forEach(configurationProperty => {
+//         if (
+//           isString(configurationProperty.value) &&
+//           configurationProperty.value.indexOf(',') > -1
+//         ) {
+//           configGroup[
+//             configurationProperty.key
+//           ] = configurationProperty.value.split(',');
+//         } else {
+//           configGroup[configurationProperty.key] = configurationProperty.value;
+//         }
+//       });
+//       mappedGroup[groupKey] = configGroup;
+//     }
+//   });
+//
+//   return mappedGroup;
+// }
+//
+// /**
+//  * This creates configuration property models for each default property and applies the provided override on top of that
+//  *
+//  * TODO i feel it would be best to do this in the view as this is a view behavior concern and not a data modeling concern
+//  *
+//  * @param defaults
+//  * @param overrides
+//  */
+// export function toConfigurationProperties(
+//   defaults: any,
+//   overrides: any = {}
+// ): any {
+//   const groupedProperties = {};
+//
+//   forOwn(defaults, (configGroup, groupKey) => {
+//     if (groupKey !== 'datasources') {
+//       const configProps: ConfigurationProperty[] = [];
+//
+//       forOwn(flattenJsonObject(configGroup), (value, key) => {
+//         const defaultVal = joinIfArray(value);
+//         if (!overrides) {
+//           configProps.push(
+//             new ConfigurationProperty(key, defaultVal, groupKey)
+//           );
+//         } else {
+//           const groupOverrides = overrides[groupKey] || {};
+//           const override = get(groupOverrides, key);
+//           if (override) {
+//             configProps.push(
+//               new ConfigurationProperty(
+//                 key,
+//                 joinIfArray(override),
+//                 groupKey,
+//                 defaultVal
+//               )
+//             );
+//           } else {
+//             configProps.push(
+//               new ConfigurationProperty(key, defaultVal, groupKey)
+//             );
+//           }
+//         }
+//       });
+//
+//       groupedProperties[groupKey] = configProps;
+//     } else {
+//       // current group is datasources
+//       const databaseProps = {};
+//
+//       // Iterate over the group of databases
+//       forOwn(configGroup, (databaseProperties, databaseName) => {
+//         const configProps: ConfigurationProperty[] = [];
+//
+//         forOwn(flattenJsonObject(databaseProperties), (value, key) => {
+//           const defaultVal = key === 'password' ? '' : joinIfArray(value);
+//           if (!overrides) {
+//             configProps.push(
+//               new ConfigurationProperty(key, defaultVal, databaseName)
+//             );
+//           } else {
+//             const groupOverrides = overrides[groupKey] || {};
+//             const override = get(groupOverrides, `${databaseName}.${key}`);
+//             if (override) {
+//               configProps.push(
+//                 new ConfigurationProperty(
+//                   key,
+//                   joinIfArray(override),
+//                   databaseName,
+//                   defaultVal
+//                 )
+//               );
+//             } else {
+//               configProps.push(
+//                 new ConfigurationProperty(key, defaultVal, databaseName)
+//               );
+//             }
+//           }
+//         });
+//
+//         databaseProps[databaseName] = configProps;
+//       });
+//
+//       groupedProperties[groupKey] = databaseProps;
+//     }
+//   });
+//   return groupedProperties;
+// }
+//
+// export function getModifiedConfigProperties(configProperties: any): any {
+//   const modifiedProperties = {};
+//   forOwn(configProperties, (group, key) => {
+//     const props = <ConfigurationProperty[]>group;
+//     if (props.some !== undefined) {
+//       if (props.some(x => x.originalValue !== x.value)) {
+//         modifiedProperties[key] = props.filter(
+//           x => x.originalValue !== x.value
+//         );
+//       }
+//     } else {
+//       // Not an array of config props, must be a sub group, i.e. datasources.reporting_rw
+//       modifiedProperties[key] = getModifiedConfigProperties(group);
+//     }
+//   });
+//   return modifiedProperties;
+// }
+//
+// function localizationToConfigurationProperties(
+//   overrides: any
+// ): ConfigurationProperty[] {
+//   const flattenedOverrides = flattenJsonObject(overrides);
+//   const configProperties: ConfigurationProperty[] = [];
+//   forOwn(flattenedOverrides, (value, key) =>
+//     configProperties.push(new ConfigurationProperty(key, value))
+//   );
+//   return configProperties;
+// }
+//
+// function toLocalizationOverridesApiModel(
+//   overrides: ConfigurationProperty[]
+// ): any {
+//   const flattenedOverrides = overrides
+//     ? overrides.reduce((localizationOverrides, { key, value }) => {
+//         localizationOverrides[key] = value;
+//         return localizationOverrides;
+//       }, {})
+//     : [];
+//
+//   return expand(flattenedOverrides);
+// }
+//
+// function joinIfArray(value: any): string {
+//   return Array.isArray(value) ? value.join(',') : value;
+// }

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
@@ -6,6 +6,7 @@ import {
   unflatten,
   UnflattenCustomizer
 } from '../../../shared/support/support';
+import { isEmpty } from 'lodash';
 
 const joinIfArrayOfPrimitives: FlattenCustomizer = (
   result,
@@ -89,7 +90,7 @@ export function toTenant(
     type,
     status,
     configurationProperties: toConfigurations(serverTenant, type),
-    localizationOverrides,
+    localizationOverrides: localizationOverrides || {},
     parentTenantCode,
     dataSet: (dataSets || []).find(dataSet => dataSetId === dataSet.id)
   };
@@ -147,7 +148,7 @@ export function toServerTenant(tenant: TenantConfiguration): any {
     parentTenantKey,
     // this should be mapped back at form submit time
     ...unflatten(configurationProperties, splitIfNonPasswordCommaJoinedString),
-    localization
+    localization: isEmpty(localization) ? null : {}
   };
 }
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
@@ -7,6 +7,7 @@ import {
   UnflattenCustomizer
 } from '../../../shared/support/support';
 import { isEmpty } from 'lodash';
+import { ValidatorFn, Validators } from '@angular/forms';
 
 const joinIfArrayOfPrimitives: FlattenCustomizer = (
   result,
@@ -41,24 +42,24 @@ const splitIfNonPasswordCommaJoinedString: UnflattenCustomizer = (
 
 export function defaultTenant(
   type: TenantType,
-  configurationProperties: any,
-  localizationOverrides: any,
+  configurations: any,
+  localizations: any,
   tenant?: TenantConfiguration,
   dataSet?: DataSet
 ) {
   return type === 'SANDBOX'
     ? {
         type,
-        configurationProperties,
-        localizationOverrides,
+        configurations,
+        localizations,
         label: tenant.label + ' Sandbox',
         parentTenantCode: tenant.code,
         dataSet
       }
     : {
         type,
-        configurationProperties,
-        localizationOverrides
+        configurations,
+        localizations
       };
 }
 
@@ -78,7 +79,7 @@ export function toTenant(
     },
     administrationStatus: { tenantAdministrationStatus: status },
     parentTenantKey: parentTenantCode,
-    localization: localizationOverrides
+    localization: localizations
   } = serverTenant;
 
   const type = sandbox ? 'SANDBOX' : 'TENANT';
@@ -89,8 +90,8 @@ export function toTenant(
     description,
     type,
     status,
-    configurationProperties: toConfigurations(serverTenant, type),
-    localizationOverrides: localizationOverrides || {},
+    configurations: toConfigurations(serverTenant, type),
+    localizations: localizations || {},
     parentTenantCode,
     dataSet: (dataSets || []).find(dataSet => dataSetId === dataSet.id)
   };
@@ -132,8 +133,8 @@ export function toServerTenant(tenant: TenantConfiguration): any {
     type,
     parentTenantCode: parentTenantKey,
     dataSet: { id: sandboxDataset } = <any>{},
-    configurationProperties,
-    localizationOverrides: localization
+    configurations,
+    localizations: localization
   } = tenant;
 
   return {
@@ -147,7 +148,7 @@ export function toServerTenant(tenant: TenantConfiguration): any {
     },
     parentTenantKey,
     // this should be mapped back at form submit time
-    ...unflatten(configurationProperties, splitIfNonPasswordCommaJoinedString),
+    ...unflatten(configurations, splitIfNonPasswordCommaJoinedString),
     localization: isEmpty(localization) ? null : {}
   };
 }

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
@@ -6,32 +6,35 @@ import {
   unflatten,
   UnflattenCustomizer
 } from '../../../shared/support/support';
-import { isEmpty } from 'lodash';
-import { ValidatorFn, Validators } from '@angular/forms';
+import { isEmpty, isObject } from 'lodash';
 
-const joinIfArrayOfPrimitives: FlattenCustomizer = (
+export const joinIfArrayOfPrimitives: FlattenCustomizer = (
   result,
   object,
   property
 ) => {
-  if (Array.isArray(object) && object.every(value => Object(value) !== value)) {
+  if (
+    Array.isArray(object) &&
+    (object.length === 0 || object.every(value => !isObject(value)))
+  ) {
     result[property] = object.join(',');
     return true;
   }
   return false;
 };
 
-const splitIfNonPasswordCommaJoinedString: UnflattenCustomizer = (
+export const splitIfNonPasswordCommaJoinedString: UnflattenCustomizer = (
   value,
   key
 ) => {
   if (
-    !key.includes('password') &&
+    // could this be placed somewhere better? so it can be controlled by metadata
+    !key.endsWith('password') &&
     typeof value === 'string' &&
     value.includes(',')
   ) {
     const array = value.split(',');
-    if (array.every(element => Object(element) !== element)) {
+    if (array.every(element => !isObject(element))) {
       return array.map(element =>
         typeof element === 'string' ? element.trim() : element
       );
@@ -91,7 +94,7 @@ export function toTenant(
     type,
     status,
     configurations: toConfigurations(serverTenant, type),
-    localizations: localizations || {},
+    localizations: flatten(localizations || {}),
     parentTenantCode,
     dataSet: (dataSets || []).find(dataSet => dataSetId === dataSet.id)
   };
@@ -123,7 +126,6 @@ export function toConfigurations(
   );
 }
 
-// DO this at form submit time
 export function toServerTenant(tenant: TenantConfiguration): any {
   const {
     code: key,
@@ -149,187 +151,6 @@ export function toServerTenant(tenant: TenantConfiguration): any {
     parentTenantKey,
     // this should be mapped back at form submit time
     ...unflatten(configurations, splitIfNonPasswordCommaJoinedString),
-    localization: isEmpty(localization) ? null : {}
+    localization: isEmpty(localization) ? null : unflatten(localization)
   };
 }
-
-// /**
-//  * Maps configuration properties back to the server side representation
-//  *
-//  * TODO this impl assumes max depth of props
-//  *
-//  * @param configProperties
-//  */
-// function toConfigurationPropertiesApiModel(configProperties: any): any {
-//   const mappedGroup = {};
-//
-//   forOwn(configProperties, (group, groupKey) => {
-//     if (groupKey === 'datasources') {
-//       const datasourceGroup = {};
-//
-//       forOwn(group, (configurationProperties, datasourceKey) => {
-//         const configGroup = {};
-//         configurationProperties.forEach(
-//           configurationProperty =>
-//             (configGroup[configurationProperty.key] =
-//               configurationProperty.value)
-//         );
-//         datasourceGroup[datasourceKey] = expand(configGroup);
-//       });
-//
-//       mappedGroup[groupKey] = datasourceGroup;
-//     } else {
-//       const configGroup = {};
-//       // group is the list of configuration properties
-//       group.forEach(configurationProperty => {
-//         if (
-//           isString(configurationProperty.value) &&
-//           configurationProperty.value.indexOf(',') > -1
-//         ) {
-//           configGroup[
-//             configurationProperty.key
-//           ] = configurationProperty.value.split(',');
-//         } else {
-//           configGroup[configurationProperty.key] = configurationProperty.value;
-//         }
-//       });
-//       mappedGroup[groupKey] = configGroup;
-//     }
-//   });
-//
-//   return mappedGroup;
-// }
-//
-// /**
-//  * This creates configuration property models for each default property and applies the provided override on top of that
-//  *
-//  * TODO i feel it would be best to do this in the view as this is a view behavior concern and not a data modeling concern
-//  *
-//  * @param defaults
-//  * @param overrides
-//  */
-// export function toConfigurationProperties(
-//   defaults: any,
-//   overrides: any = {}
-// ): any {
-//   const groupedProperties = {};
-//
-//   forOwn(defaults, (configGroup, groupKey) => {
-//     if (groupKey !== 'datasources') {
-//       const configProps: ConfigurationProperty[] = [];
-//
-//       forOwn(flattenJsonObject(configGroup), (value, key) => {
-//         const defaultVal = joinIfArray(value);
-//         if (!overrides) {
-//           configProps.push(
-//             new ConfigurationProperty(key, defaultVal, groupKey)
-//           );
-//         } else {
-//           const groupOverrides = overrides[groupKey] || {};
-//           const override = get(groupOverrides, key);
-//           if (override) {
-//             configProps.push(
-//               new ConfigurationProperty(
-//                 key,
-//                 joinIfArray(override),
-//                 groupKey,
-//                 defaultVal
-//               )
-//             );
-//           } else {
-//             configProps.push(
-//               new ConfigurationProperty(key, defaultVal, groupKey)
-//             );
-//           }
-//         }
-//       });
-//
-//       groupedProperties[groupKey] = configProps;
-//     } else {
-//       // current group is datasources
-//       const databaseProps = {};
-//
-//       // Iterate over the group of databases
-//       forOwn(configGroup, (databaseProperties, databaseName) => {
-//         const configProps: ConfigurationProperty[] = [];
-//
-//         forOwn(flattenJsonObject(databaseProperties), (value, key) => {
-//           const defaultVal = key === 'password' ? '' : joinIfArray(value);
-//           if (!overrides) {
-//             configProps.push(
-//               new ConfigurationProperty(key, defaultVal, databaseName)
-//             );
-//           } else {
-//             const groupOverrides = overrides[groupKey] || {};
-//             const override = get(groupOverrides, `${databaseName}.${key}`);
-//             if (override) {
-//               configProps.push(
-//                 new ConfigurationProperty(
-//                   key,
-//                   joinIfArray(override),
-//                   databaseName,
-//                   defaultVal
-//                 )
-//               );
-//             } else {
-//               configProps.push(
-//                 new ConfigurationProperty(key, defaultVal, databaseName)
-//               );
-//             }
-//           }
-//         });
-//
-//         databaseProps[databaseName] = configProps;
-//       });
-//
-//       groupedProperties[groupKey] = databaseProps;
-//     }
-//   });
-//   return groupedProperties;
-// }
-//
-// export function getModifiedConfigProperties(configProperties: any): any {
-//   const modifiedProperties = {};
-//   forOwn(configProperties, (group, key) => {
-//     const props = <ConfigurationProperty[]>group;
-//     if (props.some !== undefined) {
-//       if (props.some(x => x.originalValue !== x.value)) {
-//         modifiedProperties[key] = props.filter(
-//           x => x.originalValue !== x.value
-//         );
-//       }
-//     } else {
-//       // Not an array of config props, must be a sub group, i.e. datasources.reporting_rw
-//       modifiedProperties[key] = getModifiedConfigProperties(group);
-//     }
-//   });
-//   return modifiedProperties;
-// }
-//
-// function localizationToConfigurationProperties(
-//   overrides: any
-// ): ConfigurationProperty[] {
-//   const flattenedOverrides = flattenJsonObject(overrides);
-//   const configProperties: ConfigurationProperty[] = [];
-//   forOwn(flattenedOverrides, (value, key) =>
-//     configProperties.push(new ConfigurationProperty(key, value))
-//   );
-//   return configProperties;
-// }
-//
-// function toLocalizationOverridesApiModel(
-//   overrides: ConfigurationProperty[]
-// ): any {
-//   const flattenedOverrides = overrides
-//     ? overrides.reduce((localizationOverrides, { key, value }) => {
-//         localizationOverrides[key] = value;
-//         return localizationOverrides;
-//       }, {})
-//     : [];
-//
-//   return expand(flattenedOverrides);
-// }
-//
-// function joinIfArray(value: any): string {
-//   return Array.isArray(value) ? value.join(',') : value;
-// }

--- a/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
@@ -24,7 +24,6 @@ import { FormMode } from '../../component/tenant-form/tenant-form.component';
 import { TenantType } from '../../model/tenant-type';
 import { combineLatest } from 'rxjs/internal/observable/combineLatest';
 import { defaultTenant } from '../../model/tenants';
-import { tap } from 'rxjs/internal/operators/tap';
 import { flatten } from '../../../../shared/support/support';
 
 // TODO have diff checking to disable and enable the save button accordingly
@@ -111,13 +110,13 @@ export class TenantComponent implements OnDestroy {
                   type,
                   [firstTenant],
                   [firstDataSet],
-                  configurationProperties,
-                  localizationOverrides
+                  configurations,
+                  localizations
                 ]) =>
                   defaultTenant(
                     type,
-                    configurationProperties,
-                    localizationOverrides,
+                    configurations,
+                    localizations,
                     firstTenant,
                     firstDataSet
                   )

--- a/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
@@ -26,7 +26,6 @@ import { combineLatest } from 'rxjs/internal/observable/combineLatest';
 import { defaultTenant } from '../../model/tenants';
 import { flatten } from '../../../../shared/support/support';
 
-// TODO have diff checking to disable and enable the save button accordingly
 @Component({
   selector: 'app-tenant',
   templateUrl: './tenant.component.html',
@@ -151,46 +150,11 @@ export class TenantComponent implements OnDestroy {
   }
 
   onCreate(value: TenantConfiguration): void {
-    this.service.create(value).subscribe(
-      () => {
-        this.router.navigate(['..'], {
-          relativeTo: this.route
-        });
-        this.notificationService.info({
-          id: `tenant.create.success.${value.type}`,
-          args: value
-        });
-      },
-      error => {
-        try {
-          this.notificationService.error({ id: error.json().message });
-        } catch (exception) {
-          this.notificationService.error({
-            id: `tenant.create.error.${value.type}`
-          });
-        }
-      }
-    );
+    this.onSave('create', value);
   }
 
   onUpdate(value: TenantConfiguration): void {
-    this.service.update(value).subscribe(
-      () => {
-        this.notificationService.info({
-          id: `tenant.update.success.${value.type}`,
-          args: value
-        });
-      },
-      error => {
-        try {
-          this.notificationService.error({ id: error.json().message });
-        } catch (exception) {
-          this.notificationService.error({
-            id: `tenant.update.error.${value.type}`
-          });
-        }
-      }
-    );
+    this.onSave('update', value);
   }
 
   onDelete(tenant: TenantConfiguration): void {
@@ -227,5 +191,33 @@ export class TenantComponent implements OnDestroy {
         }
       );
     });
+  }
+
+  private onSave(mode: 'create' | 'update', value: TenantConfiguration): void {
+    const observable =
+      mode === 'create'
+        ? this.service.create(value)
+        : this.service.update(value);
+
+    observable.subscribe(
+      () => {
+        this.router.navigate(['..'], {
+          relativeTo: this.route
+        });
+        this.notificationService.info({
+          id: `tenant.${mode}.success.${value.type}`,
+          args: value
+        });
+      },
+      error => {
+        try {
+          this.notificationService.error({ id: error.json().message });
+        } catch (exception) {
+          this.notificationService.error({
+            id: `tenant.${mode}.error.${value.type}`
+          });
+        }
+      }
+    );
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/pages/tenant/tenant.component.ts
@@ -25,6 +25,7 @@ import { TenantType } from '../../model/tenant-type';
 import { combineLatest } from 'rxjs/internal/observable/combineLatest';
 import { defaultTenant } from '../../model/tenants';
 import { tap } from 'rxjs/internal/operators/tap';
+import { flatten } from '../../../../shared/support/support';
 
 // TODO have diff checking to disable and enable the save button accordingly
 @Component({
@@ -86,8 +87,9 @@ export class TenantComponent implements OnDestroy {
     );
 
     this.localizationDefaults$ = this.translationLoader
-      .getFlattenedTranslations(this.languageStore.currentLanguage)
+      .getTranslation(this.languageStore.currentLanguage)
       .pipe(
+        map(defaults => flatten(defaults)),
         publishReplay(),
         refCount()
       );

--- a/webapp/src/main/webapp/src/app/admin/tenant/service/tenant.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/service/tenant.service.ts
@@ -5,10 +5,10 @@ import { DataService } from '../../../shared/data/data.service';
 import { ResponseUtils } from '../../../shared/response-utils';
 import { AdminServiceRoute } from '../../../shared/service-route';
 import {
-  toConfigurationOverrides,
+  toConfigurations,
   toConfigurationProperties,
   toTenant,
-  toTenantApiModel
+  toServerTenant
 } from '../model/tenants';
 import { DataSet, TenantConfiguration } from '../model/tenant-configuration';
 import { TenantType } from '../model/tenant-type';
@@ -81,7 +81,7 @@ export class TenantService {
    */
   create(tenant: TenantConfiguration): Observable<TenantConfiguration> {
     return this.dataService
-      .post(ResourceRoute, toTenantApiModel(tenant))
+      .post(ResourceRoute, toServerTenant(tenant))
       .pipe(map(() => tenant));
   }
 
@@ -91,7 +91,7 @@ export class TenantService {
    */
   update(tenant: TenantConfiguration): Observable<TenantConfiguration> {
     return this.dataService
-      .put(ResourceRoute, toTenantApiModel(tenant))
+      .put(ResourceRoute, toServerTenant(tenant))
       .pipe(map(() => tenant));
   }
 
@@ -111,7 +111,7 @@ export class TenantService {
   getDefaultConfigurationProperties(type: TenantType): Observable<any> {
     return this.cachingDataService.get(DefaultsRoute).pipe(
       map(defaults =>
-        toConfigurationProperties(toConfigurationOverrides(defaults, type))
+        toConfigurationProperties(toConfigurations(defaults, type))
       ),
       catchError(ResponseUtils.throwError)
     );

--- a/webapp/src/main/webapp/src/app/admin/tenant/service/tenant.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/service/tenant.service.ts
@@ -4,12 +4,7 @@ import { catchError, map, mapTo } from 'rxjs/operators';
 import { DataService } from '../../../shared/data/data.service';
 import { ResponseUtils } from '../../../shared/response-utils';
 import { AdminServiceRoute } from '../../../shared/service-route';
-import {
-  toConfigurations,
-  toConfigurationProperties,
-  toTenant,
-  toServerTenant
-} from '../model/tenants';
+import { toConfigurations, toTenant, toServerTenant } from '../model/tenants';
 import { DataSet, TenantConfiguration } from '../model/tenant-configuration';
 import { TenantType } from '../model/tenant-type';
 import { CachingDataService } from '../../../shared/data/caching-data.service';
@@ -110,9 +105,7 @@ export class TenantService {
    */
   getDefaultConfigurationProperties(type: TenantType): Observable<any> {
     return this.cachingDataService.get(DefaultsRoute).pipe(
-      map(defaults =>
-        toConfigurationProperties(toConfigurations(defaults, type))
-      ),
+      map(defaults => toConfigurations(defaults, type)),
       catchError(ResponseUtils.throwError)
     );
   }

--- a/webapp/src/main/webapp/src/app/shared/form/forms.ts
+++ b/webapp/src/main/webapp/src/app/shared/form/forms.ts
@@ -32,12 +32,15 @@ export function controlValueAccessorProvider(reference: any): Provider {
   };
 }
 
+const options = { onlySelf: true };
 export function validate(formGroup: FormGroup): void {
-  // TODO this step should be recursive but there is currently no use case
   Object.values(formGroup.controls).forEach(control => {
-    control.markAsDirty();
+    control.markAsTouched(options);
+    control.updateValueAndValidity(options);
+    if ((<FormGroup>control).controls != null) {
+      validate(control as FormGroup);
+    }
   });
-  formGroup.updateValueAndValidity();
 }
 
 /**
@@ -46,7 +49,12 @@ export function validate(formGroup: FormGroup): void {
  * @param control the form control to test
  */
 export function showErrors(control: AbstractControl): boolean {
-  return control.invalid && (control.dirty || control.touched);
+  return (
+    control.invalid &&
+    (control.dirty || control.touched) &&
+    control.errors != null &&
+    Object.keys(control.errors).length > 0
+  );
 }
 
 /**

--- a/webapp/src/main/webapp/src/app/shared/i18n/rdw-translate-loader.ts
+++ b/webapp/src/main/webapp/src/app/shared/i18n/rdw-translate-loader.ts
@@ -7,7 +7,6 @@ import { EmbeddedLanguages } from './language-settings';
 import { HttpClient } from '@angular/common/http';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { SubjectService } from '../../subject/subject.service';
-import { flattenJsonObject, Utils } from '../support/support';
 import { UserService } from '../security/service/user.service';
 
 const EmptyObservable = of({});
@@ -51,12 +50,6 @@ export class RdwTranslateLoader implements TranslateLoader {
       );
   }
 
-  getFlattenedTranslations(languageCode: string): Observable<any> {
-    return this.getUserTranslations(languageCode).pipe(
-      map(translations => flattenJsonObject(translations))
-    );
-  }
-
   private getClientTranslations(languageCode: string): Observable<any> {
     return EmbeddedLanguages.indexOf(languageCode) != -1
       ? this.clientTranslationsLoader.getTranslation(languageCode)
@@ -95,8 +88,7 @@ export class RdwTranslateLoader implements TranslateLoader {
           serverTranslations,
           `subject.${subject}.asmt-type.${assessmentType}.name`
         );
-        if (Utils.isNullOrUndefined(label) || labels.indexOf(label) >= 0)
-          continue;
+        if (label == null || labels.indexOf(label) >= 0) continue;
 
         labels.push(label);
       }

--- a/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
@@ -7,6 +7,7 @@ import {
   unflatten,
   Utils
 } from './support';
+import { isObject } from 'lodash';
 
 describe('Utils', () => {
   it('should pass isNullOrUndefined', () => {
@@ -128,7 +129,7 @@ describe('flatten', () => {
         (result, object, property) => {
           if (
             Array.isArray(object) &&
-            object.every(value => Object(value) !== value)
+            object.every(value => !isObject(value))
           ) {
             result[property] = object.join(',');
             return true;

--- a/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.spec.ts
@@ -1,7 +1,10 @@
 import {
   deepEqualsIgnoringNullAndFalse,
+  difference,
   equalDate,
-  flattenJsonObject,
+  flatten,
+  rightDifference,
+  unflatten,
   Utils
 } from './support';
 
@@ -33,44 +36,6 @@ describe('Utils', () => {
     expect(
       Utils.appendOrIncrementFileNameSuffix('an aggregateReport (1)')
     ).toEqual('an aggregateReport (2)');
-  });
-
-  it('should flatten JSON object', () => {
-    let mockJSON = {
-      foo: 'bar',
-      state: {
-        code: 'CA',
-        label: 'California'
-      }
-    };
-    expect(flattenJsonObject(mockJSON)).toEqual({
-      foo: 'bar',
-      'state.code': 'CA',
-      'state.label': 'California'
-    });
-  });
-
-  it('should flatten JSON object with an array of values', () => {
-    let mockJSON = {
-      foo: 'bar',
-      state: {
-        code: 'CA',
-        label: 'California',
-        description: null
-      },
-      languages: ['en', 'es']
-    };
-    expect(flattenJsonObject(mockJSON)).toEqual({
-      foo: 'bar',
-      'state.code': 'CA',
-      'state.label': 'California',
-      'state.description': null,
-      languages: 'en,es'
-    });
-  });
-
-  it('should return empty object for an undefined input', () => {
-    expect(flattenJsonObject(undefined)).toEqual({});
   });
 });
 
@@ -123,5 +88,153 @@ describe('equalDate', () => {
     const a = new Date(1, 2, 3, 4, 5, 6);
     const b = new Date(1, 2, 3, 5, 6, 7);
     expect(equalDate(a, b)).toBe(true);
+  });
+});
+
+describe('flatten', () => {
+  it('should flatten tree structure', () => {
+    expect(
+      flatten({
+        a: {
+          b: [
+            {
+              c: 1,
+              d: '3'
+            }
+          ],
+          bb: 2
+        }
+      })
+    ).toEqual({
+      'a.b.0.c': 1,
+      'a.b.0.d': '3',
+      'a.bb': 2
+    });
+  });
+
+  it('should run "primitive array value joining" customizer ', () => {
+    expect(
+      flatten(
+        {
+          a: {
+            b: [
+              {
+                c: 1,
+                d: ['3', '4']
+              }
+            ]
+          }
+        },
+        (result, object, property) => {
+          if (
+            Array.isArray(object) &&
+            object.every(value => Object(value) !== value)
+          ) {
+            result[property] = object.join(',');
+            return true;
+          }
+          return false;
+        }
+      )
+    ).toEqual({
+      'a.b.0.c': 1,
+      'a.b.0.d': '3,4'
+    });
+  });
+});
+
+describe('unflatten', () => {
+  it('should unflatten a flattened object', () => {
+    expect(
+      unflatten({
+        'a.b.0.c': 1,
+        'a.b.0.d': '3',
+        'a.bb': 2
+      })
+    ).toEqual({
+      a: {
+        b: [
+          {
+            c: 1,
+            d: '3'
+          }
+        ],
+        bb: 2
+      }
+    });
+  });
+  it('should run customizer', () => {
+    expect(
+      unflatten(
+        {
+          'a.b.0.c': '1',
+          'a.b.0.d': '3,4,5',
+          'a.bb': 2
+        },
+        value => {
+          if (typeof value === 'string') {
+            if (value.includes(',')) {
+              const array = value.split(',');
+              if (array.every(element => Object(element) !== element)) {
+                return array.map(element =>
+                  typeof element === 'string' ? element.trim() : element
+                );
+              }
+            }
+          }
+          return value;
+        }
+      )
+    ).toEqual({
+      a: {
+        b: [
+          {
+            c: '1',
+            d: ['3', '4', '5']
+          }
+        ],
+        bb: 2
+      }
+    });
+  });
+});
+
+const left = {
+  a: 1,
+  b: 2,
+  c: 3
+};
+
+const right = {
+  b: 2,
+  c: 4,
+  d: 5
+};
+
+describe('difference', () => {
+  it('should produce the difference of two flat objects', () => {
+    expect(difference(left, right)).toEqual({
+      left: {
+        a: 1
+      },
+      middle: {
+        c: {
+          left: 3,
+          right: 4
+        }
+      },
+      right: {
+        d: 5
+      }
+    });
+  });
+});
+
+describe('rightDifference', () => {
+  it('should only take the right difference', () => {
+    expect(rightDifference(left, right)).toEqual({
+      c: 4,
+      d: 5
+    });
   });
 });

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -1,5 +1,4 @@
-import { isEmpty, isEqual, omitBy } from 'lodash';
-import { diff } from 'ngx-bootstrap/chronos/moment/diff';
+import { isEmpty, isEqual, omitBy, isObject } from 'lodash';
 
 export function isBlank(value: string): boolean {
   return value.trim().length === 0;
@@ -354,42 +353,6 @@ export function range(start: number, end: number): number[] {
   return values;
 }
 
-/**
- * Flattens a (potentially deeply nested) JSON object to a single-level shallow JSON object
- *
- * @param value potentially deeply nested JSON object
- * @returns A flattened JSON object containing key/value pairings
- */
-export function flattenJsonObject(value: any): any {
-  const toReturn = {};
-
-  for (const property in value) {
-    const propertyValue = value[property];
-
-    if (typeof propertyValue === 'object') {
-      if (propertyValue == null) {
-        // coerce undefined to null
-        toReturn[property] = null;
-      } else if (
-        Array.isArray(propertyValue) &&
-        propertyValue.every(value => typeof value !== 'object')
-      ) {
-        // to avoid the .0 .1 .x index flattening of array values? this should only apply when there are no children
-        toReturn[property] = propertyValue.join();
-      } else {
-        const flatObject = flattenJsonObject(propertyValue);
-        for (const flatObjectProperty in flatObject) {
-          toReturn[property + '.' + flatObjectProperty] =
-            flatObject[flatObjectProperty];
-        }
-      }
-    } else {
-      toReturn[property] = propertyValue;
-    }
-  }
-  return toReturn;
-}
-
 // https://stackoverflow.com/questions/19098797/fastest-way-to-flatten-un-flatten-nested-json-objects
 
 export interface FlattenCustomizer {
@@ -411,7 +374,7 @@ function flattenRecurse(
 ) {
   if (customizer(result, object, property)) {
     // customizer handled it
-  } else if (Object(object) !== object) {
+  } else if (!isObject(object)) {
     // is primitive
     result[property] = object;
   } else if (Array.isArray(object)) {
@@ -458,7 +421,7 @@ export function unflatten(
   object: any,
   customizer: UnflattenCustomizer = nullUnflattenCustomizer
 ): any {
-  if (Object(object) !== object || Array.isArray(object)) {
+  if (!isObject(object) || Array.isArray(object)) {
     return object;
   }
   let result = {},

--- a/webapp/src/main/webapp/src/app/shared/support/support.ts
+++ b/webapp/src/main/webapp/src/app/shared/support/support.ts
@@ -556,3 +556,17 @@ function oneSidedDifference(a: any, b: any, side: 'left' | 'right'): any {
 export function rightDifference(a: any, b: any): any {
   return oneSidedDifference(a, b, 'right');
 }
+
+/**
+ * Returns the provided object but with only entries that have values other than null or undefined
+ *
+ * @param value The object to prune of null or undefined valued entries
+ */
+export function valued(value: { [key: string]: any }): { [key: string]: any } {
+  return Object.entries(value).reduce((valued, [key, value]) => {
+    if (value != null) {
+      valued[key] = value;
+    }
+    return valued;
+  }, {});
+}

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1279,8 +1279,8 @@
           "required": "Please select a data set to initialize the sandbox with"
         }
       },
-      "configurationOverrides": {
-        "label": "Configuration Overrides",
+      "configurations": {
+        "label": "Configurations",
         "error": {
           "onePasswordPerUser": "Multiple passwords were provided for the following user names: {{usernames}}. Please provide the same password wherever the username is the same."
         },
@@ -1296,8 +1296,8 @@
           }
         }
       },
-      "localizationOverrides": {
-        "label": "Localization Overrides",
+      "localizations": {
+        "label": "Localizations",
         "control": {
           "search": {
             "placeholder": "Search properties by key or value"

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1309,7 +1309,7 @@
       }
     }
   },
-  "tenant-configuration-override-form": {
+  "tenant-configuration-form": {
     "column": {
       "key": {
         "label": "Key"
@@ -1332,7 +1332,7 @@
     },
     "no-results": "There are no configuration properties matching your search"
   },
-  "tenant-localization-override-form": {
+  "tenant-localization-form": {
     "column": {
       "key": {
         "label": "Key"

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1312,7 +1312,7 @@
   "tenant-configuration-form": {
     "column": {
       "key": {
-        "label": "Key"
+        "label": "Property"
       },
       "value": {
         "label": "Value"
@@ -1335,7 +1335,7 @@
   "tenant-localization-form": {
     "column": {
       "key": {
-        "label": "Key"
+        "label": "Property"
       },
       "value": {
         "label": "Value"

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -779,17 +779,6 @@ aggregate-report-table {
 }
 
 .sandbox-config {
-  .action-buttons {
-    margin-top: 10px;
-    margin-bottom: 10px;
-  }
-
-  .property-input {
-    width: 100%;
-    padding: 5px;
-    margin: -5px 0;
-  }
-
   .sandbox-container {
     .sandbox-header {
       display: flex;


### PR DESCRIPTION
bugfixes

1.  sandbox save now sends key & id
2.  searching both tables results in empty message appearing when there are no results

improvements

1.  save and create now take you back to list view
2.  when there is a config table search present all the properties expand
3.  the submit button is now always enabled and triggers form validation when clicked & everything invalid highlights
4.  implemented the username/password validation with message

 
todos

1.  username defaults based on tenant key (regression)
2.  disable save button if there is no diff with current saved tenant config
3.  expand config table when fields are invalid