### PR TITLE
RP-721: allow configurable logout redirect that skips saml logout

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -12,6 +12,7 @@ import org.opentestsystem.rdw.security.Permission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.saml.SAMLCredential;
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService;
@@ -21,6 +22,7 @@ import javax.validation.constraints.NotNull;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opentestsystem.rdw.reporting.common.web.security.GrantedAuthorities.toGrantedAuthorities;
 
 @Service
@@ -29,6 +31,9 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
     private static final Logger logger = LoggerFactory.getLogger(SamlUserDetailsService.class);
     private final AuthorityService authorityService;
     private final TenantProperties tenantProperties;
+
+    @Value("${reporting.logout-redirect-url:}")
+    private String logoutRedirectUrl;
 
     @Autowired
     public SamlUserDetailsService(
@@ -45,6 +50,7 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
         final String lastName = credential.getAttributeAsString("sn");
         final String email = credential.getAttributeAsString("mail");
         final String[] encodedGrants = credential.getAttributeAsStringArray("sbacTenancyChain");
+        final String logoutUrl = isBlank(logoutRedirectUrl) ? "/saml/logout" : "/logout-redirect";
 
         // for SmarterBalanced SSO the user lookup value (aka username aka login) is configured to be "mail"
         final String username = email;
@@ -79,7 +85,7 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
                                 .id(stateId)
                                 .name(tenantName)
                                 .sandbox(false)
-                                .logoutUrl("/saml/logout")
+                                .logoutUrl(logoutUrl)
                                 .logoutSuccessUrl("/landing")
                                 .build()
                 )

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -1,12 +1,14 @@
 package org.opentestsystem.rdw.reporting.web;
 
-import org.opentestsystem.rdw.reporting.common.security.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.view.RedirectView;
+
+import org.opentestsystem.rdw.reporting.common.security.User;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 
@@ -20,6 +22,9 @@ public class ViewController implements ErrorController {
 
     @Value("${reporting.landing-page-url:}")
     private String landingPageUrl;
+
+    @Value("${reporting.logout-redirect-url:}")
+    private String logoutRedirectUrl;
 
     /**
      * Public routes
@@ -40,6 +45,14 @@ public class ViewController implements ErrorController {
             return this.accessDeniedUrl;
         }
         return Index;
+    }
+
+    @PostMapping("/logout-redirect")
+    public RedirectView logoutRedirect() {
+        if (!isBlank(logoutRedirectUrl)) {
+            return new RedirectView(logoutRedirectUrl);
+        }
+        return new RedirectView("/");
     }
 
     /**


### PR DESCRIPTION
A bit quick-and-dirty, but should do the job. (Well, dirty anyway. It took me an unreasonable amount of trial-and-error to get it working.) If reporting.logout-redirect-url is set, the logout will redirect to that URL instead of performing /saml/logout. However, the access-denied message hard-codes a link to /saml/logout, and at the moment, that's still there.