### PR TITLE
RP-650: log error in archive deletion, but allow sandbox removal

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultSandboxArchiveRemovalService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultSandboxArchiveRemovalService.java
@@ -31,7 +31,7 @@ public class DefaultSandboxArchiveRemovalService implements SandboxArchiveRemova
 
         try {
             rootArchiveService.delete(folderName);
-        } catch (final IllegalArgumentException e) {
+        } catch (final Exception e) {
             logger.info("Cannot remove archives for sandbox id {}: {}", tenantKey, e.getMessage());
         }
     }


### PR DESCRIPTION
This will allow the rest of the sandbox deletion tasks to continue even if deleting the archive files fails. This failure seems to be caused by a permissions issue.