### PR TITLE
RDW6: fixes error is sandbox display.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,13 +228,15 @@ non-trivial configurations. This section is a stream-of-consciousness dump of st
 
 For SandboxCreation, a list of datasets is required. Locally they won't exist.
 so if you add the following to your application.yml to list 'available' datasets.
-# Only here for local Dev for Sandbox creation, not real dataSets
+#### Only here for local Dev for Sandbox creation, not real dataSets
+```yaml
 sandbox-properties:
   sandboxDatasets:
     - label: Demo Dataset
       id: demo-dataset
     - label: SBAC Dataset
       id: sbac-dataset
+```
 **NOTE: do NOT check in this change to the file!**
 
 

--- a/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
+++ b/webapp/src/main/webapp/src/app/admin/tenant/component/property-override-tree-table/property-override-tree-table.component.html
@@ -144,6 +144,7 @@
                         </ng-container>
                         <ng-container *ngSwitchCase="'multiselect'">
                           <sb-button-group
+                            *ngIf="(getOptions(data) | async).length > 1"
                             id="{{ configuration.name }}"
                             name="{{ configuration.name }}"
                             [options]="getOptions(data) | async"


### PR DESCRIPTION
Prevents an error that QA reported from being logged to the console, but otherwise does not change behavior.