### PR TITLE
just enough code change to work with latest schema 

### DIFF
--- a/admin-service/src/test/resources/warehouse-metrics-setup.sql
+++ b/admin-service/src/test/resources/warehouse-metrics-setup.sql
@@ -96,11 +96,11 @@ SET created = '2017-07-18 19:06:30.966000',
 WHERE id IN (1, 2);
 
 -- add subjects' related data for the new subjects
-INSERT INTO subject_asmt_type (subject_id, asmt_type_id, target_report, printed_report)
-VALUES (-1, 1, 0, 1),
-       (-2, 1, 0, 1),
-       (-3, 1, 0, 1), -- new entry
-       (-3, 2, 0, 1); -- updated entry
+INSERT INTO subject_asmt_type (subject_id, asmt_type_id, target_report, printed_report, trait_report)
+VALUES (-1, 1, 0, 1, 0),
+       (-2, 1, 0, 1, 0),
+       (-3, 1, 0, 1, 0), -- new entry
+       (-3, 2, 0, 1, 0); -- updated entry
 
 INSERT INTO subject_asmt_scoring (subject_id, asmt_type_id, score_type_id, performance_level_count,
                                   performance_level_standard_cutoff)

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ idea {
 project.ext.apps = subprojects.findAll { !'lib'.equalsIgnoreCase(it.findProperty('moduleType') as String) }
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "2.4.0-15"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "2.4.0-12"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "2.4.0-18"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "2.4.0-15"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/Assessment.java
@@ -25,6 +25,7 @@ public class Assessment {
     private Boolean werItem;
     private boolean targetReportEnabled;
     private boolean printedReportEnabled;
+    private boolean traitReportEnabled;
 
     private Assessment() {
     }
@@ -110,6 +111,13 @@ public class Assessment {
     }
 
     /**
+     * @return {@code true} if the assessment's subject has exam-level trait report enabled
+     */
+    public boolean isTraitReportEnabled() {
+        return traitReportEnabled;
+    }
+
+    /**
      * Gets the assessment cut points.
      * Cut points are the point values which separate the performance levels of assessments.
      * These points are sorted in ascending order beginning with the minimum score and ending with the maximum.
@@ -187,6 +195,7 @@ public class Assessment {
         private Boolean werItem;
         private boolean targetReportEnabled;
         private boolean printedReportEnabled;
+        private boolean traitReportEnabled;
 
         public Builder id(final int id) {
             this.id = id;
@@ -248,6 +257,11 @@ public class Assessment {
             return this;
         }
 
+        public Builder traitReportEnabled(final boolean traitReportEnabled) {
+            this.traitReportEnabled = traitReportEnabled;
+            return this;
+        }
+
         public Builder werItem(final Boolean werItem) {
             this.werItem = werItem;
             return this;
@@ -267,6 +281,7 @@ public class Assessment {
             werItem = assessment.werItem;
             targetReportEnabled = assessment.targetReportEnabled;
             printedReportEnabled = assessment.printedReportEnabled;
+            traitReportEnabled = assessment.traitReportEnabled;
             return this;
         }
 
@@ -285,6 +300,7 @@ public class Assessment {
             assessment.werItem = werItem;
             assessment.targetReportEnabled = targetReportEnabled;
             assessment.printedReportEnabled = printedReportEnabled;
+            assessment.traitReportEnabled = traitReportEnabled;
             return assessment;
         }
     }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/model/SubjectDefinition.java
@@ -16,6 +16,7 @@ public class SubjectDefinition {
     private Integer altScorePerformanceLevelCount;
     private boolean targetReport;
     private boolean printedReport;
+    private boolean traitReport;
 
     // TODO enhance with data_order and display_order data - not just codes in display order
     private List<String> scorableClaims;
@@ -53,6 +54,10 @@ public class SubjectDefinition {
         return printedReport;
     }
 
+    public boolean isTraitReport() {
+        return traitReport;
+    }
+
     public List<String> getScorableClaims() {
         return scorableClaims == null ? ImmutableList.of() : scorableClaims;
     }
@@ -78,6 +83,7 @@ public class SubjectDefinition {
         private Integer altScorePerformanceLevelCount;
         private boolean targetReport;
         private boolean printedReport;
+        private boolean traitReport;
         private List<String> scorableClaims;
         private List<String> altScores;
 
@@ -91,6 +97,7 @@ public class SubjectDefinition {
             definition.altScorePerformanceLevelCount = altScorePerformanceLevelCount;
             definition.targetReport = targetReport;
             definition.printedReport = printedReport;
+            definition.traitReport = traitReport;
             definition.scorableClaims = scorableClaims;
             definition.altScores = altScores;
             return definition;
@@ -105,6 +112,7 @@ public class SubjectDefinition {
             altScorePerformanceLevelCount = definition.altScorePerformanceLevelCount;
             targetReport = definition.targetReport;
             printedReport = definition.printedReport;
+            traitReport = definition.traitReport;
             scorableClaims = definition.scorableClaims;
             altScores = definition.altScores;
             return this;
@@ -147,6 +155,11 @@ public class SubjectDefinition {
 
         public Builder printedReport(final boolean printedReport) {
             this.printedReport = printedReport;
+            return this;
+        }
+
+        public Builder traitReport(final boolean traitReport) {
+            this.traitReport = traitReport;
             return this;
         }
 

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepository.java
@@ -56,6 +56,7 @@ public class JdbcSubjectDefinitionRepository implements SubjectDefinitionReposit
                         .altScorePerformanceLevelCount(getNullable(row, row.getInt("alt_score_performance_level_count")))
                         .targetReport(row.getBoolean("target_report"))
                         .printedReport(row.getBoolean("printed_report"))
+                        .traitReport(row.getBoolean("trait_report"))
                         .scorableClaims(scorableCodesByKey.get(key(row.getString("subject_code"), row.getString("asmt_type_code"), ScoreType.CLAIM)))
                         .altScores(scorableCodesByKey.get(key(row.getString("subject_code"), row.getString("asmt_type_code"), ScoreType.ALT)))
                         .build()

--- a/common/src/main/resources/common.sql.yml
+++ b/common/src/main/resources/common.sql.yml
@@ -128,7 +128,8 @@ sql:
         sat.claim_score_performance_level_count,
         sat.alt_score_performance_level_count,
         sat.target_report,
-        sat.printed_report
+        sat.printed_report,
+        sat.trait_report
       FROM subject_asmt_type sat
         JOIN asmt_type at ON at.id = sat.asmt_type_id
         JOIN subject s ON s.id = sat.subject_id

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/repository/impl/JdbcSubjectDefinitionRepositoryIT.java
@@ -39,6 +39,7 @@ public class JdbcSubjectDefinitionRepositoryIT {
                 .claimScorePerformanceLevelCount(3)
                 .targetReport(false)
                 .printedReport(true)
+                .traitReport(false)
                 .scorableClaims(newArrayList("SOCK_R", "SOCK_LS", "2-W", "4-CR"))
                 .build();
         final SubjectDefinition mathSumDefinition = SubjectDefinition.builder()
@@ -49,6 +50,7 @@ public class JdbcSubjectDefinitionRepositoryIT {
                 .claimScorePerformanceLevelCount(3)
                 .targetReport(true)
                 .printedReport(true)
+                .traitReport(false)
                 .scorableClaims(newArrayList("1", "SOCK_2", "3"))
                 .build();
 
@@ -60,7 +62,7 @@ public class JdbcSubjectDefinitionRepositoryIT {
 
     @Sql(statements = {
          "INSERT INTO subject (id, code, update_import_id, migrate_id) VALUES (-9, 'ALT', -1, -1)",
-         "INSERT INTO subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report) VALUES (-9, 3, 4, 3, 4, 0, 0)",
+         "INSERT INTO subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report, trait_report) VALUES (-9, 3, 4, 3, 4, 0, 0, 1)",
          "INSERT INTO subject_score (id, subject_id, asmt_type_id, score_type_id, code, data_order, display_order) VALUES (-90, -9, 3, 2, '1', 1, 1), (-91, -9, 3, 2, '2', 2, 2), (-92, -9, 3, 3, '1-L', 1, 1), (-93, -9, 3, 3, '2-R', 2, 2)"
     })
     @Test
@@ -73,6 +75,7 @@ public class JdbcSubjectDefinitionRepositoryIT {
                 .altScorePerformanceLevelCount(4)
                 .targetReport(false)
                 .printedReport(false)
+                .traitReport(true)
                 .scorableClaims(newArrayList("1-L", "2-R"))
                 .altScores(newArrayList("1", "2"))
                 .build();

--- a/report-processor/src/test/resources/integration-test-data.sql
+++ b/report-processor/src/test/resources/integration-test-data.sql
@@ -30,8 +30,8 @@ insert into school_year (year) values
 insert into subject (id, code, update_import_id, migrate_id) values
   (-1, 'sub', -1, -1);
 
-insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report) VALUES
-  (-1, 3, 4, 3, 3, 0, 0);
+insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report, trait_report) VALUES
+  (-1, 3, 4, 3, 3, 0, 0, 0);
 
 insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, inferred_school_id, update_import_id, updated, migrate_id) values
   (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -10, -1, '1997-07-18 20:14:34.000000', -1),

--- a/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractAssessmentRepository.java
+++ b/reporting-service/src/main/java/org/opentestsystem/rdw/reporting/exam/AbstractAssessmentRepository.java
@@ -1,11 +1,9 @@
 package org.opentestsystem.rdw.reporting.exam;
 
-import com.google.common.collect.ImmutableList;
 import org.opentestsystem.rdw.reporting.common.jdbc.Assessments;
 import org.opentestsystem.rdw.reporting.common.jdbc.SecurityParameterProvider;
 import org.opentestsystem.rdw.reporting.common.model.Assessment;
 import org.opentestsystem.rdw.reporting.common.security.PermissionSource;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -93,6 +91,7 @@ public abstract class AbstractAssessmentRepository<T extends AbstractAssessmentS
                 .werItem(row.getBoolean("has_wer_item"))
                 .targetReportEnabled(row.getBoolean("target_report"))
                 .printedReportEnabled(row.getBoolean("printed_report"))
+                .traitReportEnabled(row.getBoolean("trait_report"))
                 .build();
     }
 

--- a/reporting-service/src/main/resources/application.sql.yml
+++ b/reporting-service/src/main/resources/application.sql.yml
@@ -331,8 +331,8 @@ sql:
         EXISTS(SELECT 1 FROM item i WHERE i.asmt_id = a.id AND i.type = 'WER') as has_wer_item,
         su.code as subject_code,
         sat.target_report,
-        sat.printed_report
-
+        sat.printed_report,
+        sat.trait_report
 
       selectFromExamItem: >-
        SELECT

--- a/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subject/SubjectControllerIT.java
+++ b/reporting-service/src/test/java/org/opentestsystem/rdw/reporting/subject/SubjectControllerIT.java
@@ -55,6 +55,7 @@ public class SubjectControllerIT extends UserAwareControllerSupport {
                 .claimScorePerformanceLevelCount(3)
                 .targetReport(true)
                 .printedReport(true)
+                .traitReport(true)
                 .build();
         final SubjectDefinition iabEla = SubjectDefinition.builder()
                 .asmtTypeCode("iab")
@@ -69,6 +70,7 @@ public class SubjectControllerIT extends UserAwareControllerSupport {
                 .altScorePerformanceLevelCount(4)
                 .targetReport(false)
                 .printedReport(false)
+                .traitReport(false)
                 .scorableClaims(newArrayList("1-L", "1-S", "2-R", "2-W"))
                 .altScores(newArrayList("1", "2"))
                 .build();
@@ -84,6 +86,7 @@ public class SubjectControllerIT extends UserAwareControllerSupport {
                 .andExpect(jsonPath("$[0].claimScorePerformanceLevelCount").value(3))
                 .andExpect(jsonPath("$[0].targetReport").value(true))
                 .andExpect(jsonPath("$[0].printedReport").value(true))
+                .andExpect(jsonPath("$[0].traitReport").value(true))
                 .andExpect(jsonPath("$[1].asmtTypeCode").value("iab"))
                 .andExpect(jsonPath("$[1].subjectCode").value("ELA"))
                 .andExpect(jsonPath("$[1].performanceLevelCount").value(3))
@@ -97,6 +100,7 @@ public class SubjectControllerIT extends UserAwareControllerSupport {
                 .andExpect(jsonPath("$[2].altScorePerformanceLevelCount").value(4))
                 .andExpect(jsonPath("$[2].targetReport").value(false))
                 .andExpect(jsonPath("$[2].printedReport").value(false))
+                .andExpect(jsonPath("$[2].traitReport").value(false))
                 .andExpect(jsonPath("$[2].scorableClaims").isArray())
                 .andExpect(jsonPath("$[2].scorableClaims[2]").value("2-R"))
                 .andExpect(jsonPath("$[2].altScores").isArray())

--- a/reporting-service/src/test/resources/integration-test-data.sql
+++ b/reporting-service/src/test/resources/integration-test-data.sql
@@ -3,8 +3,8 @@ insert into ethnicity VALUES (-29,'ethnicity-29'),(-28,'ethnicity-28'),(-27, 'et
 insert into subject (id, code, updated, update_import_id, migrate_id) values
   (-1, 'NEW', now(), -1, -1);
 
-insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report) values
-  (-1, 1, 6, 3, 6, 3, 0, 0);
+insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report, trait_report) values
+  (-1, 1, 6, 3, 6, 3, 0, 0, 0);
 
 insert into subject_score (id, subject_id, asmt_type_id, score_type_id, code, display_order, data_order) values
   (-1, -1, 1, 3, 'claim1', 1, 1),

--- a/webapp/src/test/resources/integration-test-data.sql
+++ b/webapp/src/test/resources/integration-test-data.sql
@@ -46,8 +46,8 @@ insert into school_year (year) values
 insert into subject (id, code, update_import_id, migrate_id) values
   (-1, 'sub', -1, -1);
 
-insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report) VALUES
-  (-1, 3, 4, 3, 3, 0, 0);
+insert into subject_asmt_type (subject_id, asmt_type_id, performance_level_count, claim_score_performance_level_count, alt_score_performance_level_count, target_report, printed_report, trait_report) VALUES
+  (-1, 3, 4, 3, 3, 0, 0, 0);
 
 insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, inferred_school_id, update_import_id, updated, migrate_id) values
   (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '1997-01-01 00:00:00.000000', -10, -1, '1997-07-18 20:14:34.000000', -1),


### PR DESCRIPTION
The trait_report field is required, so change tests to work with the latest schema.

Nothing is really being done with trait_report. Nor subject traits. Nor exam trait scores. Yet.