### PR TITLE
Feature/676 tenant create errors

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationStatusContext.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/administration/TenantAdministrationStatusContext.java
@@ -21,7 +21,6 @@ public class TenantAdministrationStatusContext {
 
     private String stackTrace;
 
-    @JsonIgnore
     private Instant updated;
 
     public Tenant getTenant() {

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
@@ -146,6 +146,8 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
                                 .tenant(entry.getValue().getTenant())
                                 .administrationStatus(TenantAdministrationStatusContext.builder()
                                         .tenantAdministrationStatus(entry.getValue().getTenantAdministrationStatus())
+                                        .message(entry.getValue().getMessage())
+                                        .stackTrace(entry.getValue().getStackTrace())
                                         .build())
                                 .build()));
     }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantConfigurationViewService.java
@@ -148,6 +148,7 @@ public class DefaultTenantConfigurationViewService implements TenantConfiguratio
                                         .tenantAdministrationStatus(entry.getValue().getTenantAdministrationStatus())
                                         .message(entry.getValue().getMessage())
                                         .stackTrace(entry.getValue().getStackTrace())
+                                        .updated(entry.getValue().getUpdated())
                                         .build())
                                 .build()));
     }

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.html
@@ -39,7 +39,12 @@
     </ng-container>
     <ng-template #notProcessing>
       <div class="menu" *ngIf="status.failed">
-        <div class="label border-only red">
+        <div
+          class="label border-only red"
+          [popover]="errorsPopover"
+          container="body"
+          triggers="mouseenter:mouseleave"
+        >
           <i class="fa fa-warning"></i>
           {{ 'common.tenant-status.' + tenant.status | translate }}
         </div>
@@ -70,3 +75,14 @@
     </strong>
   </div>
 </a>
+
+<ng-template #errorsPopover>
+  <div>
+    <p>
+      {{ tenant.error.message }}
+    </p>
+    <p>
+      {{ 'tenant-link.see-logs' | translate }}
+    </p>
+  </div>
+</ng-template>

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.less
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/tenant-link/tenant-link.component.less
@@ -18,7 +18,8 @@ a {
     color: @gray-dark;
     pointer-events: none;
     a,
-    button {
+    button,
+    .label {
       pointer-events: all;
     }
   }

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenant-configuration.ts
@@ -54,6 +54,16 @@ export interface TenantConfiguration {
    * The current status of this tenant.
    */
   status?: TenantStatus;
+
+  /**
+   * The error message and stack trace for when there is a failure tenant status
+   */
+  error?: TenantConfigurationError;
+
+  /**
+   * The time of the last update
+   */
+  updatedOn?: Date;
 }
 
 export interface DataSet {
@@ -66,4 +76,12 @@ export interface DataSet {
    * A more human-readable label for a data template
    */
   label: string;
+}
+
+/**
+ * Represents a tenant operation exception
+ */
+export interface TenantConfigurationError {
+  message: string;
+  stackTrace?: string;
 }

--- a/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
+++ b/webapp/src/main/webapp/src/app/admin/tenant/model/tenants.ts
@@ -124,7 +124,12 @@ export function toTenant(
       sandbox,
       sandboxDataset: dataSetId
     },
-    administrationStatus: { tenantAdministrationStatus: status },
+    administrationStatus: {
+      message,
+      stackTrace,
+      updated,
+      tenantAdministrationStatus: status
+    },
     parentTenantKey: parentTenantCode,
     localization: localizations
   } = serverTenant;
@@ -137,6 +142,11 @@ export function toTenant(
     description,
     type,
     status,
+    error: {
+      message,
+      stackTrace
+    },
+    updatedOn: new Date(updated),
     configurations: toConfigurations(serverTenant, type),
     localizations: valued(flatten(localizations || {})),
     parentTenantCode,

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -1570,6 +1570,9 @@
       "true": "True"
     }
   },
+  "tenant-link": {
+    "see-logs": "See application logs for more details."
+  },
   "tenant-localization-form": {
     "column": {
       "key": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23462925/63187133-fb535e80-c012-11e9-9ec4-60f4455d2b73.png)

I didn't stick the stacktrace in there yet because i couldn't really think of a nice way to do it. Something would need to be a button that you can click to bring you to a stack trace view or modal but just making the label that button felt non-intuitive.
What do you guys think? should the label open a page with the stack trace?