### PR TITLE
Fix overlap in MyReports

### DIFF
--- a/webapp/src/main/webapp/src/app/report/user-report-table.component.html
+++ b/webapp/src/main/webapp/src/app/report/user-report-table.component.html
@@ -32,9 +32,9 @@
           [ngTemplateOutletContext]="row"
         ></ng-template>
 
-        <ng-container *ngSwitchCase="'type'">
+        <span *ngSwitchCase="'type'" style="width: 285px;">
           {{ 'reports.report-type.' + row.report.query.type | translate }}
-        </ng-container>
+        </span>
 
         <ng-container *ngSwitchCase="'assessmentTypes'">
           {{
@@ -46,26 +46,13 @@
           }}
         </ng-container>
 
-        <ng-container *ngSwitchCase="'subjects'">
-          <ng-container *ngIf="row.subjectCodes.length === 0">
-            {{ 'reports.all' | translate }}
-          </ng-container>
-          <ng-container
-            *ngFor="let subjectCode of row.subjectCodes; let last = last"
-          >
-            {{ 'subject.' + subjectCode + '.name' | translate
-            }}<ng-container *ngIf="!last">, </ng-container>
-          </ng-container>
-        </ng-container>
+        <span *ngSwitchCase="'subjects'" [title]="subjectName(row)">
+          {{ subjectName(row) }}
+        </span>
 
-        <ng-container *ngSwitchCase="'schoolYears'">
-          <ng-container
-            *ngFor="let schoolYear of row.schoolYears; let last = last"
-          >
-            {{ schoolYear | schoolYear
-            }}<ng-container *ngIf="!last">, </ng-container>
-          </ng-container>
-        </ng-container>
+        <span *ngSwitchCase="'schoolYears'" [title]="academicYears(row)">
+          {{ academicYears(row) | translate }}
+        </span>
 
         <span
           *ngSwitchCase="'status'"

--- a/webapp/src/main/webapp/src/app/report/user-report-table.component.ts
+++ b/webapp/src/main/webapp/src/app/report/user-report-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, TemplateRef } from '@angular/core';
 import { UserReport } from './report';
 import { getSchoolYears, getSubjectCodes } from './reports';
+import { TranslateService } from '@ngx-translate/core';
 
 class Column {
   id: string;
@@ -58,5 +59,23 @@ export class UserReportTableComponent {
   @Input()
   set userReports(values: UserReport[]) {
     this.rows = (values || []).map(toUserReportTableRow);
+  }
+
+  constructor(private translate: TranslateService) {}
+
+  academicYears(row): string {
+    // use prev year of school year to create academic year : example 2019 => 2018-19
+    return row.schoolYears
+      .map(y => y - 1 + '-' + y.toString().slice(-2))
+      .join(',');
+  }
+
+  subjectName(row) {
+    if (row.subjectCodes.length === 0) {
+      return `${this.translate.instant('reports.all')}`;
+    }
+    return row.subjectCodes.map(
+      c => `${this.translate.instant('subject.' + c + '.name')}`
+    );
   }
 }

--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -2290,3 +2290,7 @@ body .ui-paginator .ui-paginator-pages .ui-paginator-page {
     margin: 0 -20px;
   }
 }
+.user-report-table table td {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}


### PR DESCRIPTION
Changed the columns for the subject and school year to use span and  not ng-containers so a title can be added and the work done to build those fields was moved to TS file.
Added specific style for user-report-table
Changed the Report to a span as well, the width now shows up in the elements in the browser.

unfortunately
 my local browser was still expanding the column to the MyReports table - so I was unable to test the overflow: hidden option, but the hover text is in place.  *Greg* if you can pull down and test.  
If this looks good - reviewer can merge.