### PR TITLE
UAT-6 (Req4): Update the format of the date in the Alt Scores CSV file

### DIFF
--- a/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
+++ b/report-processor/src/main/java/org/opentestsystem/rdw/reporting/processor/web/converter/AbstractAggregateReportCsvHandler.java
@@ -34,9 +34,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
@@ -73,6 +73,9 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
     protected static final String NotApplicable = "";
     protected static final Joiner AttributeJoiner = Joiner.on("; ");
     private static final Joiner AttributeValueJoiner = Joiner.on("|");
+
+    private static final DateTimeFormatter UtcDateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss 'UTC'");
 
     private final MessageSource messageSource;
     private final ObjectMapper objectMapper;
@@ -212,8 +215,9 @@ abstract class AbstractAggregateReportCsvHandler<Q extends AbstractAggregateRepo
     private List<String> getFirstRowAttributes(final Q query) {
         final List<String> attributes = newArrayList();
 
-        final LocalDateTime localDate = LocalDateTime.now();
-        appendAttribute(attributes, "ReportDate", Collections.singleton(localDate.format(DateTimeFormatter.ISO_DATE_TIME)));
+        final ZonedDateTime utcDateTime = ZonedDateTime.now(ZoneOffset.UTC);
+        appendAttribute(attributes, "ReportDate", Collections.singleton(utcDateTime.format(UtcDateTimeFormatter)));
+
         appendAttribute(attributes, "AdministrationCondition", query.getAdministrativeConditionCodes());
         appendAttribute(attributes, "Completeness", query.getCompletenessCodes());
         if (!query.isFilteredSubgroupQuery()) attributes.addAll(getFiltersAsAttributes(query.getStudentFilters()));


### PR DESCRIPTION
The server seems to be running in the UTC timezone, so formatting a local date time was fine, but since I put UTC literally into the pattern (which otherwise would show 'Z'), I made the date/time zoned to UTC to be safe.

Note: this will apply to all aggregate reports.