### PR TITLE
Fix to download Alt Score reports

### DIFF
--- a/common/src/main/resources/i18n/en.json
+++ b/common/src/main/resources/i18n/en.json
@@ -6,7 +6,7 @@
     "aggregate": {
       "export": {
         "header": {
-          "alt-score": "Alt",
+          "alt-score": "Alt Score",
           "assessment": "AssessmentName",
           "assessment-type": "AssessmentType",
           "attributes": "Attributes",

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AltScoreAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AltScoreAggregateReportCsvHandler.java
@@ -45,29 +45,7 @@ public class AltScoreAggregateReportCsvHandler extends AbstractAggregateReportCs
     @Override
     protected List<String> getReportCustomValues(final CsvContext context, final AltScoreRow result) {
         // text associated with the alt score code (by subject)
-        return newArrayList(getMessage("subject." + result.getAssessment().getSubjectCode() + ".alt-score." + result.getAltScoreCode() + ".name"));
-    }
-
-    @Override
-    protected String getMessage(String key) {
-        // Handle inconsistencies with some keys using "alt" and others using "alt-score".
-        String value = super.getMessage(key);
-        if (value.equals(key)) {
-            if (key.contains(".alt-score.")) {
-                final String newKey = key.replace(".alt-score.", ".alt.");
-                final String newValue = super.getMessage(newKey);
-                if (!newValue.equals(newKey)) {
-                    value = newValue;
-                }
-            } else {
-                final String newKey = key.replace(".alt.", ".alt-score.");
-                final String newValue = super.getMessage(newKey);
-                if (!newValue.equals(newKey)) {
-                    value = newValue;
-                }
-            }
-        }
-        return value;
+        return newArrayList(getMessage("subject." + result.getAssessment().getSubjectCode() + ".alt." + result.getAltScoreCode() + ".name"));
     }
 
     @Override

--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AltScoreAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AltScoreAggregateReportCsvHandler.java
@@ -49,6 +49,28 @@ public class AltScoreAggregateReportCsvHandler extends AbstractAggregateReportCs
     }
 
     @Override
+    protected String getMessage(String key) {
+        // Handle inconsistencies with some keys using "alt" and others using "alt-score".
+        String value = super.getMessage(key);
+        if (value.equals(key)) {
+            if (key.contains(".alt-score.")) {
+                final String newKey = key.replace(".alt-score.", ".alt.");
+                final String newValue = super.getMessage(newKey);
+                if (!newValue.equals(newKey)) {
+                    value = newValue;
+                }
+            } else {
+                final String newKey = key.replace(".alt.", ".alt-score.");
+                final String newValue = super.getMessage(newKey);
+                if (!newValue.equals(newKey)) {
+                    value = newValue;
+                }
+            }
+        }
+        return value;
+    }
+
+    @Override
     protected Class<AltScoreRow> getRowInstanceClass() {
         return AltScoreRow.class;
     }


### PR DESCRIPTION
Changed column header from Alt to Alt Score. Changed Alt Score code keys to match format in the subject translation table.