### PR TITLE
UAT-53 (Req3): An information icons in writing trait purposes tab.

### DIFF
--- a/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.html
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.html
@@ -297,15 +297,17 @@
     </ng-container>
 
     <!-- Summative type assessments have a table for each writing purpose on a tabbed panel-->
-    <p-tabView *ngIf="assessment.type === 'sum' && traitScoreSummary.size > 0">
-      <p-tabPanel
-        *ngFor="let purpose of purposes(traitScoreSummary); let i = index"
-        [selected]="i === 0"
-        header="{{
-          'subject.' + assessment.subject + '.trait.purpose.' + purpose
-            | translate
-        }}"
-      >
+    <tabset *ngIf="assessment.type === 'sum' && traitScoreSummary.size > 0">
+      <tab *ngFor="let purpose of purposes(traitScoreSummary)">
+        <ng-template tabHeading>
+          <span
+            info-button
+            title="{{ getNameForPurpose(assessment.subject, purpose) }}"
+            content="{{
+              getDescriptionForPurpose(assessment.subject, purpose)
+            }}"
+          ></span>
+        </ng-template>
         <ng-template
           [ngTemplateOutlet]="traitScoreSummaryTable"
           [ngTemplateOutletContext]="{
@@ -317,8 +319,8 @@
           }"
         >
         </ng-template>
-      </p-tabPanel>
-    </p-tabView>
+      </tab>
+    </tabset>
 
     <div *ngIf="traitScoreSummary.size === 0">
       <ul

--- a/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.ts
+++ b/webapp/src/main/webapp/src/app/assessments/results/view/writing-trait-scores/writing-trait-scores.component.ts
@@ -22,6 +22,7 @@ import { sum } from '../../../../exam/model/score-statistics';
 import { ExportWritingTraitsRequest } from '../../../model/export-writing-trait-request.model';
 import { ExportResults } from '../export-results';
 import { StudentResponsesAssessmentItem } from '../../../model/student-responses-item.model';
+import { TranslateService } from '@ngx-translate/core';
 
 interface ItemView {
   item: AssessmentItem;
@@ -178,7 +179,10 @@ export class WritingTraitScoresComponent
   private _hasDataToExport: boolean;
   isDevMode = isDevMode();
 
-  constructor(private examCalculator: ExamStatisticsCalculator) {}
+  constructor(
+    private translate: TranslateService,
+    private examCalculator: ExamStatisticsCalculator
+  ) {}
 
   ngOnDestroy(): void {
     this.destroyed$.next();
@@ -352,5 +356,30 @@ export class WritingTraitScoresComponent
 
   purposes(traitScoreSummary: Map<string, any>) {
     return Array.from(traitScoreSummary.keys());
+  }
+
+  getNameForPurpose(subjectCode: string, purposeCode: string) {
+    // TODO: add ".name" to translation key when db changes have been made.
+    return this.translate.instant(
+      'subject.' + subjectCode + '.trait.purpose.' + purposeCode
+    );
+  }
+
+  getDescriptionForPurpose(subjectCode: string, purposeCode: string) {
+    const key =
+      'subject.' +
+      subjectCode +
+      '.trait.purpose.' +
+      purposeCode +
+      '.description';
+    let description = this.translate.instant(key);
+    if (description === key) {
+      const name = this.getNameForPurpose(subjectCode, purposeCode);
+      description = this.translate.instant(
+        'common.writing-trait.default-purpose-description',
+        { name: name }
+      );
+    }
+    return description;
   }
 }

--- a/webapp/src/main/webapp/src/assets/i18n/en.json
+++ b/webapp/src/main/webapp/src/assets/i18n/en.json
@@ -962,7 +962,8 @@
       "organization": "Organization / Purpose",
       "total": "Transformed Points",
       "total-info": "The Transformed Points value is calculated by adding the Conventions score to the average of the Organization/Purpose and Evidence/Elaboration scores. These two values represent two dimensions that are used to compute the student’s overall scale score and Claim 2 – Writing score. For more information, see the Interpretive Guide.",
-      "no-data": "No writing trait results are available for the student group and advanced filters selected."
+      "no-data": "No writing trait results are available for the student group and advanced filters selected.",
+      "default-purpose-description": "Insert popup text for {{name}} here."
     }
   },
   "common-ngx": {


### PR DESCRIPTION
Changed prime-ng widget (p-tabview) to bootstrap (tabset). Added info icons with popup descriptions of each tab's purpose. Text will eventually come from the database, with a default local string if data values non-existent. Copy for this text still pending from Smarter.