### PR TITLE
RDW6: fix bug with sandbox creation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ subprojects {
         rootProject.ext['jackson.version'] = '2.9.9'
         rootProject.ext['mockito.version'] = '2.28.2'
         rootProject.ext['mysql.version'] = '5.1.46'  // 5.1.47 causes problems
+        rootProject.ext['flyway.version'] = '5.2.4'
         rootProject.ext['thymeleaf.version'] = '3.0.6.RELEASE'
         rootProject.ext['thymeleaf-layout-dialect.version'] = '2.1.1'
 
@@ -74,6 +75,7 @@ subprojects {
 
             // commonly used libraries
             implementation "mysql:mysql-connector-java:${rootProject.ext['mysql.version']}"
+            implementation "org.flywaydb:flyway-core:${rootProject.ext['flyway.version']}"
             implementation 'com.google.guava:guava:27.0.1-jre'
             implementation 'commons-io:commons-io:2.6'
             implementation 'io.jsonwebtoken:jjwt:0.9.0'
@@ -83,7 +85,6 @@ subprojects {
             implementation 'org.apache.pdfbox:pdfbox:2.0.7'
             implementation 'org.slf4j:slf4j-api:1.7.26'
             implementation 'org.thymeleaf:thymeleaf:3.0.6.RELEASE'
-            implementation "org.flywaydb:flyway-core:5.2.4"
 
             // jackson
             implementation "com.fasterxml.jackson.core:jackson-annotations:${rootProject.ext['jackson.version']}"


### PR DESCRIPTION
The problem is actually with RDW_Schema, so I'm not sure this is the right place to fix it. The RDW_Schema code is:

`public class SchemaMigration {
    private Flyway flyway;

    public SchemaMigration(DataSource dataSource, String schemaName, SchemaMigration.Migration migration) {
        this.flyway = Flyway.configure().table("schema_version").locations(new String[]{migration.directory + "/sql"}).placeholders(Collections.singletonMap("schemaName", schemaName)).schemas(new String[]{schemaName}).dataSource(dataSource).load();
    }
...
`

RDW_Reporting was bringing in flyway 3.2.1, based on Spring Boot dependencies, but 5.2.4 is needed for the Flyway.configure() method. Should the RDW_Schema be changed to ensure that its internal calls use the version of flyway that it expects, even when RDW_Schema is used as a dependency to another project? 

This fix does force RDW_Reporting to use 5.2.4 instead of 3.2.1. 