### PR TITLE
add Jackson DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES to false

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/configserver/DefaultConfigServerClient.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/configserver/DefaultConfigServerClient.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.admin.multitenant.configserver;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
@@ -38,6 +39,7 @@ public class DefaultConfigServerClient implements ConfigServerClient {
         this.configServerUri = configServerUri;
         ymlMapper = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
         ymlMapper.findAndRegisterModules();
+        ymlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         placeholderHelper = new PropertyPlaceholderHelper("${", "}");
     }
 


### PR DESCRIPTION
At least partial fix for RP-699

json now being serialized (tested locally with CA)

http://localhost:8080/api/admin-service/tenants/CA

```
  "artClient": {
    "oauth2": {
      "grantType": "password",
      "clientAuthenticationScheme": "header",
      "tokenName": "access_token",
      "password": "password",
      "authenticationScheme": "header",
      "clientOnly": false,
      "authenticationRequired": false,
      "scoped": false
    }
  },
  "importServiceClient": {
    "oauth2": {
      "grantType": "password",
      "clientAuthenticationScheme": "header",
      "tokenName": "access_token",
      "password": "password",
      "authenticationScheme": "header",
      "clientOnly": false,
      "authenticationRequired": false,
      "scoped": false
    }
  },
```