### PR TITLE
RP-663: filter state organizations out if no state permissions

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultOrganizationService.java
@@ -50,7 +50,8 @@ class DefaultOrganizationService implements OrganizationService {
                 .limit(Math.max(0, Math.min(MaxLimit, query.getLimit())))
                 .build();
         final List<Organization> organizations = newArrayList(repository.findAll(permissionScope, limitedQuery));
-        if (query.getTypes().contains(OrganizationType.State) &&
+        if (permissionScope.isStatewide() &&
+                query.getTypes().contains(OrganizationType.State) &&
                 (query.getName() == null || systemSettingsProperties.getState().getName().toUpperCase().contains(query.getName().toUpperCase()))) {
             organizations.add(State.builder()
                     .naturalId(systemSettingsProperties.getState().getCode())


### PR DESCRIPTION
All types configured in typescript CreateInstructionalResourceModal.findOrganizations, and if this later filtered by permissions, I'm not seeing it. This fix prevents state orgs from being return to users who don't have statewide permissions. However, the header for the input box still says "Search by State, District, etc". 