### PR TITLE
Defect/633 stdandard error safety

### DIFF
--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.mapper.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.mapper.ts
@@ -54,7 +54,7 @@ export class AggregateReportItemMapper {
 
     const measures: any = measuresGetter(row) || {};
     item.avgScaleScore = measures.avgScaleScore || 0;
-    item.avgStdErr = measures.avgStdErr || 0;
+    item.avgStdErr = measures.avgStdErr;
     item.studentsTested = measures.studentCount;
 
     for (

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-item.ts
@@ -13,7 +13,7 @@ export class AggregateReportItem {
   subjectCode: string;
   schoolYear: number;
   avgScaleScore: number;
-  avgStdErr: number;
+  avgStdErr?: number;
   studentsTested: any;
   performanceLevelByDisplayTypes: {
     [performanceLevelDisplayType: string]: {

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table-export.service.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-report-table-export.service.ts
@@ -105,7 +105,11 @@ export class AggregateReportTableExportService {
           'aggregate-report-table.columns.avg-scale-score'
         ),
         (item: AggregateReportItem) =>
-          item.studentsTested ? `${item.avgScaleScore} ± ${item.avgStdErr}` : ''
+          item.studentsTested
+            ? item.avgStdErr != null
+              ? `${item.avgScaleScore} ± ${item.avgStdErr}`
+              : item.avgScaleScore
+            : ''
       );
 
       this.addPerformanceLevelColumns(builder, options);

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.component.html
@@ -16,7 +16,10 @@
               <span class="score label label-primary">{{
                 overview.averageScaleScore
               }}</span>
-              <span class="error-band black">
+              <span
+                class="error-band black"
+                *ngIf="overview.averageStandardError != null"
+              >
                 {{
                   'common.error-band-value'
                     | translate

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/aggregate-target-overview.ts
@@ -1,5 +1,5 @@
 export interface AggregateTargetOverview {
   readonly averageScaleScore: number;
-  readonly averageStandardError: number;
+  readonly averageStandardError?: number;
   readonly studentsTested: number;
 }

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.html
@@ -103,7 +103,7 @@
     <span class="label label-lg {{ point.levelRange.level.color }}">{{
       point.scaleScore
     }}</span>
-    <span>{{
+    <span *ngIf="point.standardError != null">{{
       'common.error-band-value'
         | translate: { errorBand: point.standardError | number: '1.0-0' }
     }}</span>

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.component.ts
@@ -73,7 +73,7 @@ interface PerformancePath extends DiscretePath<PerformancePoint> {
 interface PerformancePoint extends Point {
   readonly levelRange: LevelRange;
   readonly scaleScore: number;
-  readonly standardError: number;
+  readonly standardError?: number;
 }
 
 interface PerformanceLevelPath extends Path {
@@ -330,8 +330,8 @@ export class LongitudinalCohortChartComponent implements OnInit {
                     styles: `point color-stroke`,
                     x: xScale(j),
                     y: yScale(scaleScore),
-                    scaleScore: scaleScore,
-                    standardError: standardError || 0,
+                    scaleScore,
+                    standardError,
                     levelRange: findPerformanceLevelRange(
                       levelRangesByYearGradeIndex,
                       j,

--- a/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.ts
+++ b/webapp/src/main/webapp/src/app/aggregate-report/results/longitudinal-cohort-chart.ts
@@ -57,7 +57,7 @@ export interface NumberRange {
 export interface YearGradeScaleScore {
   readonly yearGrade: YearGrade;
   readonly scaleScore: number;
-  readonly standardError: number;
+  readonly standardError?: number;
 }
 
 /**

--- a/webapp/src/main/webapp/src/app/assessments/model/exam-statistics.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/exam-statistics.model.ts
@@ -4,7 +4,7 @@
 export class ExamStatistics {
   total: number;
   average: number;
-  standardError: number;
+  standardError?: number;
   levels: ExamStatisticsLevel[];
   percents: ExamStatisticsLevel[];
   claims: ClaimStatistics[];

--- a/webapp/src/main/webapp/src/app/assessments/model/export-target-report-request.model.ts
+++ b/webapp/src/main/webapp/src/app/assessments/model/export-target-report-request.model.ts
@@ -9,7 +9,7 @@ export interface ExportTargetReportRequest extends ExportRequest {
   group: string;
   schoolYear: number;
   averageScaleScore: number;
-  standardError: number;
+  standardError?: number;
   subjectDefinition: SubjectDefinition;
   targetScoreRows: AggregateTargetScoreRow[];
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
@@ -306,7 +306,7 @@ export class TargetStatisticsCalculator {
     delta: number,
     standardError: number
   ): TargetReportingLevel {
-    if (standardError == null || standardError > this._insufficientDataCutoff) {
+    if (standardError > this._insufficientDataCutoff) {
       return TargetReportingLevel.InsufficientData;
     }
     if (delta >= standardError) {

--- a/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/target-statistics-calculator.ts
@@ -306,10 +306,15 @@ export class TargetStatisticsCalculator {
     delta: number,
     standardError: number
   ): TargetReportingLevel {
-    if (standardError > this._insufficientDataCutoff)
+    if (standardError == null || standardError > this._insufficientDataCutoff) {
       return TargetReportingLevel.InsufficientData;
-    if (delta >= standardError) return TargetReportingLevel.Above;
-    if (delta <= -standardError) return TargetReportingLevel.Below;
+    }
+    if (delta >= standardError) {
+      return TargetReportingLevel.Above;
+    }
+    if (delta <= -standardError) {
+      return TargetReportingLevel.Below;
+    }
     return TargetReportingLevel.Near;
   }
 }

--- a/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/target-report/target-report.component.ts
@@ -343,7 +343,10 @@ export class TargetReportComponent implements OnInit, ExportResults {
       group: this.displayedFor,
       schoolYear: this.schoolYear,
       averageScaleScore: Math.round(this.statistics.average),
-      standardError: Math.round(this.statistics.standardError),
+      standardError:
+        this.statistics.standardError != null
+          ? Math.round(this.statistics.standardError)
+          : null,
       subjectDefinition: this.subjectDefinition
     });
   }

--- a/webapp/src/main/webapp/src/app/dashboard/measured-assessment.ts
+++ b/webapp/src/main/webapp/src/app/dashboard/measured-assessment.ts
@@ -4,7 +4,7 @@ export interface MeasuredAssessment {
   readonly assessment: Assessment;
   readonly studentCountByPerformanceLevel: DetailsByPerformanceLevel[];
   readonly averageScaleScore: number;
-  readonly averageStandardError: number;
+  readonly averageStandardError?: number;
   readonly date: Date;
   readonly studentsTested: number;
 }

--- a/webapp/src/main/webapp/src/app/exam/model/scale-score.ts
+++ b/webapp/src/main/webapp/src/app/exam/model/scale-score.ts
@@ -1,5 +1,5 @@
 export interface ScaleScore {
   level: number;
-  standardError: number;
+  standardError?: number;
   score: number;
 }

--- a/webapp/src/main/webapp/src/app/report/aggregate-report.ts
+++ b/webapp/src/main/webapp/src/app/report/aggregate-report.ts
@@ -44,7 +44,7 @@ export interface AggregateReportRowAssessment {
 
 export interface AggregateReportRowMeasure {
   readonly avgScaleScore: number;
-  readonly avgStdErr: number;
+  readonly avgStdErr?: number;
   readonly level1Count: number;
   readonly level2Count: number;
   readonly level3Count: number;

--- a/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.html
+++ b/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.html
@@ -6,11 +6,11 @@
     }"
     >{{ _score ? _roundedScaleScore : '-' }}</span
   >
-  <span *ngIf="_score && _standardError" class="error-band pl-xs">{{
+  <span *ngIf="_score && _standardError != null" class="error-band pl-xs">{{
     'common.error-band-value' | translate: { errorBand: _roundedStandardError }
   }}</span>
   <span
-    *ngIf="_score && _standardError && infoEnabled"
+    *ngIf="_score && _standardError != null && infoEnabled"
     class="info-button"
     info-button
     content="{{ 'average-scale-score.scale-score-info' | translate }}"

--- a/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.ts
+++ b/webapp/src/main/webapp/src/app/shared/scale-score/scale-score.component.ts
@@ -20,7 +20,7 @@ export class ScaleScoreComponent {
   _score: number;
   _roundedScaleScore: number;
 
-  _standardError: number;
+  _standardError?: number;
   _roundedStandardError: number;
 
   @Input()


### PR DESCRIPTION
must test:
1. [x] aggregate report table scale scores

![image](https://user-images.githubusercontent.com/23462925/62664087-0a5d5100-b92f-11e9-893b-b1a1f9c0bf10.png)

![image](https://user-images.githubusercontent.com/23462925/62664143-4abccf00-b92f-11e9-814e-d555c2e68780.png)

2. [x] aggregate report table export csv standard error column values

![image](https://user-images.githubusercontent.com/23462925/62664119-3547a500-b92f-11e9-9df0-513ff1b5747e.png)

![image](https://user-images.githubusercontent.com/23462925/62664166-6627da00-b92f-11e9-9ad7-5fafde5e1a48.png)

3. [x] target aggregate report overview (summary block on the top right of the results page)

  Not sure a good query for this one

4. [x] longitudinal aggregate report data point popovers

![image](https://user-images.githubusercontent.com/23462925/62664060-ee59af80-b92e-11e9-8972-d5b8d1af84f3.png)

![image](https://user-images.githubusercontent.com/23462925/62664187-7a6bd700-b92f-11e9-85fb-28b5f64e2c21.png)

5. [x] target report exam result view (was not actually impacted by change)
6. [x] alternate score table (uses std error of mean - not null)
7. [x] overall score table (uses std error of mean - not null)
8. [x] student exam history page result table

![image](https://user-images.githubusercontent.com/23462925/62663806-e9483080-b92d-11e9-8cf6-033c4b6db8ba.png)

![image](https://user-images.githubusercontent.com/23462925/62663813-f1a06b80-b92d-11e9-9656-f8e0ba642c61.png)

![image](https://user-images.githubusercontent.com/23462925/62664484-90c66280-b930-11e9-8f73-8ac99a9b6897.png)

9. [x] results by student exam result table

![image](https://user-images.githubusercontent.com/23462925/62663859-172d7500-b92e-11e9-8a26-e2fa22c5c812.png)

![image](https://user-images.githubusercontent.com/23462925/62663872-23b1cd80-b92e-11e9-9460-edb256533472.png)

![image](https://user-images.githubusercontent.com/23462925/62664531-c3705b00-b930-11e9-9ea8-5d4e3f442bf4.png)

