### PR TITLE
RP-726 Show summary metrics about each tenant in UI

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/multitenant/service/impl/DefaultTenantService.java
@@ -177,9 +177,6 @@ public class DefaultTenantService implements TenantService {
             try {
                 TenantContextHolder.setTenantId(tenant.getId());
                 result = metricsRepository.findAllMetrics();
-            } catch (Exception e) {
-                //rethrow just need to make sure context is clear or odd behavior could occur
-                throw e;
             } finally {
                 TenantContextHolder.clear();
             }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/status/DatabaseStatusIndicator.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/status/DatabaseStatusIndicator.java
@@ -9,7 +9,6 @@ import org.opentestsystem.rdw.common.status.StatusIndicator;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,21 +51,23 @@ public class DatabaseStatusIndicator extends AbstractStatusIndicator {
     @Override
     protected void doStatusCheck(final Status.Builder builder, final int level) {
         for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
+            try {
+                TenantContextHolder.setTenantId(tenant.getId());
 
-            final Status.Builder opBuilder = Status.builder().detail("schema", "warehouse").detail("type", "READ");
-            final List<String> codes = responseTime(opBuilder, 50, () ->
-                    warehouseJdbcTemplate.getJdbcOperations().queryForList(sqlReadTest, String.class));
-            if (codes.size() != ImportStatus.values().length) {
-                opBuilder.rating(Rating.Warning);
-                opBuilder.detail("warning", "import_status table not loaded properly");
+                final Status.Builder opBuilder = Status.builder().detail("schema", "warehouse").detail("type", "READ");
+                final List<String> codes = responseTime(opBuilder, 50, () ->
+                        warehouseJdbcTemplate.getJdbcOperations().queryForList(sqlReadTest, String.class));
+                if (codes.size() != ImportStatus.values().length) {
+                    opBuilder.rating(Rating.Warning);
+                    opBuilder.detail("warning", "import_status table not loaded properly");
+                }
+
+                final List<Status> ops = newArrayList(opBuilder.build());
+                builder.detail("databaseOperations - " + tenant.getId(), ops);
+                builder.worstRating(ops);
+            } finally {
+                TenantContextHolder.clear();
             }
-
-            final List<Status> ops = newArrayList(opBuilder.build());
-            builder.detail("databaseOperations - " + tenant.getId(), ops);
-            builder.worstRating(ops);
-
-            TenantContextHolder.clear();
         }
     }
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/QueryPoolExecutor.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/QueryPoolExecutor.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.olap.service.impl;
 
+import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -7,8 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 
 /**
  * Configuration for thread pool to run sql queries in parallel
@@ -38,8 +37,13 @@ public class QueryPoolExecutor {
         public void execute(final Runnable task) {
             final String tenantId = TenantContextHolder.getTenantId();
             super.execute(() -> {
-                TenantContextHolder.setTenantId(tenantId);
-                task.run();
+                try {
+                    TenantContextHolder.setTenantId(tenantId);
+                    task.run();
+                } finally {
+                    TenantContextHolder.clear();
+                    ;
+                }
             });
         }
 
@@ -47,8 +51,12 @@ public class QueryPoolExecutor {
         public void execute(final Runnable task, final long startTimeout) {
             final String tenantId = TenantContextHolder.getTenantId();
             super.execute(() -> {
-                TenantContextHolder.setTenantId(tenantId);
-                task.run();
+                try {
+                    TenantContextHolder.setTenantId(tenantId);
+                    task.run();
+                } finally {
+                    TenantContextHolder.clear();
+                }
             }, startTimeout);
         }
     }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/status/DatabaseStatusIndicator.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/status/DatabaseStatusIndicator.java
@@ -8,7 +8,6 @@ import org.opentestsystem.rdw.common.status.StatusIndicator;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -47,13 +46,15 @@ public class DatabaseStatusIndicator extends AbstractStatusIndicator {
     @Override
     protected void doStatusCheck(final Status.Builder builder, final int level) {
         for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
+            try {
+                TenantContextHolder.setTenantId(tenant.getId());
 
-            final List<Status> statuses = newArrayList(getOlapReadStatus());
-            builder.detail("databaseOperations - " + tenant.getId(), statuses);
-            builder.worstRating(statuses);
-
-            TenantContextHolder.clear();
+                final List<Status> statuses = newArrayList(getOlapReadStatus());
+                builder.detail("databaseOperations - " + tenant.getId(), statuses);
+                builder.worstRating(statuses);
+            } finally {
+                TenantContextHolder.clear();
+            }
         }
     }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/StaticTenantIdUtil.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/multitenant/StaticTenantIdUtil.java
@@ -19,7 +19,7 @@ public class StaticTenantIdUtil {
      * @return tenantId Option
      */
     public static Optional<String> tenantId() {
-        return Stream.of(tenantIdFromSecurityContext(), tenantIdFromTenantContext())
+        return Stream.of(tenantIdFromTenantContext(), tenantIdFromSecurityContext())
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst();

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/status/DatabaseStatusIndicator.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/status/DatabaseStatusIndicator.java
@@ -9,7 +9,6 @@ import org.opentestsystem.rdw.common.status.StatusIndicator;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -52,21 +51,23 @@ public class DatabaseStatusIndicator extends AbstractStatusIndicator {
     @Override
     protected void doStatusCheck(final Status.Builder builder, final int level) {
         for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
+            try {
+                TenantContextHolder.setTenantId(tenant.getId());
 
-            final Status.Builder opBuilder = Status.builder().detail("schema", "reporting").detail("type", "READ");
-            final List<String> codes = responseTime(opBuilder, 50, () -> jdbcOperations.queryForList(sqlReadTest, String.class));
-            if (codes.size() != AssessmentType.values().length) {
-                opBuilder.rating(Rating.Warning);
-                opBuilder.detail("warning", "asmt_type table not loaded properly");
+                final Status.Builder opBuilder = Status.builder().detail("schema", "reporting").detail("type", "READ");
+                final List<String> codes = responseTime(opBuilder, 50, () -> jdbcOperations.queryForList(sqlReadTest, String.class));
+                if (codes.size() != AssessmentType.values().length) {
+                    opBuilder.rating(Rating.Warning);
+                    opBuilder.detail("warning", "asmt_type table not loaded properly");
+                }
+
+                final List<Status> ops = newArrayList(opBuilder.build());
+
+                builder.detail("databaseOperations - " + tenant.getId(), ops);
+                builder.worstRating(ops);
+            } finally {
+                TenantContextHolder.clear();
             }
-
-            final List<Status> ops = newArrayList(opBuilder.build());
-
-            builder.detail("databaseOperations - " + tenant.getId(), ops);
-            builder.worstRating(ops);
-
-            TenantContextHolder.clear();
         }
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/sandbox/DefaultSandboxService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/sandbox/DefaultSandboxService.java
@@ -64,8 +64,8 @@ public class DefaultSandboxService implements SandboxService {
         SecurityContextHolder.getContext().setAuthentication(null);
 
         for (final Tenant sandbox : sandboxes) {
-            TenantContextHolder.setTenantId(sandbox.getId());
             try {
+                TenantContextHolder.setTenantId(sandbox.getId());
                 rolesBySandboxKey.put(sandbox.getKey(), sandboxRoleRepository.findAll());
             } catch (final Exception e) {
                 logger.warn("Failed to retrieve sandbox roles for {}: {}", sandbox.toString(), e.getMessage());

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/saml/SamlUserDetailsService.java
@@ -102,21 +102,21 @@ public class SamlUserDetailsService implements SAMLUserDetailsService {
         }
 
         // set tenant in thread local context during user info lookup
-        TenantContextHolder.setTenantId(stateId);
-        final Set<Permission> permissions = authorityService.getPermissions(authorities);
-        TenantContextHolder.clear();
+        try {
+            TenantContextHolder.setTenantId(stateId);
+            final Set<Permission> permissions = authorityService.getPermissions(authorities);
 
-        return user
-                .permissionsById(
-                        Maps.uniqueIndex(permissions, Permission::getId)
-                )
-                .authorities(
-                        toGrantedAuthorities(
-                                authorities.stream().map(Authority::getRole).collect(toSet()),
-                                permissions.stream().map(Permission::getId).collect(toSet())
-                        )
-                )
-                .build();
+            user.permissionsById(Maps.uniqueIndex(permissions, Permission::getId))
+                    .authorities(
+                            toGrantedAuthorities(
+                                    authorities.stream().map(Authority::getRole).collect(toSet()),
+                                    permissions.stream().map(Permission::getId).collect(toSet())
+                            )
+                    );
+        } finally {
+            TenantContextHolder.clear();
+        }
+        return user.build();
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/sandbox/SandboxUserDetailsService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/security/sandbox/SandboxUserDetailsService.java
@@ -46,67 +46,72 @@ class SandboxUserDetailsService implements AuthenticationUserDetailsService<Sand
     public UserDetails loadUserDetails(final SandboxAuthenticationToken token) throws UsernameNotFoundException {
 
         final Tenant sandbox = sandboxRepository.findByKey(token.getSandboxKey());
-        TenantContextHolder.setTenantId(sandbox.getId());
+        final User.Builder userBuilder = User.builderExt();
 
-        // User ID is a combination of the requested role and UUID
-        final String usernameAndId = String.format(
-                "%s,%s",
-                token.getRole(),
-                token.getUserId() != null
-                    ? token.getUserId()
-                    : UUID.randomUUID()
-        );
+        try {
 
-        final SandboxRole role = sandboxRoleRepository.findById(token.getRole());
+            TenantContextHolder.setTenantId(sandbox.getId());
 
-        // The request was tampered with or someone's saved sandbox login link is no longer valid
-        if (role == null) {
-            throw new AuthenticationServiceException(String.format(
-                    "Sandbox role \"%s\" not found",
-                    token.getRole()
-            ));
-        }
-
-        final Set<Authority> authorities = authorityService.getAuthorities(role);
-        final Set<Permission> permissions = authorityService.getPermissions(authorities);
-        final Map<String, Permission> permissionsById = Maps.uniqueIndex(permissions, Permission::getId);
-        if (permissionsById.containsKey(ReportingPermission.GroupPiiRead)) {
-            sandboxUserGroupRepository.createByOrganization(
-                    usernameAndId,
-                    role.getOrganization().getName()
+            // User ID is a combination of the requested role and UUID
+            final String usernameAndId = String.format(
+                    "%s,%s",
+                    token.getRole(),
+                    token.getUserId() != null
+                            ? token.getUserId()
+                            : UUID.randomUUID()
             );
+
+            final SandboxRole role = sandboxRoleRepository.findById(token.getRole());
+
+            // The request was tampered with or someone's saved sandbox login link is no longer valid
+            if (role == null) {
+                throw new AuthenticationServiceException(String.format(
+                        "Sandbox role \"%s\" not found",
+                        token.getRole()
+                ));
+            }
+
+            final Set<Authority> authorities = authorityService.getAuthorities(role);
+            final Set<Permission> permissions = authorityService.getPermissions(authorities);
+            final Map<String, Permission> permissionsById = Maps.uniqueIndex(permissions, Permission::getId);
+            if (permissionsById.containsKey(ReportingPermission.GroupPiiRead)) {
+                sandboxUserGroupRepository.createByOrganization(
+                        usernameAndId,
+                        role.getOrganization().getName()
+                );
+            }
+
+            userBuilder
+                    .tenant(
+                            UserTenant.builder()
+                                    .id(sandbox.getId())
+                                    .name(sandbox.getName())
+                                    .sandbox(true)
+                                    .logoutUrl("/logout")
+                                    .logoutSuccessUrl(token.getLogoutSuccessUrl())
+                                    .sessionRefreshUrl(token.getSessionRefreshUrl())
+                                    .build()
+                    )
+                    .id(usernameAndId)
+                    .username(usernameAndId)
+                    .password("N/A")
+                    .firstName(token.getUsername().trim())
+                    .lastName("")
+                    .permissionsById(permissionsById)
+                    .enabled(true)
+                    .credentialsNonExpired(true)
+                    .accountNonExpired(true)
+                    .accountNonLocked(true)
+                    .authorities(
+                            toGrantedAuthorities(
+                                    authorities.stream().map(Authority::getRole).collect(toSet()),
+                                    permissions.stream().map(Permission::getId).collect(toSet())
+                            )
+                    );
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        TenantContextHolder.clear();
-
-        return User.builderExt()
-                .tenant(
-                        UserTenant.builder()
-                                .id(sandbox.getId())
-                                .name(sandbox.getName())
-                                .sandbox(true)
-                                .logoutUrl("/logout")
-                                .logoutSuccessUrl(token.getLogoutSuccessUrl())
-                                .sessionRefreshUrl(token.getSessionRefreshUrl())
-                                .build()
-                )
-                .id(usernameAndId)
-                .username(usernameAndId)
-                .password("N/A")
-                .firstName(token.getUsername().trim())
-                .lastName("")
-                .permissionsById(permissionsById)
-                .enabled(true)
-                .credentialsNonExpired(true)
-                .accountNonExpired(true)
-                .accountNonLocked(true)
-                .authorities(
-                        toGrantedAuthorities(
-                                authorities.stream().map(Authority::getRole).collect(toSet()),
-                                permissions.stream().map(Permission::getId).collect(toSet())
-                        )
-                )
-                .build();
+        return userBuilder.build();
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/status/DatabaseStatusIndicator.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/status/DatabaseStatusIndicator.java
@@ -9,11 +9,8 @@ import org.opentestsystem.rdw.common.status.StatusIndicator;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -53,21 +50,22 @@ public class DatabaseStatusIndicator extends AbstractStatusIndicator {
     @Override
     protected void doStatusCheck(final Status.Builder builder, final int level) {
         for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
+            try {
+                TenantContextHolder.setTenantId(tenant.getId());
 
-            final Status.Builder opBuilder = Status.builder().detail("schema", "reporting").detail("type", "READ");
-            final List<String> codes = responseTime(opBuilder, 50, () -> jdbcTemplate.getJdbcOperations().queryForList(sqlReadTest, String.class));
-            if (codes.size() != AssessmentType.values().length) {
-                opBuilder.rating(Rating.Warning);
-                opBuilder.detail("warning", "asmt_type table not loaded properly");
+                final Status.Builder opBuilder = Status.builder().detail("schema", "reporting").detail("type", "READ");
+                final List<String> codes = responseTime(opBuilder, 50, () -> jdbcTemplate.getJdbcOperations().queryForList(sqlReadTest, String.class));
+                if (codes.size() != AssessmentType.values().length) {
+                    opBuilder.rating(Rating.Warning);
+                    opBuilder.detail("warning", "asmt_type table not loaded properly");
+                }
+
+                final List<Status> ops = newArrayList(opBuilder.build());
+                builder.detail("databaseOperations - " + tenant.getId(), ops);
+                builder.worstRating(ops);
+            } finally {
+                TenantContextHolder.clear();
             }
-
-            final List<Status> ops = newArrayList(opBuilder.build());
-
-            builder.detail("databaseOperations - " + tenant.getId(), ops);
-            builder.worstRating(ops);
-
-            TenantContextHolder.clear();
         }
     }
 }


### PR DESCRIPTION
- change order of precedence in StatidTenantIdUtil.tenantId() to allow tenant context to override the context for an already logged in user
- audited code and made sure all places where TenantContextHolder.setTenantId() is used a matching TenantContextHolder.clear() is used in a finally block