### PR TITLE
Fixes for node build / sbac-ui-kit

### DIFF
--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -60,7 +60,6 @@ dependencies {
 node {
     version = '12.11.1'
     npmVersion = '6.11.3'
-    distBaseUrl = 'https://nodejs.org/dist'
     download = true
 }
 

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -58,8 +58,9 @@ dependencies {
  ***************************************************************************************/
 
 node {
-    version = '8.9.1'
-    npmVersion = '5.5.1'
+    version = '12.11.1'
+    npmVersion = '6.11.3'
+    distBaseUrl = 'https://nodejs.org/dist'
     download = true
 }
 

--- a/webapp/src/main/webapp/.npmrc
+++ b/webapp/src/main/webapp/.npmrc
@@ -1,2 +1,0 @@
-@sbac:registry=https://registry.npmjs.org
-

--- a/webapp/src/main/webapp/.npmrc
+++ b/webapp/src/main/webapp/.npmrc
@@ -1,1 +1,2 @@
-@sbac:registry=https://airdev.jfrog.io/airdev/api/npm/npm
+@sbac:registry=https://registry.npmjs.org
+

--- a/webapp/src/main/webapp/package.json
+++ b/webapp/src/main/webapp/package.json
@@ -30,7 +30,7 @@
     "@kourge/ordering": "^1.0.1",
     "@ngx-translate/core": "^11.0.1",
     "@ngx-translate/http-loader": "^4.0.0",
-    "@sbac/sbac-ui-kit": "0.0.29",
+    "@sbac/sbac-ui-kit": "0.0.30",
     "@swimlane/ngx-dnd": "^3.1.3",
     "ace-builds": "^1.4.3",
     "ace-diff": "^2.3.0",


### PR DESCRIPTION
Upped sbac-ui-kit to version 0.0.30 and removed .npmrc, which pointed at old report. I also matched "node" configuration in build.gradle with what TIMS has. However, we still have the problem of the "dist" folder of sbac-ui-kit not being brought in and causing the "ng build" to fail. On TIMS, the dist folder is also missing on new builds, though it was in my cached version. The TIMS "ng build" does _not_  fail despite the missing sbac-ui-kit/dist folder. 