### PR TITLE
adds edit icon on hover of tenant in tenant list

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.html
@@ -35,6 +35,7 @@
       >
         {{ 'common.action.delete' | translate }}
       </button>
+      <i class="edit-icon fa fa-edit"></i>
     </div>
   </div>
   <div class="body">

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.less
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.less
@@ -3,9 +3,12 @@
 
 a {
   display: block;
-  padding: 30px 30px 15px 30px;
+  padding: 30px 15px 15px 30px;
   text-decoration: none;
   color: inherit;
+  .edit-icon {
+    visibility: hidden;
+  }
   &:not(.status-active):not(.status-update_failed) {
     pointer-events: none;
     a,
@@ -17,6 +20,9 @@ a {
   &.status-update_failed {
     &:hover {
       background-color: @gray-lightest;
+      .edit-icon {
+        visibility: visible;
+      }
     }
     &:active {
       background-color: @gray-lighter;
@@ -52,4 +58,9 @@ h2 {
 
 .label {
   font-size: 14px;
+  height: 24px;
+}
+
+.edit-icon {
+  font-size: 26px;
 }


### PR DESCRIPTION
![edit-icon-hover](https://user-images.githubusercontent.com/23462925/62898753-1ff5c080-bd0b-11e9-975e-909aba640282.gif)

Can't tell on the GIF but the item also highlights on hover as it always did