### PR TITLE
Req1: Fix Audit Filename

### DIFF
--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/service/test-results-availability.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/service/test-results-availability.service.ts
@@ -2,6 +2,12 @@ import { Injectable, OnInit } from '@angular/core';
 import { TestResultAvailability } from '../model/test-result-availability';
 import { TestResultAvailabilityFilters } from '../model/test-result-availability-filters';
 import { MockTestResultsAvailability } from '../mockTestResultsAvailability';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Download } from '../../../shared/data/download.model';
+import { Http } from '@angular/http';
+import { TranslateService } from '@ngx-translate/core';
+import { TranslateDatePipe } from '../../../shared/i18n/translate-date.pipe';
 
 @Injectable({
   providedIn: 'root'
@@ -24,9 +30,19 @@ export class TestResultsAvailabilityService implements OnInit {
   private sandbox = false; // set from session info
   private adminDistrict = 'District 12'; // default district for districtAdmin
 
+  constructor(
+    private datePipe: TranslateDatePipe,
+    private http: Http,
+    private translate: TranslateService
+  ) {}
+
   ngOnInit(): void {
     this.setTestResultFilterDefaults();
     this.testResultFilters = this.getTestResultAvailabilityFilterDefaults();
+  }
+
+  formatAsLocalDate(date: Date): string {
+    return this.datePipe.transform(date, 'yyyy-MM-dd');
   }
 
   // receive test results and apply filter's options
@@ -179,7 +195,6 @@ export class TestResultsAvailabilityService implements OnInit {
 
   // Filter options are obtained from initial test results availability
   getTestResultsSchoolYearOptions(): number[] {
-    // return [2020, 2019, 2018];
     return this.mockTestResults.getTestResultsSchoolYearOptions();
   }
 
@@ -193,5 +208,22 @@ export class TestResultsAvailabilityService implements OnInit {
 
   getTestResultsReportTypeOptions(): string[] {
     return this.mockTestResults.getTestResultsReportTypeOptions();
+  }
+
+  public getTemplateFile(): Observable<any> {
+    // TODO: Replace with call to real file location
+    return this.http
+      .get('/assets/testResultsAudit202006040.csv')
+      .pipe(
+        map(
+          response =>
+            new Download(
+              `${this.translate.instant(
+                'test-results-availability.audit-filename'
+              )}.csv`,
+              new Blob([response.text()], { type: 'text/csv; charset=utf-8' })
+            )
+        )
+      );
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.html
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.html
@@ -6,8 +6,8 @@
     <li>
       <a
         class="btn btn-default"
-        href="/assets/testResultsAudit202006040.csv"
-        download="/assets/testResultsAudit202006040.csv"
+        href="javascript:void(0);"
+        (click)="downloadAuditFile()"
         title="{{ 'test-results-availability.history-link' | translate }}"
         ><i class="fa fa-cloud-download" aria-hidden="true"></i>
         {{ 'test-results-availability.history-link' | translate }}</a

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.ts
@@ -7,10 +7,12 @@ import { TestResultAvailability } from './model/test-result-availability';
 import { TestResultsAvailabilityService } from './service/test-results-availability.service';
 import { TestResultAvailabilityFilters } from './model/test-result-availability-filters';
 import { TestResultsAvailabilityChangeStatusModal } from './test-results-availability-change-status.modal';
+import { Download } from '../../shared/data/download.model';
+import { saveAs } from 'file-saver';
 
 class Column {
   id: string; // en.json name
-  field: string; // TestResult field
+  field: string; // TestResult fielf
   sortable: boolean;
 
   constructor({ id, field = '', sortable = true }) {
@@ -35,8 +37,10 @@ export class TestResultsAvailabilityComponent implements OnInit {
   ];
   private _testResultsAvailability: TestResultAvailability[];
 
-  changeResultsTooltip: string =
-    'Change status of selected test results availability (all pages).';
+  changeResultsTooltip = `${this.translate.instant(
+    'test-results-availability.change-results-tooltip'
+  )}`;
+  // 'Change status of selected test results availability (all pages).';
   testResultAvailabilityFilters: TestResultAvailabilityFilters;
   filteredTestResults: TestResultAvailability[];
 
@@ -64,7 +68,8 @@ export class TestResultsAvailabilityComponent implements OnInit {
     private modalService: BsModalService,
     private translateService: TranslateService,
     private notificationService: NotificationService,
-    private testResultsService: TestResultsAvailabilityService
+    private testResultsService: TestResultsAvailabilityService,
+    private translate: TranslateService
   ) {}
 
   get testResultsAvailability(): TestResultAvailability[] {
@@ -160,7 +165,23 @@ export class TestResultsAvailabilityComponent implements OnInit {
       ? 'reviewingColor'
       : 'releasedColor';
   }
-  onDownloadAuditFile() {}
+
+  downloadAuditFile(): void {
+    // replace download file name with date info
+    const now = this.testResultsService.formatAsLocalDate(new Date());
+    const auditFilename =
+      `${this.translate.instant('test-results-availability.audit-filename')}_` +
+      now +
+      `.csv`;
+    this.testResultsService.getTemplateFile().subscribe(
+      (download: Download) => {
+        saveAs(download.content, auditFilename);
+      },
+      (error: Error) => {
+        console.error(error);
+      }
+    );
+  }
 
   closeSuccessAlert() {
     this.successfulChange = false;

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.ts
@@ -12,7 +12,7 @@ import { saveAs } from 'file-saver';
 
 class Column {
   id: string; // en.json name
-  field: string; // TestResult fielf
+  field: string; // TestResult field
   sortable: boolean;
 
   constructor({ id, field = '', sortable = true }) {

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -2011,6 +2011,8 @@
   },
   "test-results-availability": {
     "all-text": "All",
+    "audit-filename": "test_results_availability_audit",
+    "change-results-tooltip": "Change status of selected test results availability (all pages).",
     "change-status": "Change Status",
     "columns": {
       "school-year": "School Year",


### PR DESCRIPTION
Updated download ability to dynamically change the name of the audit history file, to include the current date.
it also now has an http call that can be used to call the real file in the next phase.