### PR TITLE
switch from immutable sets to mutable lists

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
@@ -36,9 +36,15 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
                                                     final ConfigServerClient configServerClient) {
         this.tenantConfigurationPersistenceProperties = tenantConfigurationPersistenceProperties;
         this.configServerClient = configServerClient;
-        this.ymlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
-        this.ymlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        this.ymlMapper.findAndRegisterModules();
+        this.ymlMapper = createObjectMapper();
+    }
+
+    @VisibleForTesting
+    static ObjectMapper createObjectMapper() {
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.findAndRegisterModules();
+        return mapper;
     }
 
     @VisibleForTesting

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/OjbectMapperTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/OjbectMapperTest.java
@@ -1,10 +1,8 @@
 package org.opentestsystem.rdw.admin.multitenant.git;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
@@ -21,6 +19,7 @@ import java.util.Properties;
 import org.opentestsystem.rdw.admin.multitenant.model.ApplicationTenantConfigurationPersistence;
 import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
 import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingPropertiesTenant;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,11 +36,7 @@ public class OjbectMapperTest {
 
     @Before
     public void createMapper() {
-        // create the mapper the same way DefaultConfigServerClient does
-        ymlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
-//        ymlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        ymlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        ymlMapper.findAndRegisterModules();
+        ymlMapper = GitTenantConfigurationPersistenceService.createObjectMapper();
     }
 
     @Test
@@ -68,15 +63,40 @@ public class OjbectMapperTest {
         assertThat(reporting.getIrisVendorId()).isEqualTo("IRIS");
     }
 
+    @Test
+    public void itShouldReadAssessmentTypes() throws BindException {
+        // This was a reported bug in QA.
+        // NOTE: the solution (switching from immutable Set to mutable List) means that we lose
+        //       the deduplication behavior of the set. Fortunately, we use Jackson YAML to write
+        //       the configuration so it generally won't be a problem.
+        final String yaml =
+                "aggregateReporting:\n" +
+                "  tenants:\n" +
+                "    TS_S002:\n" +
+                "      assessmentTypes:\n" +
+                "        - \"sum\"\n" +
+                "        - \"iab\"\n" +
+                "        - \"sum\"";
+
+        final ApplicationTenantConfigurationPersistence out =
+                buildFromYaml(new ApplicationTenantConfigurationPersistence(), yaml);
+        assertThat(out.getAggregateReporting().get("tenants").get("TS_S002").getAssessmentTypes())
+                .containsExactlyInAnyOrder("sum", "iab", "sum");
+    }
+
     private TenantConfiguration tenantConfiguration() {
         final ReportingSystemPropertiesImpl reporting = new ReportingSystemPropertiesImpl();
         reporting.setIrisVendorId("IRIS");
 
-        // TODO - add other things
+        final AggregateReportingPropertiesTenant aggregate = new AggregateReportingPropertiesTenant();
+        aggregate.setAssessmentTypes(ImmutableSet.of("sum", "iab"));
+
+        // TODO - add more data to test stuff
 
         return TenantConfiguration.builder()
                 .tenant(Tenant.builder().id("XX").key("XX").name("Test").build())
                 .reporting(reporting)
+                .aggregateReportingProperties(aggregate)
                 .build();
     }
 

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/DefaultUserAssessmentTypeService.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/DefaultUserAssessmentTypeService.java
@@ -1,15 +1,14 @@
 package org.opentestsystem.rdw.olap.service.impl;
 
-import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingProperties;
-import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
-import org.opentestsystem.rdw.olap.service.AssessmentTypeService;
-import org.opentestsystem.rdw.olap.service.UserAssessmentTypeService;
-import org.opentestsystem.rdw.reporting.common.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
+import org.opentestsystem.rdw.olap.service.AssessmentTypeService;
+import org.opentestsystem.rdw.olap.service.UserAssessmentTypeService;
+import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingProperties;
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
+import org.opentestsystem.rdw.reporting.common.security.User;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.opentestsystem.rdw.olap.model.AggregateServicePermission.AggregateRead;
@@ -30,7 +29,7 @@ class DefaultUserAssessmentTypeService implements UserAssessmentTypeService {
 
     @Override
     public List<CodedEntity> getAssessmentTypes(final User user) {
-        final Set<String> userAssessmentTypeCodes = user.getPermissionScopeByPermissionId(AggregateRead).isStatewide()
+        final List<String> userAssessmentTypeCodes = user.getPermissionScopeByPermissionId(AggregateRead).isStatewide()
                 ? aggregateReportingProperties.getStatewideUserAssessmentTypes()
                 : aggregateReportingProperties.getAssessmentTypes();
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingProperties.java
@@ -1,10 +1,9 @@
 package org.opentestsystem.rdw.reporting.common.configuration;
 
-import com.google.common.collect.ImmutableSet;
-
-import java.util.Set;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public interface AggregateReportingProperties {
     /**
@@ -13,27 +12,28 @@ public interface AggregateReportingProperties {
      * is no Spring way to create an empty property that overrides the default setting.
      *
      * @param values type values, may be null
-     * @return immutable set with "none"/"null" removed, may be empty but never null
+     * @return list with "none"/"null" removed, may be empty but never null
      */
-    static ImmutableSet<String> toTypeSet(Set<String> values) {
-        return values == null ? ImmutableSet.of() : values.stream()
+    static List<String> toTypes(final Collection<String> values) {
+        return values == null ? new ArrayList<>() : values.stream()
                 .filter(value -> !value.equalsIgnoreCase("none") && !value.equalsIgnoreCase("null"))
-                .collect(toImmutableSet());
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     /**
-     * The assessment types non statewide aggregate reporters can select for aggregate reports
+     * @return The assessment types non statewide aggregate reporters can select for aggregate reports
      */
-    Set<String> getAssessmentTypes();
+    List<String> getAssessmentTypes();
 
     /**
-     * The assessment types a statewide aggregate reporter can select for aggregate reports
+     * @return The assessment types a statewide aggregate reporter can select for aggregate reports
      */
-    Set<String> getStatewideUserAssessmentTypes();
+    List<String> getStatewideUserAssessmentTypes();
 
     /**
-     * The assessment types allowed for the state level aggregation in the aggregate report
+     * @return The assessment types allowed for the state level aggregation in the aggregate report
      */
-    Set<String> getStateAggregateAssessmentTypes();
+    List<String> getStateAggregateAssessmentTypes();
 
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingPropertiesResolver.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingPropertiesResolver.java
@@ -4,8 +4,8 @@ import org.opentestsystem.rdw.multitenant.TenantKeyResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class AggregateReportingPropertiesResolver implements AggregateReportingProperties {
 
@@ -26,21 +26,21 @@ public class AggregateReportingPropertiesResolver implements AggregateReportingP
     }
 
     @Override
-    public Set<String> getAssessmentTypes() {
+    public List<String> getAssessmentTypes() {
         return getAggregateReportingPropertiesTenant()
                 .map(AggregateReportingPropertiesTenant::getAssessmentTypes)
                 .orElse(propertiesRoot.getAssessmentTypes());
     }
 
     @Override
-    public Set<String> getStatewideUserAssessmentTypes() {
+    public List<String> getStatewideUserAssessmentTypes() {
         return getAggregateReportingPropertiesTenant()
                 .map(AggregateReportingPropertiesTenant::getStatewideUserAssessmentTypes)
                 .orElse(propertiesRoot.getStatewideUserAssessmentTypes());
     }
 
     @Override
-    public Set<String> getStateAggregateAssessmentTypes() {
+    public List<String> getStateAggregateAssessmentTypes() {
         return getAggregateReportingPropertiesTenant()
                 .map(AggregateReportingPropertiesTenant::getStateAggregateAssessmentTypes)
                 .orElse(propertiesRoot.getStateAggregateAssessmentTypes());

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingPropertiesTenant.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/AggregateReportingPropertiesTenant.java
@@ -3,7 +3,8 @@ package org.opentestsystem.rdw.reporting.common.configuration;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.google.common.base.Objects;
 
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * POJO for reading/writing aggregate reporting properties
@@ -14,40 +15,38 @@ import java.util.Set;
  */
 public class AggregateReportingPropertiesTenant implements AggregateReportingProperties {
 
-    private Set<String> assessmentTypes;
-
-    private Set<String> statewideUserAssessmentTypes;
-
-    private Set<String> stateAggregateAssessmentTypes;
+    private List<String> assessmentTypes;
+    private List<String> statewideUserAssessmentTypes;
+    private List<String> stateAggregateAssessmentTypes;
 
     @Override
-    public Set<String> getAssessmentTypes() {
+    public List<String> getAssessmentTypes() {
         return assessmentTypes;
     }
 
     @JsonAlias({"assessment-types", "assessment_types"})
-    public void setAssessmentTypes(final Set<String> values) {
-        this.assessmentTypes = AggregateReportingProperties.toTypeSet(values);
+    public void setAssessmentTypes(final Collection<String> values) {
+        this.assessmentTypes = AggregateReportingProperties.toTypes(values);
     }
 
     @Override
-    public Set<String> getStatewideUserAssessmentTypes() {
+    public List<String> getStatewideUserAssessmentTypes() {
         return statewideUserAssessmentTypes;
     }
 
     @JsonAlias({"statewide-user-assessment-types", "statewide_user_assessment_types"})
-    public void setStatewideUserAssessmentTypes(final Set<String> values) {
-        this.statewideUserAssessmentTypes = AggregateReportingProperties.toTypeSet(values);
+    public void setStatewideUserAssessmentTypes(final Collection<String> values) {
+        this.statewideUserAssessmentTypes = AggregateReportingProperties.toTypes(values);
     }
 
     @Override
-    public Set<String> getStateAggregateAssessmentTypes() {
+    public List<String> getStateAggregateAssessmentTypes() {
         return stateAggregateAssessmentTypes;
     }
 
     @JsonAlias({"state-aggregate-assessment-types", "state_aggregate_assessment_types"})
-    public void setStateAggregateAssessmentTypes(final Set<String> values) {
-        this.stateAggregateAssessmentTypes = AggregateReportingProperties.toTypeSet(values);
+    public void setStateAggregateAssessmentTypes(final Collection<String> values) {
+        this.stateAggregateAssessmentTypes = AggregateReportingProperties.toTypes(values);
     }
 
     @Override


### PR DESCRIPTION
The basic problem is that Spring's SnakeYAML doesn't do Sets and doesn't do immutable. So Immutable Sets are right out.

You can create custom resolvers or some such to deal with it but it is surprisingly convoluted. I was hoping i could convince everybody that this is okay. Even though i'm changing the implementation because of technical difficulties, something i advise against generally.

@ftdholbrook, given all your poking around with SnakeYAML, if you know a way to get the deserializer to call a custom setter, that would probably be a more elegant solution. I know how to do it for Jackson YAML, XML, and JSON but it didn't seem to work for Spring's SnakeYAML.