### PR TITLE
Defect/633 null std err vs zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 1.3.2 - 2019-08-07
+
+* Added support for exams and reports missing data for standard error
+
 #### 1.3.1 - 2019-04-05
 
 * Extract both answer key parts for EBSR items (reporting-service).

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ String dockerPrefix = "smarterbalanced"
 
 allprojects {
     group = 'org.opentestsystem.rdw.reporting'
-    version = '1.3.1-SNAPSHOT'
+    version = '1.3.2-SNAPSHOT'
 
     apply plugin: 'idea'
     apply plugin: 'propdeps'

--- a/report-processor/src/main/resources/templates/iab-body.html
+++ b/report-processor/src/main/resources/templates/iab-body.html
@@ -72,7 +72,9 @@
                                               th:attr="data-left=${scaleScoreView.position}"><span
                                                 class="score label"
                                                 th:classappend="#{'subject.' + ${report.subject} + '.asmt-type.iab.level.' + ${exam.scaleScore.level} + '.color'}"
-                                                th:text="${exam.scaleScore.value}"></span> <span class="error-band">&plusmn;
+                                                th:text="${exam.scaleScore.value}"></span> <span
+                                                  th:if="${exam.scaleScore.standardError != null}"
+                                                  class="error-band">&plusmn;
                                             <span th:text="${support.round(exam.scaleScore.standardError)}"
                                                   th:remove="tag"></span></span></span>
                                         <div class="bar"
@@ -118,7 +120,9 @@
                                     th:if="${examStat.index} > 0"><span class="previous-result"><span class="date"
                                                                                                       th:text="${#instants.formatDate(exam.dateTime)}"></span> <span
                                     th:if="${exam.scaleScore != null}" class="scale-score"><span
-                                    th:text="${exam.scaleScore.value}" th:remove="tag"></span> <span class="error-band">&plusmn;
+                                    th:text="${exam.scaleScore.value}" th:remove="tag"></span> <span
+                                      th:if="${exam.scaleScore.standardError != null}"
+                                      class="error-band">&plusmn;
                                 <span th:text="${support.round(exam.scaleScore.standardError)}"
                                       th:remove="tag"></span></span></span> <span
                                     class="performance-level"

--- a/report-processor/src/main/resources/templates/ica-body.html
+++ b/report-processor/src/main/resources/templates/ica-body.html
@@ -45,9 +45,10 @@
                     <span class="score label"
                           th:classappend="#{'subject.' + ${report.subject} + '.asmt-type.ica.level.' + ${report.exam.scaleScore.level} + '.color'}"
                           th:text="${report.exam.scaleScore.value}"></span>
-                    <span class="level">
+                    <span class="level"
+                          th:with="additionSafeStandardError=${report.exam.scaleScore.standardError != null ? report.exam.scaleScore.standardError : 0}">
                         <strong th:text="#{'subject.' + ${report.subject} + '.asmt-type.ica.level.' + ${report.exam.scaleScore.level} + '.name'}"></strong>
-                        <span th:text="#{('report.ica.score-range')(${support.round(report.exam.scaleScore.value - report.exam.scaleScore.standardError)}, ${support.round(report.exam.scaleScore.value + report.exam.scaleScore.standardError)})}"
+                        <span th:text="#{('report.ica.score-range')(${support.round(report.exam.scaleScore.value - additionSafeStandardError)}, ${support.round(report.exam.scaleScore.value + additionSafeStandardError)})}"
                                   th:remove="tag"></span>
                     </span>
                     <p class="description mt-sm"
@@ -60,7 +61,8 @@
                             <span class="num label"
                                   th:classappend="#{'subject.' + ${report.subject} + '.asmt-type.ica.level.' + ${report.exam.scaleScore.level} + '.color'}">
                                 <span th:text="${report.exam.scaleScore.value}" th:remove="tag"></span>
-                                <span class="error">±
+                                <span th:if="${report.exam.scaleScore.standardError != null}"
+                                      class="error">±
                                     <span th:text="${support.round(report.exam.scaleScore.standardError)}"
                                           th:remove="tag"></span>*
                                 </span>
@@ -184,7 +186,7 @@
                     </p>
                 </div>
                 <div class="col-xs-4">
-                    <p>
+                    <p th:if="${report.exam.scaleScore.standardError != null}">
                         <strong>*</strong>
                         <strong th:text="#{report.scale-score.error-band}"></strong>
                         <br>

--- a/report-processor/src/main/resources/templates/sum-body.html
+++ b/report-processor/src/main/resources/templates/sum-body.html
@@ -45,9 +45,10 @@
                     <span class="score label"
                           th:classappend="#{'subject.' + ${report.subject} + '.asmt-type.sum.level.' + ${report.exam.scaleScore.level} + '.color'}"
                           th:text="${report.exam.scaleScore.value}"></span>
-                    <span class="level">
+                    <span class="level"
+                          th:with="additionSafeStandardError=${report.exam.scaleScore.standardError != null ? report.exam.scaleScore.standardError : 0}">
                         <strong th:text="#{'subject.' + ${report.subject} + '.asmt-type.sum.level.' + ${report.exam.scaleScore.level} + '.name'}"></strong>
-                        <span th:text="#{('report.sum.score-range')(${support.round(report.exam.scaleScore.value - report.exam.scaleScore.standardError)}, ${support.round(report.exam.scaleScore.value + report.exam.scaleScore.standardError)})}"
+                        <span th:text="#{('report.sum.score-range')(${support.round(report.exam.scaleScore.value - additionSafeStandardError)}, ${support.round(report.exam.scaleScore.value + additionSafeStandardError)})}"
                               th:remove="tag"></span>
                     </span>
                     <p class="description mt-sm"
@@ -60,7 +61,8 @@
                             <span class="num label"
                                   th:classappend="#{'subject.' + ${report.subject} + '.asmt-type.sum.level.' + ${report.exam.scaleScore.level} + '.color'}">
                                 <span th:text="${report.exam.scaleScore.value}" th:remove="tag"></span>
-                                <span class="error">±
+                                <span th:if="${report.exam.scaleScore.standardError != null}"
+                                      class="error">±
                                     <span th:text="${support.round(report.exam.scaleScore.standardError)}"
                                           th:remove="tag"></span>*
                                 </span>
@@ -181,7 +183,7 @@
                     
                 </div>
                 <div class="col-xs-4">
-                    <p>
+                    <p th:if="${report.exam.scaleScore.standardError != null}">
                         <strong>*</strong>
                         <strong th:text="#{report.scale-score.error-band}"></strong>
                         <br>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.mapper.ts
@@ -45,7 +45,7 @@ export class AggregateReportItemMapper {
 
     const measures: any = measuresGetter(row) || {};
     item.avgScaleScore = measures.avgScaleScore || 0;
-    item.avgStdErr = measures.avgStdErr || 0;
+    item.avgStdErr = measures.avgStdErr;
     item.studentsTested = measures.studentCount;
 
     for (let level = 1; level <= subjectDefinition.performanceLevelCount; level++) {

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.ts
@@ -13,7 +13,7 @@ export class AggregateReportItem {
   subjectCode: string;
   schoolYear: number;
   avgScaleScore: number;
-  avgStdErr: number;
+  avgStdErr?: number;
   studentsTested: any;
   performanceLevelByDisplayTypes: {
     [ performanceLevelDisplayType: string ]: {

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table-export.service.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table-export.service.ts
@@ -76,7 +76,9 @@ export class AggregateReportTableExportService {
         .withColumn(
           this.translateService.instant('aggregate-report-table.columns.avg-scale-score'),
           (item: AggregateReportItem) => item.studentsTested
-            ? `${item.avgScaleScore} ± ${item.avgStdErr}`
+            ? item.avgStdErr != null
+              ? `${item.avgScaleScore} ± ${item.avgStdErr}`
+              : item.avgScaleScore
             : ''
         );
 

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
@@ -12,7 +12,7 @@
           <td>
             <div class="scale-score font-large text-left">
               <span class="score label label-primary">{{ overallRow.avgScaleScore }}</span>
-              <span class="error-band black"> {{'common.error-band-value' | translate: {errorBand: overallRow.avgStdErr | number:'1.0-0'} }}</span>
+              <span *ngIf="overallRow.avgStdErr != null" class="error-band black"> {{'common.error-band-value' | translate: {errorBand: overallRow.avgStdErr | number:'1.0-0'} }}</span>
             </div>
           </td>
         </tr>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
@@ -79,7 +79,7 @@
 <ng-template #dataPointPopoverTemplate let-point>
   <div class="text-center">
     <span class="label label-lg {{point.levelRange.level.color}}">{{point.scaleScore}}</span>
-    <span>{{ 'common.error-band-value' | translate: {errorBand: point.standardError | number:'1.0-0'} }}</span>
+    <span *ngIf="point.standardError != null">{{ 'common.error-band-value' | translate: {errorBand: point.standardError | number:'1.0-0'} }}</span>
   </div>
   <div class="mt-xs text-center">{{point.levelRange.level.name}}</div>
 </ng-template>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
@@ -292,8 +292,8 @@ export class LongitudinalCohortChartComponent implements OnInit {
                 styles: `point color-stroke`,
                 x: xScale(j),
                 y: yScale(scaleScore),
-                scaleScore: scaleScore,
-                standardError: standardError || 0,
+                scaleScore,
+                standardError,
                 levelRange: findPerformanceLevelRange(levelRangesByYearGradeIndex, j, scaleScore)
               });
             }

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.ts
@@ -59,7 +59,7 @@ export interface NumberRange {
 export interface YearGradeScaleScore {
   readonly yearGrade: YearGrade;
   readonly scaleScore: number;
-  readonly standardError: number;
+  readonly standardError?: number;
 }
 
 /**

--- a/webapp/src/main/webapp/src/app/assessments/model/claim-score.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/claim-score.model.ts
@@ -2,7 +2,7 @@ import { ExamStatisticsLevel } from './exam-statistics.model';
 
 export class ClaimScore {
   level: number;
-  standardError: number;
+  standardError?: number;
   score: number;
 }
 

--- a/webapp/src/main/webapp/src/app/assessments/model/exam-statistics.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/exam-statistics.model.ts
@@ -3,7 +3,7 @@ import { ClaimStatistics } from './claim-score.model';
 export class ExamStatistics {
   total: number;
   average: number;
-  standardError: number;
+  standardError?: number;
   levels: ExamStatisticsLevel[];
   percents: ExamStatisticsLevel[];
 

--- a/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/exam.model.ts
@@ -12,7 +12,7 @@ export class Exam {
   level: number;
   administrativeCondition: string;
   completeness: string;
-  standardError: number;
+  standardError?: number;
   migrantStatus: boolean;
   plan504: boolean;
   iep: boolean;

--- a/webapp/src/main/webapp/src/app/assessments/model/export-target-report-request.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/export-target-report-request.model.ts
@@ -12,7 +12,7 @@ export class ExportTargetReportRequest implements ExportRequest {
   group: string;
   schoolYear: number;
   averageScaleScore: number;
-  standardError: number;
+  standardError?: number;
   subjectDefinition: SubjectDefinition;
 
   targetScoreRows: AggregateTargetScoreRow[];

--- a/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/average-scale-score.component.html
@@ -16,7 +16,7 @@
                 <div *ngIf="hasAverageScore"
                      class="scale-score font-large text-left">
                   <span class="score label label-primary">{{ averageScore }}</span>
-                  <span class="error-band black"> {{'common.error-band-value' | translate: {errorBand: statistics.standardError | number:'1.0-0'} }}</span>
+                  <span *ngIf="statistics.standardError != null" class="error-band black"> {{'common.error-band-value' | translate: {errorBand: statistics.standardError | number:'1.0-0'} }}</span>
                 </div>
               </td>
             </tr>

--- a/webapp/src/main/webapp/src/app/assessments/results/scale-score.service.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/scale-score.service.ts
@@ -105,12 +105,13 @@ export class ScaleScoreService {
     //  if the score + (1.5 * standardError) < cutScore then level 1
     //  else level 2
 
-    let cutScore = assessment.cutPoints[2];
-    if (score - (1.5 * standardError) > cutScore) {
+    const mathSafeStandardError = standardError || 0;
+    const cutScore = assessment.cutPoints[2];
+    if (score - (1.5 * mathSafeStandardError) > cutScore) {
       return 3;
     }
 
-    if (score + (1.5 * standardError) < cutScore) {
+    if (score + (1.5 * mathSafeStandardError) < cutScore) {
       return 1;
     }
 

--- a/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
@@ -212,9 +212,10 @@ export class TargetStatisticsCalculator {
    * @returns {TargetReportingLevel}
    */
   mapTargetScoreDeltaToReportingLevel(delta: number, standardError: number): TargetReportingLevel {
-    if (standardError > this._insufficientDataCutoff) return TargetReportingLevel.InsufficientData;
-    if (delta >= standardError) return TargetReportingLevel.Above;
-    if (delta <= -standardError) return TargetReportingLevel.Below;
+    const mathSafeStandardError = standardError || 0; // TODO should this return InsufficientData?
+    if (mathSafeStandardError > this._insufficientDataCutoff) return TargetReportingLevel.InsufficientData;
+    if (delta >= mathSafeStandardError) return TargetReportingLevel.Above;
+    if (delta <= -mathSafeStandardError) return TargetReportingLevel.Below;
     return TargetReportingLevel.Near;
   }
 }

--- a/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
+++ b/webapp/src/main/webapp/src/app/csv-export/csv-builder.service.ts
@@ -254,7 +254,7 @@ export class CsvBuilder {
       this.translateService.instant('csv-builder.error-band-min'),
       (item) => {
         const exam: Exam = getExam(item);
-        return !exam.score ? '' : exam.score - exam.standardError;
+        return exam.score != null ? exam.score - (exam.standardError || 0) : '';
       }
     );
   }
@@ -264,7 +264,7 @@ export class CsvBuilder {
       this.translateService.instant('csv-builder.error-band-max'),
       (item) => {
         const exam: Exam = getExam(item);
-        return exam.score ? exam.score + exam.standardError : '';
+        return exam.score != null ? exam.score + (exam.standardError || 0) : '';
       }
     );
   }

--- a/webapp/src/main/webapp/src/app/dashboard/measured-assessment.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/measured-assessment.ts
@@ -4,7 +4,7 @@ export interface MeasuredAssessment {
   readonly assessment: Assessment;
   readonly studentCountByPerformanceLevel: DetailsByPerformanceLevel[];
   readonly averageScaleScore: number;
-  readonly averageStandardError: number;
+  readonly averageStandardError?: number;
   readonly date: Date;
   readonly studentsTested: number;
 }

--- a/webapp/src/main/webapp/src/app/report/aggregate-report.ts
+++ b/webapp/src/main/webapp/src/app/report/aggregate-report.ts
@@ -45,7 +45,7 @@ export interface AggregateReportRowAssessment {
 
 export interface AggregateReportRowMeasure {
   readonly avgScaleScore: number;
-  readonly avgStdErr: number;
+  readonly avgStdErr?: number;
   readonly level1Count: number;
   readonly level2Count: number;
   readonly level3Count: number;

--- a/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.html
@@ -1,4 +1,4 @@
 <span class="scale-score">
   <span class="score">{{ score ? score : '-' }}</span>
-  <span *ngIf="score" class="error-band pl-xs">{{'common.error-band-value' | translate: {errorBand: standardError | number:'1.0-0' } }}</span>
+  <span *ngIf="score && standardError != null" class="error-band pl-xs">{{'common.error-band-value' | translate: {errorBand: standardError | number:'1.0-0' } }}</span>
 </span>

--- a/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.ts
@@ -14,6 +14,6 @@ export class ScaleScoreComponent {
   public score: number;
 
   @Input()
-  public standardError: number;
+  public standardError?: number;
 
 }


### PR DESCRIPTION
Rough notes on where i'm testing based on my assessment of where these changes affect the display:

**Printed Reports**

1. scale score display for all assessment types

**Aggregate Reports**

1.  table export csv
2.  target overview (top right summary on target aggregate report result page)
3.  longitudinal report data point popover (when hovering a scale score)

**Exam Results**

1.  overall scale score (all asmt types)
2.  csv export error band min and max column values
 
**Everywhere the <scale-score> component is used**

1. results by student (exam result view)
2. student history table
3. aggregate-report table