### PR TITLE
Reduce payload of getAll tenant configuration call to only contain Tenant and Status

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationStatusContext.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationStatusContext.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.admin.multitenant.administration;
 
 import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
+import org.opentestsystem.rdw.multitenant.Tenant;
 
 /**
  * Provides the status of a {@link TenantConfiguration} and optionally a message providing
@@ -8,14 +9,14 @@ import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
  */
 public class TenantAdministrationStatusContext {
 
-    private TenantConfiguration tenantConfiguration;
+    private Tenant tenant;
 
     private TenantAdministrationStatus tenantAdministrationStatus;
 
     private String message;
 
-    public TenantConfiguration getTenantConfiguration() {
-        return tenantConfiguration;
+    public Tenant getTenant() {
+        return tenant;
     }
 
     public TenantAdministrationStatus getTenantAdministrationStatus() {
@@ -37,15 +38,15 @@ public class TenantAdministrationStatusContext {
 
         private TenantAdministrationStatus tenantAdministrationStatus = null;
         private String message = null;
-        private TenantConfiguration tenantConfiguration = null;
+        private Tenant tenant = null;
 
         public Builder tenantAdministrationStatus(final TenantAdministrationStatus tenantAdministrationStatus) {
             this.tenantAdministrationStatus = tenantAdministrationStatus;
             return this;
         }
 
-        public Builder tenantConfiguration(final TenantConfiguration tenantConfiguration) {
-            this.tenantConfiguration = tenantConfiguration;
+        public Builder tenant(final Tenant tenant) {
+            this.tenant = tenant;
             return this;
         }
 
@@ -61,7 +62,7 @@ public class TenantAdministrationStatusContext {
             TenantAdministrationStatusContext context = new TenantAdministrationStatusContext();
             context.message = this.message;
             context.tenantAdministrationStatus = this.tenantAdministrationStatus;
-            context.tenantConfiguration = this.tenantConfiguration;
+            context.tenant = this.tenant;
             return context;
         }
     }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/GuavaCacheTenantAdministrationStatusService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/GuavaCacheTenantAdministrationStatusService.java
@@ -37,7 +37,7 @@ public class GuavaCacheTenantAdministrationStatusService implements TenantAdmini
     public void putStatus(String tenantKey, TenantAdministrationStatus status, TenantConfiguration tenantConfiguration, String message) {
         statusCache.put(tenantKey,
                 TenantAdministrationStatusContext.builder()
-                        .tenantConfiguration(tenantConfiguration)
+                        .tenant(tenantConfiguration.getTenant())
                         .tenantAdministrationStatus(status)
                         .message(message)
                         .build());
@@ -53,7 +53,7 @@ public class GuavaCacheTenantAdministrationStatusService implements TenantAdmini
         Optional.ofNullable(statusCache.getIfPresent(tenantKey)).ifPresent(currentContext -> {
                     TenantAdministrationStatusContext newContext = TenantAdministrationStatusContext
                             .builder()
-                            .tenantConfiguration(currentContext.getTenantConfiguration())
+                            .tenant(currentContext.getTenant())
                             .tenantAdministrationStatus(status)
                             .message(message)
                             .build();
@@ -71,5 +71,5 @@ public class GuavaCacheTenantAdministrationStatusService implements TenantAdmini
     public void remove(String tenantKey) {
         statusCache.invalidate(tenantKey);
     }
-    
+
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opentestsystem.rdw.admin.multitenant.administration.TenantAdministrationStatus.ACTIVE;
+
 /**
  * Classes to return tenant and sandbox properties from the RDW Actuator endpoint calls
  * This is the service the tenant & sandbox service use to retrieve default and tenant specific properties & settings
@@ -153,58 +155,6 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
                 || inProcessTenants().containsKey(key);
     }
 
-
-    /**
-     * TODO: temporarily leaving for reference
-     *
-     * @deprecated use {@link DefaultTenantConfigurationViewService#findActiveTenantConfiguration(java.lang.String)} instead
-     */
-    @VisibleForTesting
-    @Deprecated
-    Optional<TenantConfiguration> activeTenantConfiguration(String tenantKey) {
-        final Map<String, Tenant> tenants = activeTenants();
-        if (!tenants.containsKey(tenantKey)) {
-            return Optional.empty();
-        }
-
-        final Tenant tenant = tenants.get(tenantKey);
-        final boolean isSandbox = tenant.isSandbox();
-        final TenantConfiguration.Builder tenantConfigurationBuilder = TenantConfiguration.builder();
-
-        //both sandbox and non-sandbox
-        tenantConfigurationBuilder.tenant(tenant);
-        tenantConfigurationBuilder.administrationStatus(
-                TenantAdministrationStatusContext
-                        .builder()
-                        .tenantAdministrationStatus(TenantAdministrationStatus.ACTIVE)
-                        .build());
-
-
-        configpropsService.reportingSystemProperties(tenantKey).ifPresent(reporting -> {
-            tenantConfigurationBuilder.reporting(reporting);
-            final String translationLocation = reporting.getTranslationLocation();
-            final String languageCode = getLanguageCode(reporting.getUiLanguages());
-            configServerClient.getLocalization(translationLocation, languageCode)
-                    .ifPresent(tenantConfigurationBuilder::localizaton);
-        });
-
-        configpropsService.aggregateReportingProperties(tenantKey)
-                .ifPresent(tenantConfigurationBuilder::aggregateReportingProperties);
-
-        configpropsService.archiveProperties(tenantKey)
-                .ifPresent(tenantConfigurationBuilder::archiveProperties);
-
-        tenantConfigurationBuilder.dataSources(configpropsService.dataSourceElements(tenantKey));
-
-        //we aren't storing this recreating based off convention
-        if (isSandbox) {
-            //sandbox only
-            tenantConfigurationBuilder.parentTenantKey(parentTenantKey(tenantKey));
-        }
-
-        return Optional.of(tenantConfigurationBuilder.build());
-    }
-
     /**
      * ATM will return the first configured uiLanguage,
      * Expect entry to be the same name as the i18n json file (minus the json extension)
@@ -226,11 +176,15 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
     @VisibleForTesting
     Map<String, TenantConfiguration> activeTenantConfigurationsByType(TenantType tenantType) {
         return activeTenantsByType(tenantType)
-                .keySet()
+                .entrySet()
                 .stream()
-                .map(tenantKey -> ImmutablePair.of(tenantKey, findActiveTenantConfiguration(tenantKey)))
-                .filter(pair -> pair.getRight().isPresent())
-                .collect(Collectors.toMap(ImmutablePair::getLeft, pair -> pair.getRight().get()));
+                .map(entry -> ImmutablePair.of(entry.getKey(), TenantConfiguration.builder()
+                        .tenant(entry.getValue())
+                        .administrationStatus(TenantAdministrationStatusContext.builder()
+                                .tenantAdministrationStatus(ACTIVE) //TODO: temporary - next move to activeTenantsByType
+                                .build())
+                        .build()))
+                .collect(Collectors.toMap(ImmutablePair::getLeft, ImmutablePair::getRight));
     }
 
     @VisibleForTesting
@@ -308,9 +262,10 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
                 .map(entry -> {
                     String key = entry.getKey();
                     TenantAdministrationStatusContext status = entry.getValue();
-                    TenantConfiguration currentTenantConfiguration = currentAllTenantStatus.get(key).getTenantConfiguration();
+                    Tenant currentTenant = currentAllTenantStatus.get(key).getTenant();
                     TenantConfiguration.Builder tenantConfigurationBuilder =
-                            TenantConfiguration.builder().copy(currentTenantConfiguration);
+                            TenantConfiguration.builder();
+                    tenantConfigurationBuilder.tenant(currentTenant);
                     tenantConfigurationBuilder.administrationStatus(status);
                     return ImmutablePair.of(key, tenantConfigurationBuilder.build());
                 })

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
@@ -40,7 +40,6 @@ import static org.opentestsystem.rdw.admin.multitenant.administration.TenantAdmi
  * This is the service the tenant & sandbox service use to retrieve default and tenant specific properties & settings
  */
 @Service
-//TODO: refresh scope this for TenantProperties?  don't think so but verify
 public class DefaultTenantConfigurationViewService implements TenantConfigurationViewService {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultTenantConfigurationViewService.class);
@@ -178,13 +177,14 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
         return activeTenantsByType(tenantType)
                 .entrySet()
                 .stream()
-                .map(entry -> ImmutablePair.of(entry.getKey(), TenantConfiguration.builder()
-                        .tenant(entry.getValue())
-                        .administrationStatus(TenantAdministrationStatusContext.builder()
-                                .tenantAdministrationStatus(ACTIVE) //TODO: temporary - next move to activeTenantsByType
-                                .build())
-                        .build()))
-                .collect(Collectors.toMap(ImmutablePair::getLeft, ImmutablePair::getRight));
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> TenantConfiguration.builder()
+                                .tenant(entry.getValue())
+                                .administrationStatus(TenantAdministrationStatusContext.builder()
+                                        .tenantAdministrationStatus(ACTIVE)
+                                        .build())
+                                .build()));
     }
 
     @VisibleForTesting

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantValidationService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantValidationService.java
@@ -2,19 +2,16 @@ package org.opentestsystem.rdw.admin.multitenant.service.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-
 import org.opentestsystem.rdw.admin.multitenant.TenantType;
 import org.opentestsystem.rdw.admin.multitenant.administration.TenantAdministrationStatus;
 import org.opentestsystem.rdw.admin.multitenant.database.impl.RdwDatabaseType;
 import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
 import org.opentestsystem.rdw.admin.multitenant.service.TenantConfigurationViewService;
 import org.opentestsystem.rdw.admin.multitenant.service.TenantValidationService;
-import org.opentestsystem.rdw.admin.service.impl.RDWDataSourceNames;
 import org.opentestsystem.rdw.archive.ArchivePropertiesTenant;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.datasource.DataSourceElementsTenant;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewServiceTest.java
@@ -136,24 +136,24 @@ public class DefaultTenantConfigurationViewServiceTest {
                         "CC",
                         TenantAdministrationStatusContext.builder()
                                 .tenantAdministrationStatus(TenantAdministrationStatus.CREATING_DATABASES)
-                                .tenantConfiguration(generateTenantConfiguration("CC", false))
+                                .tenant(generateTenant("CC", false))
                                 .build(),
                         "CC_S001",
                         TenantAdministrationStatusContext.builder()
                                 .tenantAdministrationStatus(TenantAdministrationStatus.CREATING_DATABASES)
-                                .tenantConfiguration(generateTenantConfiguration("CC_S001", true))
+                                .tenant(generateTenant("CC_S001", true))
                                 .build(),
 
                         "AA",
                         TenantAdministrationStatusContext.builder()
                                 .tenantAdministrationStatus(TenantAdministrationStatus.PERSISTING_CONFIGURATION)
-                                .tenantConfiguration(generateTenantConfiguration("AA", false))
+                                .tenant(generateTenant("AA", false))
                                 .build(),
 
                         "DD",
                         TenantAdministrationStatusContext.builder()
                                 .tenantAdministrationStatus(TenantAdministrationStatus.PERSISTING_CONFIGURATION)
-                                .tenantConfiguration(generateTenantConfiguration("DD", false))
+                                .tenant(generateTenant("DD", false))
                                 .build()
                 )
         );
@@ -260,20 +260,6 @@ public class DefaultTenantConfigurationViewServiceTest {
     }
 
     @Test
-    public void activeTenantConfigurationShouldBeEmptyForUnknownTenantKey() {
-        Optional<TenantConfiguration> xx = defaultTenantConfigurationViewService.activeTenantConfiguration("XX");
-        assertThat(xx).isEmpty();
-    }
-
-    @Test
-    public void activeTenantConfigurationShouldReturnActiveTenantConfiguration() {
-        Optional<TenantConfiguration> aa = defaultTenantConfigurationViewService.activeTenantConfiguration("AA");
-        assertThat(aa).isNotNull();
-        assertThat(aa.get().getTenant().getKey()).isEqualTo("AA");
-        assertThat(aa.get().getLocalization()).isNotNull().isEqualTo(tenantCA_en_json);
-    }
-
-    @Test
     public void activeTenantsByTypeShouldReturnProperActiveTenants() {
         Map<String, Tenant> activeTenants = defaultTenantConfigurationViewService.activeTenantsByType(TenantType.TENANT);
         assertThat(activeTenants).containsKey("AA");
@@ -301,6 +287,14 @@ public class DefaultTenantConfigurationViewServiceTest {
                 .isNull();
     }
 
+    private Tenant generateTenant(String key, boolean isSandbox) {
+        return Tenant.builder()
+                .id(key)
+                .key(key)
+                .sandbox(isSandbox)
+                .build();
+    }
+
     private TenantConfiguration generateTenantConfiguration(String key, boolean isSandbox) {
         TenantConfiguration.Builder configurationBuilder = TenantConfiguration.builder();
         configurationBuilder.aggregateReportingProperties(new AggregateReportingPropertiesRoot());
@@ -310,11 +304,7 @@ public class DefaultTenantConfigurationViewServiceTest {
         if (activeTenantMap.containsKey(key)) {
             configurationBuilder.tenant(activeTenantMap.get(key));
         } else {
-            configurationBuilder.tenant(Tenant.builder()
-                    .id(key)
-                    .key(key)
-                    .sandbox(isSandbox)
-                    .build());
+            configurationBuilder.tenant(generateTenant(key, isSandbox));
         }
         return configurationBuilder.build();
     }

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/web/TenantControllerIT.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/web/TenantControllerIT.java
@@ -2,14 +2,12 @@ package org.opentestsystem.rdw.admin.multitenant.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.admin.multitenant.DataSet;
 import org.opentestsystem.rdw.admin.multitenant.TenantType;
 import org.opentestsystem.rdw.admin.multitenant.administration.TenantAdministrationStatus;
 import org.opentestsystem.rdw.admin.multitenant.administration.TenantAdministrationStatusContext;
@@ -26,7 +24,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;


### PR DESCRIPTION
This is WIP for the broader re-factor of the status service interactions.  It provides some decent quality of life improvements to the list view tenant and sandbox pages that I think it is worth merging now.

- Have TenantAdministrationStatusContext hold only Tenant instead of full tenant configuration
- Only populate tenant and status on tenant configuration