### PR TITLE
RP-674: archive tenant configuration on tenant delete

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationRequestHandler.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationRequestHandler.java
@@ -7,5 +7,6 @@ public interface TenantAdministrationRequestHandler {
     void createSandbox(TenantConfiguration tenantConfiguration);
     void updateTenant(TenantConfiguration tenantConfiguration);
     void updateSandbox(TenantConfiguration tenantConfiguration);
+    void deleteTenant(TenantConfiguration tenantConfiguration);
     void deleteSandbox(TenantConfiguration tenantConfiguration);
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationRequestType.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationRequestType.java
@@ -4,6 +4,7 @@ public enum TenantAdministrationRequestType {
     CREATE_TENANT,
     CREATE_SANDBOX,
     DELETE_SANDBOX,
+    DELETE_TENANT,
     UPDATE_TENANT,
     UPDATE_SANDBOX
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultTenantAdministrationRequestHandler.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultTenantAdministrationRequestHandler.java
@@ -94,6 +94,12 @@ public class DefaultTenantAdministrationRequestHandler implements TenantAdminist
     }
 
     @Override
+    public void deleteTenant(TenantConfiguration tenantConfiguration) {
+        logger.debug("Sending DELETE_TENANT {}", tenantConfiguration);
+        sendAdministrationMessage(tenantConfiguration, TenantAdministrationRequestType.DELETE_TENANT);
+    }
+
+    @Override
     public void deleteSandbox(TenantConfiguration tenantConfiguration) {
         logger.debug("Sending DELETE_SANDBOX {}", tenantConfiguration);
         sendAdministrationMessage(tenantConfiguration, TenantAdministrationRequestType.DELETE_SANDBOX);
@@ -125,14 +131,17 @@ public class DefaultTenantAdministrationRequestHandler implements TenantAdminist
                 case CREATE_SANDBOX:
                     createSandboxAsync(tenantConfiguration);
                     break;
-                case DELETE_SANDBOX:
-                    deleteSandboxAsync(tenantConfiguration);
-                    break;
                 case UPDATE_TENANT:
                     updateTenantAsync(tenantConfiguration);
                     break;
                 case UPDATE_SANDBOX:
                     updateSandboxAsync(tenantConfiguration);
+                    break;
+                case DELETE_TENANT:
+                    deleteTenantAsync(tenantConfiguration);
+                    break;
+                case DELETE_SANDBOX:
+                    deleteSandboxAsync(tenantConfiguration);
                     break;
             }
         } catch (Exception e) {
@@ -235,6 +244,29 @@ public class DefaultTenantAdministrationRequestHandler implements TenantAdminist
             //catch all / rethrow to update status
             String stackTrace = ExceptionUtils.getStackTrace(e);
             tenantAdministrationStatusService.updateStatus(tenantKey, UPDATE_FAILED, stackTrace);
+            throw e;
+        }
+    }
+
+    private void deleteTenantAsync(final TenantConfiguration tenantConfiguration) {
+        final String tenantKey = tenantConfiguration.getTenant().getKey();
+        final Tenant tenant = tenantConfiguration.getTenant();
+
+        try {
+            tenantAdministrationStatusService.putStatus(tenantKey, DELETE_STARTED, tenant);
+            logger.debug("delete tenant starting {} {}", tenantKey, tenantConfiguration);
+
+            logger.debug("archive tenant configuration {}", tenantKey);
+            tenantAdministrationStatusService.updateStatus(tenantKey, DELETE_PERSISTING_CONFIGURATION);
+            tenantConfigurationPersistenceService.deleteTenant(tenantKey);
+
+            logger.debug("delete sandbox publish changes {}", tenantKey);
+            tenantAdministrationStatusService.updateStatus(tenantKey, DELETE_PUBLISHING_CONFIGURATION_CHANGES);
+            configServerClient.postMonitor();
+        } catch (Exception e) {
+            //catch all / rethrow to update status
+            String stackTrace = ExceptionUtils.getStackTrace(e);
+            tenantAdministrationStatusService.updateStatus(tenantKey, DELETE_FAILED, stackTrace);
             throw e;
         }
     }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
@@ -128,6 +128,7 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
         }
     }
 
+    @Override
     public void deleteSandbox(final String tenantKey) {
         if (tenantKey == null || !tenantKey.contains("_S")) {
             throw new TenantConfigurationPersistenceException("Only sandboxes can be deleted, invalid tenant key " + tenantKey);
@@ -164,6 +165,52 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
                     .call();
         } catch (final IOException | GitAPIException e) {
             throw new TenantConfigurationPersistenceException("Unable to delete sandbox configuration " + tenantKey, e);
+        }
+    }
+
+    @Override
+    public void deleteTenant(final String tenantKey) {
+        if (tenantKey == null || tenantKey.contains("_S")) {
+            throw new TenantConfigurationPersistenceException("Only regular tenants can be deleted by this method, invalid tenant key " + tenantKey);
+        }
+
+        forceLocalRepositoryToCleanState();
+
+        final UsernamePasswordCredentialsProvider credentialsProvider = credentialsProvider();
+
+        try {
+            final File tenantDirectory = tenantDirectory(tenantKey);
+            final File archiveDirectory = archiveDirectory(tenantKey);
+
+            logger.debug("git mv {} {} (not currently implemented by library so broken into steps)",
+                    tenantDirectory.getName(), archiveDirectory.getName());
+
+            logger.debug("mv {} {}", tenantDirectory.getName(), archiveDirectory.getName());
+            FileUtils.moveDirectory(tenantDirectory, archiveDirectory);
+
+            final Git git = Git.open(localRepository());
+            logger.debug("git rm -r {}", tenantDirectory.getName());
+            git.rm()
+                    .addFilepattern(tenantDirectory.getName())
+                    .call();
+
+            logger.debug("git add {}", archiveDirectory.getName());
+            git.add()
+                    .addFilepattern(archiveDirectory.getName())
+                    .call();
+
+            git.commit()
+                    .setAuthor(tenantConfigurationPersistenceProperties.getAuthor(),
+                            tenantConfigurationPersistenceProperties.getAuthorEmail())
+                    .setMessage("archiving tenant " + tenantKey + " configuration.")
+                    .call();
+
+            logger.debug("git push");
+            git.push()
+                    .setCredentialsProvider(credentialsProvider)
+                    .call();
+        } catch (final IOException | GitAPIException e) {
+            throw new TenantConfigurationPersistenceException("Unable to delete tenant " + tenantKey, e);
         }
     }
 
@@ -275,6 +322,11 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
 
     private File tenantDirectory(final String tenantKey) {
         final String pathname = localRepository().getPath() + File.separator + "tenant-" + tenantKey;
+        return new File(pathname);
+    }
+
+    private File archiveDirectory(final String tenantKey) {
+        final String pathname = localRepository().getPath() + File.separator + "archive-" + tenantKey;
         return new File(pathname);
     }
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceService.java
@@ -27,6 +27,8 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
     private static final String ConfigFileName = "application.yml";
     private static final String LocalizationName = "en.json";
     private static final String CIPHER = "{cipher}";
+    private static final int ARCHIVE_RETRIES = 10;
+
     private final ObjectMapper ymlMapper;
 
     private final TenantConfigurationPersistenceProperties tenantConfigurationPersistenceProperties;
@@ -180,7 +182,7 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
 
         try {
             final File tenantDirectory = tenantDirectory(tenantKey);
-            final File archiveDirectory = archiveDirectory(tenantKey);
+            final File archiveDirectory = nextAvailableArchiveDirectory(tenantKey);
 
             logger.debug("git mv {} {} (not currently implemented by library so broken into steps)",
                     tenantDirectory.getName(), archiveDirectory.getName());
@@ -209,7 +211,7 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
             git.push()
                     .setCredentialsProvider(credentialsProvider)
                     .call();
-        } catch (final IOException | GitAPIException e) {
+        } catch (final IOException | GitAPIException | IllegalStateException e) {
             throw new TenantConfigurationPersistenceException("Unable to delete tenant " + tenantKey, e);
         }
     }
@@ -325,9 +327,24 @@ public class GitTenantConfigurationPersistenceService implements TenantConfigura
         return new File(pathname);
     }
 
-    private File archiveDirectory(final String tenantKey) {
-        final String pathname = localRepository().getPath() + File.separator + "archive-" + tenantKey;
-        return new File(pathname);
+    private File nextAvailableArchiveDirectory(final String tenantKey) {
+        File archiveDir = new File(localRepository(), "archive-" + tenantKey);
+        if (!archiveDir.exists()) {
+            return archiveDir;
+        }
+
+        // This will rarely if ever happen. It would be caused if a tenant was deleted, the archived
+        // configuration not cleaned up, another tenant with the same key created, and then that
+        // tenant also deleted. In this case we'll try to archive to archive-<n>-<tenantKey>, where
+        // <n> is a number between 1 and 9. If all these folders already exist, throw an error.
+        for (int i = 1; i < ARCHIVE_RETRIES; i++) {
+            archiveDir = new File(localRepository(), "archive-" + i + "-" +tenantKey);
+            if (!archiveDir.exists()) {
+                return archiveDir;
+            }
+        }
+
+        throw new IllegalStateException("Exceeded retries; cannot archive configuration file");
     }
 
     private File applicationYmlFile(final String tenantKey) {

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/TenantConfigurationPersistenceService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/git/TenantConfigurationPersistenceService.java
@@ -5,4 +5,5 @@ import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
 public interface TenantConfigurationPersistenceService {
     void saveTenantConfiguration(TenantConfiguration tenantConfiguration);
     void deleteSandbox(String tenantKey);
+    void deleteTenant(String tenantKey);
 }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantService.java
@@ -97,18 +97,6 @@ public class DefaultTenantService implements TenantService {
     }
 
     @Override
-    public void deleteTenant(final String tenantKey) {
-        Optional<TenantConfiguration> tenantConfigurationOptional =
-                tenantConfigurationViewService.findActiveTenantConfiguration(tenantKey);
-        TenantConfiguration tenantConfiguration = tenantConfigurationOptional.orElseThrow(() -> new IllegalArgumentException("Tenant key not found"));
-        if (tenantConfiguration.getTenant().isSandbox()) {
-            tenantAdministrationRequestHandler.deleteSandbox(tenantConfiguration);
-        } else {
-            throw new IllegalArgumentException("Only sandboxes can be deleted");
-        }
-    }
-
-    @Override
     public void updateTenant(final TenantConfiguration tenantConfiguration) {
         logger.debug("Updating tenant {}", tenantConfiguration.getTenant().getKey());
         final boolean isSandbox = tenantConfiguration.getTenant().isSandbox();
@@ -120,6 +108,18 @@ public class DefaultTenantService implements TenantService {
             tenantValidationService.tenantUpdateValidation(tenantConfiguration);
             TenantConfiguration updateTenantConfiguration = generateUpdateTenantConfiguration(tenantConfiguration);
             tenantAdministrationRequestHandler.updateTenant(updateTenantConfiguration);
+        }
+    }
+
+    @Override
+    public void deleteTenant(final String tenantKey) {
+        Optional<TenantConfiguration> tenantConfigurationOptional =
+                tenantConfigurationViewService.findActiveTenantConfiguration(tenantKey);
+        TenantConfiguration tenantConfiguration = tenantConfigurationOptional.orElseThrow(() -> new IllegalArgumentException("Tenant key not found"));
+        if (tenantConfiguration.getTenant().isSandbox()) {
+            tenantAdministrationRequestHandler.deleteSandbox(tenantConfiguration);
+        } else {
+            tenantAdministrationRequestHandler.deleteTenant(tenantConfiguration);
         }
     }
 

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultTenantAdministrationRequestHandlerTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/administration/impl/DefaultTenantAdministrationRequestHandlerTest.java
@@ -116,6 +116,27 @@ public class DefaultTenantAdministrationRequestHandlerTest {
     }
 
     @Test
+    public void deleteTenant() {
+        defaultTenantAdministrationRequestHandler.deleteTenant(new TenantConfiguration());
+        verify(tenantAdministrationOutput).send(isA(GenericMessage.class));
+    }
+
+    @Test
+    public void deleteTenantAsync() {
+        TenantConfiguration tenantConfiguration = TenantConfiguration.builder()
+                .tenant(Tenant.builder()
+                        .sandbox(false)
+                        .id("XX")
+                        .key("XX")
+                        .build())
+                .build();
+        defaultTenantAdministrationRequestHandler.tenantAdministrationDispatcher(createMessage(tenantConfiguration, TenantAdministrationRequestType.DELETE_TENANT));
+        verify(tenantConfigurationPersistenceService).deleteTenant(tenantConfiguration.getTenant().getKey());
+        verify(configServerClient).postMonitor();
+    }
+
+
+    @Test
     public void createSandbox() {
         defaultTenantAdministrationRequestHandler.createSandbox(new TenantConfiguration());
         verify(tenantAdministrationOutput).send(isA(GenericMessage.class));
@@ -153,6 +174,8 @@ public class DefaultTenantAdministrationRequestHandlerTest {
         defaultTenantAdministrationRequestHandler.tenantAdministrationDispatcher(createMessage(tenantConfiguration, TenantAdministrationRequestType.DELETE_SANDBOX));
         verify(sandboxArchiveRemovalService).remove(tenantConfiguration.getTenant().getKey());
         verify(tenantDatabaseAdminOrchestrationService).deleteSandboxDatabases(any());
+        verify(tenantConfigurationPersistenceService).deleteSandbox(tenantConfiguration.getTenant().getKey());
+
         verify(configServerClient).postMonitor();
     }
 

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceServiceTest.java
@@ -244,6 +244,39 @@ public class GitTenantConfigurationPersistenceServiceTest {
         assertThat(FileUtils.getFile(localizationWorkingFilePath).exists()).isFalse();
     }
 
+    @Test
+    public void deleteTenantShouldRenameConfigurationDirectory() throws Exception {
+        Tenant tenant = Tenant.builder()
+                .id("CAX")
+                .key("CAX")
+                .name("CAX Test")
+                .build();
+
+        ExamProcessorValidationPropertiesTenant validation = new ExamProcessorValidationPropertiesTenant();
+        validation.setRequiredDataElements(Arrays.asList("FirstName", "LastOrSurname"));
+
+        TenantConfiguration tenantConfiguration = TenantConfiguration.builder()
+                .tenant(tenant)
+                .archiveProperties(new ArchivePropertiesTenant()) // needed for saveTenantConfiguration()
+                .build();
+
+        logger.debug("localRepositoryDirectory {}", localRepositoryDirectory.getPath());
+
+        tenantConfigurationPersistenceService.saveTenantConfiguration(tenantConfiguration);
+        cloneRemoteStateToWorking();
+
+        final File tenantFolder = new File(remoteRepositoryDirectoryWorking, "tenant-" + tenant.getKey());
+        final File archiveFolder = new File(remoteRepositoryDirectoryWorking, "archive-" + tenant.getKey());
+
+        assertThat(FileUtils.getFile(tenantFolder).exists()).isTrue();
+        assertThat(FileUtils.getFile(archiveFolder).exists()).isFalse();
+
+        tenantConfigurationPersistenceService.deleteTenant("CAX");
+        pullFromRemoteToWorking();
+
+        assertThat(FileUtils.getFile(tenantFolder).exists()).isFalse();
+        assertThat(FileUtils.getFile(archiveFolder).exists()).isTrue();
+    }
 
     @Test
     public void writeLocalizationFileShouldWriteAFile() throws Exception {

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/git/GitTenantConfigurationPersistenceServiceTest.java
@@ -6,6 +6,13 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
 import org.opentestsystem.rdw.admin.multitenant.configserver.ConfigServerClient;
 import org.opentestsystem.rdw.admin.multitenant.model.TenantConfiguration;
 import org.opentestsystem.rdw.admin.service.impl.RDWDataSourceNames;
@@ -16,14 +23,6 @@ import org.opentestsystem.rdw.multitenant.datasource.DataSourceUrlParts;
 import org.opentestsystem.rdw.multitenant.validation.ExamProcessorValidationPropertiesTenant;
 import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingPropertiesTenant;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
-
-import java.io.File;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -37,11 +36,8 @@ public class GitTenantConfigurationPersistenceServiceTest {
     private GitTenantConfigurationPersistenceService tenantConfigurationPersistenceService;
 
     private TenantConfigurationPersistenceProperties tenantConfigurationPersistenceProperties;
-    private ConfigServerClient configServerClient;
-    private Yaml applicationTenantConfigurationPersistenceYaml;
 
     private File localRepositoryDirectory;
-    private File remoteRepositoryDirectoryBare;
     private File remoteRepositoryDirectoryWorking;
     private final String encryptedPassword = "{cipher}AE0983AZJD0019";
     private final String testPassword = "testPassword1";
@@ -56,13 +52,13 @@ public class GitTenantConfigurationPersistenceServiceTest {
         tenantConfigurationPersistenceProperties.setAuthor("test");
         tenantConfigurationPersistenceProperties.setAuthorEmail("test@example.com");
 
-        configServerClient = mock(ConfigServerClient.class);
+        final ConfigServerClient configServerClient = mock(ConfigServerClient.class);
         when(configServerClient.encryptPassword(testPassword)).thenReturn(encryptedPassword);
 
         tenantConfigurationPersistenceService = new GitTenantConfigurationPersistenceService(tenantConfigurationPersistenceProperties, configServerClient);
 
         URL remoteRepositoryURL = new URL(tenantConfigurationPersistenceProperties.getRemoteRepositoryUri());
-        remoteRepositoryDirectoryBare = FileUtils.toFile(remoteRepositoryURL);
+        final File remoteRepositoryDirectoryBare = FileUtils.toFile(remoteRepositoryURL);
         remoteRepositoryDirectoryWorking = FileUtils.getFile(remoteRepositoryDirectoryBare.getPath() + "_working");
 
         //set up bare empty repository to simulate remote
@@ -277,6 +273,48 @@ public class GitTenantConfigurationPersistenceServiceTest {
         assertThat(FileUtils.getFile(tenantFolder).exists()).isFalse();
         assertThat(FileUtils.getFile(archiveFolder).exists()).isTrue();
     }
+
+    @Test
+    public void deleteTenantShouldResolveArchiveConflicts() throws Exception {
+        Tenant tenant = Tenant.builder()
+                .id("CAX")
+                .key("CAX")
+                .name("CAX Test")
+                .build();
+
+        ExamProcessorValidationPropertiesTenant validation = new ExamProcessorValidationPropertiesTenant();
+        validation.setRequiredDataElements(Arrays.asList("FirstName", "LastOrSurname"));
+
+        TenantConfiguration tenantConfiguration = TenantConfiguration.builder()
+                .tenant(tenant)
+                .archiveProperties(new ArchivePropertiesTenant()) // needed for saveTenantConfiguration()
+                .build();
+
+        logger.debug("localRepositoryDirectory {}", localRepositoryDirectory.getPath());
+
+        // Save, delete, and save again.
+        tenantConfigurationPersistenceService.saveTenantConfiguration(tenantConfiguration);
+        tenantConfigurationPersistenceService.deleteTenant("CAX");
+        tenantConfigurationPersistenceService.saveTenantConfiguration(tenantConfiguration);
+
+        cloneRemoteStateToWorking();
+
+        final File tenantFolder = new File(remoteRepositoryDirectoryWorking, "tenant-" + tenant.getKey());
+        final File archiveFolder = new File(remoteRepositoryDirectoryWorking, "archive-" +tenant.getKey());
+        final File secondArchiveFolder = new File(remoteRepositoryDirectoryWorking, "archive-1-" +tenant.getKey());
+
+        assertThat(FileUtils.getFile(tenantFolder).exists()).isTrue();
+        assertThat(FileUtils.getFile(archiveFolder).exists()).isTrue();
+        assertThat(FileUtils.getFile(secondArchiveFolder).exists()).isFalse();
+
+        tenantConfigurationPersistenceService.deleteTenant("CAX");
+        pullFromRemoteToWorking();
+
+        assertThat(FileUtils.getFile(tenantFolder).exists()).isFalse();
+        assertThat(FileUtils.getFile(archiveFolder).exists()).isTrue();
+        assertThat(FileUtils.getFile(secondArchiveFolder).exists()).isTrue();
+    }
+
 
     @Test
     public void writeLocalizationFileShouldWriteAFile() throws Exception {

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantServiceTest.java
@@ -96,11 +96,19 @@ public class DefaultTenantServiceTest {
     }
 
     @Test
-    public void deleteTenantShouldDeleteTenant() {
+    public void deleteTenantWithSandboxKeyShouldDeleteSandbox() {
         TenantConfiguration sandboxConfiguration = sandboxConfigurations.get("AA_S001");
         when(tenantConfigurationViewService.findActiveTenantConfiguration("AA_S001")).thenReturn(Optional.of(sandboxConfiguration));
         defaultTenantService.deleteTenant("AA_S001");
         verify(tenantAdministrationRequestHandler).deleteSandbox(sandboxConfiguration);
+    }
+
+    @Test
+    public void deleteTenantWithNonSandboxKeyShouldDeleteTenant() {
+        TenantConfiguration tenantConfiguration = tenantConfigurations.get("AA");
+        when(tenantConfigurationViewService.findActiveTenantConfiguration("AA")).thenReturn(Optional.of(tenantConfiguration));
+        defaultTenantService.deleteTenant("AA");
+        verify(tenantAdministrationRequestHandler).deleteTenant(tenantConfiguration);
     }
 
     @Test

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-form/tenant-form.component.html
@@ -39,7 +39,7 @@
                 }}
               </button>
             </div>
-            <ng-container *ngIf="value.type === 'SANDBOX' && mode === 'update'">
+            <ng-container *ngIf="mode === 'update'">
               <div class="btn-group" dropdown>
                 <button
                   id="dropdown-button"

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1428,7 +1428,7 @@
         "head": "Delete <strong>{{label}} ({{code}})</strong>?",
         "body": {
           "SANDBOX": "Are you sure you want to delete sandbox <strong>{{label}} ({{code}})</strong>?",
-          "TENANT": "Are you sure you want to delete tenant <strong>{{label}} ({{code}})</strong>?"
+          "TENANT": "<strong>WARNING!!! This is a tenant, not a sandbox!</strong><br>Are you really sure you want to delete tenant <strong>{{label}} ({{code}})</strong>?"
         }
       }
     }


### PR DESCRIPTION
Backend component of Tenant Deletion, which will only archive the tenant configuration in gitlab. The other resources (databases, archives, etc.) will be left in place.

I did a sort of end-to-end test of this, even though I can't create a non-sandbox tenant locally, by manually creating a configuration in my forked version of the config repo and then sending a manual request to the tenant controller. It renamed my tentant-XX folder to archive-XX and checked in the changes as expected. However, the tenant list in the UI still showed tenant-XX until I completely restarted. Logging out and in again didn't work. Neither did stopping the config-server container and restarting. I'm assuming there's a cache not being cleared somewhere, but I'm not sure if that's a missing call, or just to be expected when running in local development.