### PR TITLE
RDW6, req1 -- retrieve filter options in separate  REST call

### DIFF
--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TestResultAvailabilityOptions.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TestResultAvailabilityOptions.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.admin.model;
 
 import com.google.common.collect.ImmutableList;
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
 import org.opentestsystem.rdw.reporting.common.model.Organization;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +19,11 @@ public class TestResultAvailabilityOptions {
     private List<TestResultsStatus> statuses;     // All the statuses available to the user, sorted by enum order.
     private boolean viewAudit;                    // True if user has permission to view audits.
     private boolean districtAdmin;                // True for district administrator
-    private Collection<Organization> districts;   // Collection of districts for district admins.
+    private Collection<Organization> districts;   // Collection of districts (complete for district admin, possibly size limited for state users.
+    private int districtCount;                    // Total count of districts, in case it is too many to retrieve all at once.
+    private Collection<CodedEntity> subjects;     // Collection of districts
+    private Collection<Integer> schoolYears;      // Collection of active school years in the system.
+    private Collection<TestResultsReportType> reportTypes;
 
     public List<TestResultsStatus> getStatuses() {
         return statuses;
@@ -33,6 +39,22 @@ public class TestResultAvailabilityOptions {
 
     public Collection<Organization> getDistricts() {
         return districts;
+    }
+
+    public int getDistrictCount() {
+        return districtCount;
+    }
+
+    public Collection<CodedEntity> getSubjects() {
+        return subjects;
+    }
+
+    public Collection<Integer> getSchoolYears() {
+        return schoolYears;
+    }
+
+    public Collection<TestResultsReportType> getReportTypes() {
+        return reportTypes;
     }
 
     /**
@@ -54,6 +76,10 @@ public class TestResultAvailabilityOptions {
         private boolean viewAudit;
         private boolean districtAdmin;
         private Collection<Organization> districts;
+        private int districtCount;
+        private Collection<CodedEntity> subjects;
+        private Collection<Integer> schoolYears;
+        private Collection<TestResultsReportType> reportTypes;
 
         public TestResultAvailabilityOptions build() {
             final TestResultAvailabilityOptions options = new TestResultAvailabilityOptions();
@@ -63,7 +89,11 @@ public class TestResultAvailabilityOptions {
             options.statuses = ImmutableList.copyOf(statuses);
             options.viewAudit = viewAudit;
             options.districtAdmin = districtAdmin;
+            options.districtCount = districtCount;
             options.districts = ImmutableList.copyOf(districts);
+            options.subjects = ImmutableList.copyOf(subjects);
+            options.schoolYears = ImmutableList.copyOf(schoolYears);
+            options.reportTypes = ImmutableList.copyOf(reportTypes);
 
             return options;
         }
@@ -73,6 +103,10 @@ public class TestResultAvailabilityOptions {
             viewAudit = options.viewAudit;
             districtAdmin = options.districtAdmin;
             districts = options.districts;
+            districtCount = options.districtCount;
+            subjects = options.subjects;
+            schoolYears = options.schoolYears;
+            reportTypes = options.reportTypes;
 
             return this;
         }
@@ -94,6 +128,26 @@ public class TestResultAvailabilityOptions {
 
         public Builder districts(final Collection<Organization> districts) {
             this.districts = districts;
+            return this;
+        }
+
+        public Builder districtCount(int districtCount) {
+            this.districtCount = districtCount;
+            return this;
+        }
+
+        public Builder subjects(List<CodedEntity> subjects) {
+            this.subjects = subjects;
+            return this;
+        }
+
+        public Builder schoolYears(List<Integer> schoolYears) {
+            this.schoolYears = schoolYears;
+            return this;
+        }
+
+        public Builder reportTypes(TestResultsReportType[] reportTypes) {
+            this.reportTypes = Arrays.asList(reportTypes);
             return this;
         }
     }

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TestResultAvailabilityOptions.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/model/TestResultAvailabilityOptions.java
@@ -21,7 +21,7 @@ public class TestResultAvailabilityOptions {
     private boolean districtAdmin;                // True for district administrator
     private Collection<Organization> districts;   // Collection of districts (complete for district admin, possibly size limited for state users.
     private int districtCount;                    // Total count of districts, in case it is too many to retrieve all at once.
-    private Collection<CodedEntity> subjects;     // Collection of districts
+    private Collection<CodedEntity> subjects;     // Collection of subjects
     private Collection<Integer> schoolYears;      // Collection of active school years in the system.
     private Collection<TestResultsReportType> reportTypes;
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/EmbargoRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/EmbargoRepository.java
@@ -51,6 +51,14 @@ public interface EmbargoRepository {
     List<TestResultAvailability> findTestResultsAvailability(EmbargoQuery query);
 
     /**
+     * Find the total row count for the TestResultsAvailability
+     * @param query query object with filters
+     *
+     * @return count of total rows available to the query
+     */
+    int countByQuery(EmbargoQuery query);
+
+    /**
      * Create new embargo settings.<br/>
      *
      * @param embargo  embargo settings to store

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SchoolYearRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SchoolYearRepository.java
@@ -1,0 +1,14 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import java.util.List;
+
+/**
+ * Repository responsible for accessing school years.
+ */
+public interface SchoolYearRepository {
+
+    /**
+     * @return all active school years, may be empty won't be null
+     */
+    List<Integer> findAll();
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SubjectRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/SubjectRepository.java
@@ -1,0 +1,16 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
+
+import java.util.List;
+
+/**
+ * Repository responsible for accessing subject
+ */
+public interface SubjectRepository {
+
+    /**
+     * @return all subjects, may be empty won't be null
+     */
+    List<CodedEntity> findAll();
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepository.java
@@ -160,8 +160,6 @@ public class JdbcEmbargoRepository implements EmbargoRepository, EmbargoAuditRep
         final String sql = String.format("select count(*) from (%s) as results",
             addOrdering(findTestResultsAvailability, " "));
 
-        System.out.println(sql);
-
         return template.queryForObject(
             sql,
             getSqlParameterSource(noLimitsQuery),

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepository.java
@@ -139,16 +139,6 @@ public class JdbcEmbargoRepository implements EmbargoRepository, EmbargoAuditRep
                 EmbargoExtractor);
     }
 
-    public int countDistricts() {
-        return template.query("select count(*) from district", new MapSqlParameterSource(), rs -> rs.next() ? rs.getInt(1) : 0);
-    }
-
-    public List<String> findAllDistricts() {
-        return template.query("select id, name from district order by id",
-            new MapSqlParameterSource(),
-            (row, index) -> "" + (index + 1) + ":" + row.getInt("id") + ":" + row.getString("name"));
-    }
-
     @Override
     public List<TestResultAvailability> findTestResultsAvailability(final EmbargoQuery query) {
         final String orderBySql = getOrderBy(query.getSortField(), query.isDescending());
@@ -156,20 +146,42 @@ public class JdbcEmbargoRepository implements EmbargoRepository, EmbargoAuditRep
 
         return template.query(
             enhancedSql,
-            new MapSqlParameterSource()
-                .addValue("statuses", nullOrEmptyToDefault(query.getStatusValues(), UNMATCHABLE_STATUSES))
-                .addValue("filter_by_year", query.getSchoolYear() != null)
-                .addValue("year", query.getSchoolYear())
-                .addValue("filter_by_district", !safeIsEmpty(query.getDistrictIds()))
-                .addValue("district_ids", nullOrEmptyToDefault(query.getDistrictIds(), UNMATCHABLE_IDS))
-                .addValue("filter_by_subject", query.getSubjectId() != null)
-                .addValue("subject_id", query.getSubjectId())
-                .addValue("filter_by_report_type", query.getReportType() != null)
-                .addValue("report_type", query.getReportTypeValue())
-                .addValue("page_size", query.getPageSize())
-                .addValue("offset", query.getRowOffset()),
+            getSqlParameterSource(query),
             (row, index) -> mapToTestResults(row)
         );
+    }
+
+    @Override
+    public int countByQuery(final EmbargoQuery query) {
+        // Remove any page limits to ensure we get the proper count.
+        final EmbargoQuery noLimitsQuery = query.copy().rowOffset(0).pageSize(Integer.MAX_VALUE).build();
+
+        // Convert existing SQL to count rows.
+        final String sql = String.format("select count(*) from (%s) as results",
+            addOrdering(findTestResultsAvailability, " "));
+
+        System.out.println(sql);
+
+        return template.queryForObject(
+            sql,
+            getSqlParameterSource(noLimitsQuery),
+            Integer.class
+        );
+    }
+
+    private MapSqlParameterSource getSqlParameterSource(final EmbargoQuery query) {
+        return new MapSqlParameterSource()
+            .addValue("statuses", nullOrEmptyToDefault(query.getStatusValues(), UNMATCHABLE_STATUSES))
+            .addValue("filter_by_year", query.getSchoolYear() != null)
+            .addValue("year", query.getSchoolYear())
+            .addValue("filter_by_district", !safeIsEmpty(query.getDistrictIds()))
+            .addValue("district_ids", nullOrEmptyToDefault(query.getDistrictIds(), UNMATCHABLE_IDS))
+            .addValue("filter_by_subject", query.getSubjectId() != null)
+            .addValue("subject_id", query.getSubjectId())
+            .addValue("filter_by_report_type", query.getReportType() != null)
+            .addValue("report_type", query.getReportTypeValue())
+            .addValue("page_size", query.getPageSize())
+            .addValue("offset", query.getRowOffset());
     }
 
     private String getOrderBy(final String sortField, final boolean descending) {

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepository.java
@@ -1,0 +1,33 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
+import org.opentestsystem.rdw.admin.repository.SubjectRepository;
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JdbcSchoolYearRepository implements SchoolYearRepository {
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.schoolYear.findAll}")
+    private String findAllQuery;
+
+    @Autowired
+    JdbcSchoolYearRepository(@Qualifier("warehouseJdbcTemplate") final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<Integer> findAll() {
+        return template.query(
+            findAllQuery,
+            (row, index) -> row.getInt("year")
+        );
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSubjectRepository.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSubjectRepository.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.opentestsystem.rdw.admin.repository.SubjectRepository;
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JdbcSubjectRepository implements SubjectRepository {
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.subject.findAll}")
+    private String findAllQuery;
+
+    @Autowired
+    JdbcSubjectRepository(@Qualifier("warehouseJdbcTemplate") final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<CodedEntity> findAll() {
+        return template.query(
+            findAllQuery,
+            (row, index) -> CodedEntity.builder()
+                .id(row.getInt("id"))
+                .code(row.getString("code"))
+                .build()
+        );
+    }
+}

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/EmbargoService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/EmbargoService.java
@@ -49,9 +49,17 @@ public interface EmbargoService {
      *
      * @param query query parameters for the search
      * @param user the user
-     * @return collection of {@link TestResultAvailability}
+     * @return list of {@link TestResultAvailability} sorted according to the query request
      */
-    Collection<TestResultAvailability> findTestResults(EmbargoQuery query, User user);
+    List<TestResultAvailability> findTestResults(EmbargoQuery query, User user);
+
+    /**
+     * Returns a count of the total Test Results based on the filters in the query.
+     * @param query query parameters for the count. Any offset, page size, and sort will be ignored.
+     * @param user the user
+     * @return count of the total test results based on permissions and filters.
+     */
+    int countTestResults(EmbargoQuery query, User user);
 
     /**
      * Returns date and time order list of updates to the embargo statuses.

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultEmbargoService.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultEmbargoService.java
@@ -7,14 +7,19 @@ import org.opentestsystem.rdw.admin.model.EmbargoAuditRecord;
 import org.opentestsystem.rdw.admin.model.EmbargoQuery;
 import org.opentestsystem.rdw.admin.model.TestResultAvailability;
 import org.opentestsystem.rdw.admin.model.TestResultAvailabilityOptions;
+import org.opentestsystem.rdw.admin.model.TestResultsReportType;
 import org.opentestsystem.rdw.admin.model.TestResultsStatus;
 import org.opentestsystem.rdw.admin.repository.EmbargoAuditRepository;
 import org.opentestsystem.rdw.admin.repository.EmbargoRepository;
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
+import org.opentestsystem.rdw.admin.repository.SubjectRepository;
+import org.opentestsystem.rdw.admin.repository.DistrictRepository;
 import org.opentestsystem.rdw.admin.repository.ImportRepository;
 import org.opentestsystem.rdw.admin.service.EmbargoService;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
+import org.opentestsystem.rdw.reporting.common.model.CodedEntity;
 import org.opentestsystem.rdw.reporting.common.model.Organization;
 import org.opentestsystem.rdw.reporting.common.model.OrganizationQuery;
 import org.opentestsystem.rdw.reporting.common.model.OrganizationType;
@@ -64,18 +69,24 @@ public class DefaultEmbargoService implements EmbargoService {
     private final OrganizationRepository organizationRepository;
     private final ImportRepository importRepository;
     private final ReportingSystemProperties reportingSystemProperties;
+    private final SubjectRepository subjectRepository;
+    private final SchoolYearRepository schoolYearRepository;
 
     @Autowired
     public DefaultEmbargoService(final EmbargoRepository repository,
                                  final EmbargoAuditRepository auditRepository,
                                  @Qualifier("warehouseOrganizationRepository") final OrganizationRepository organizationRepository,
                                  final ImportRepository importRepository,
-                                 @Qualifier("reportingSystemPropertiesResolver") final ReportingSystemProperties reportingSystemProperties) {
+                                 @Qualifier("reportingSystemPropertiesResolver") final ReportingSystemProperties reportingSystemProperties,
+                                 final SubjectRepository subjectRepository,
+                                 final SchoolYearRepository schoolYearRepository) {
         this.repository = repository;
         this.auditRepository = auditRepository;
         this.organizationRepository = organizationRepository;
         this.importRepository = importRepository;
         this.reportingSystemProperties = reportingSystemProperties;
+        this.subjectRepository = subjectRepository;
+        this.schoolYearRepository = schoolYearRepository;
     }
 
     @Transactional(transactionManager = "warehouseTxManager")
@@ -139,7 +150,28 @@ public class DefaultEmbargoService implements EmbargoService {
     }
 
     @Override
-    public Collection<TestResultAvailability> findTestResults(final EmbargoQuery query, final User user) {
+    public List<TestResultAvailability> findTestResults(final EmbargoQuery query, final User user) {
+        return repository.findTestResultsAvailability(
+            reconcileQueryWithUserPermissions(query, user));
+    }
+
+
+    @Override
+    public int countTestResults(EmbargoQuery query, User user) {
+        return repository.countByQuery(
+            reconcileQueryWithUserPermissions(query, user));
+    }
+
+    /***
+     * Reconciles the query with the permissions of the user. Errors if the query is not permitted at all.
+     * Otherwise returns a possibly modified query with status and district restrictions approprite for the
+     * user.
+     *
+     * @param query the original requested query
+     * @param user the user
+     * @return modified query compatible with user permissions.
+     */
+    private EmbargoQuery reconcileQueryWithUserPermissions(EmbargoQuery query, User user) {
         final boolean loader = user.getPermissionsById().get(TestDataLoadingWrite) != null;
 
         final boolean stateReviewer =
@@ -172,12 +204,10 @@ public class DefaultEmbargoService implements EmbargoService {
         final Set<TestResultsStatus> filterStatuses = statusFilters(
             loader, districtReviewer || stateReviewer, query.getStatuses());
 
-        final EmbargoQuery permittedQuery = query.copy()
+        return query.copy()
             .districtIds(filterDistrictIds)
             .statuses(filterStatuses)
             .build();
-
-        return repository.findTestResultsAvailability(permittedQuery);
     }
 
     private Set<Long> districtFilters(Set<Long> allowedDistrictIds, Set<Long> queryDistrictIds) {
@@ -272,19 +302,30 @@ public class DefaultEmbargoService implements EmbargoService {
         final Permission loadingPermission = user.getPermissionsById().get(TestDataLoadingWrite);
         final Permission reviewingPermission = user.getPermissionsById().get(TestDataReviewingWrite);
 
+        if (loadingPermission == null && reviewingPermission == null) {
+            throw new NoSuchElementException("Not authorized to retrieve filter options");
+        }
+
         final boolean districtAdmin = reviewingPermission != null && !reviewingPermission.getScope().isStatewide();
-        final Collection<Organization> districts = districtAdmin ?
+
+        // TODO: for statewide users, we should populate the list if there are fewer than n total districts.
+        final Collection<Organization> districts =  districtAdmin ?
             getDistrictsForReview(reviewingPermission.getScope()) :
             Collections.emptyList();
 
+        final List<CodedEntity> subjects = subjectRepository.findAll();
+        final List<Integer> schoolYears = schoolYearRepository.findAll();
         final boolean viewAudit = loadingPermission != null;
         final Set<TestResultsStatus> statuses = getIncludeStatuses(loadingPermission, reviewingPermission);
 
         return TestResultAvailabilityOptions.builder()
             .districtAdmin(districtAdmin)
             .districts(districts)
-            .viewAudit(viewAudit)
+            .subjects(subjects)
+            .schoolYears(schoolYears)
             .statuses(statuses)
+            .reportTypes(TestResultsReportType.values())
+            .viewAudit(viewAudit)
             .build();
     }
 

--- a/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TestResultsController.java
+++ b/admin-service/src/main/java/org/opentestsystem/rdw/admin/web/TestResultsController.java
@@ -39,7 +39,7 @@ public class TestResultsController {
      * @return collection of embargo settings for which the user has permission
      */
     @PostMapping
-    public Collection<TestResultAvailability> get(
+    public Collection<TestResultAvailability> findByQuery(
         @AuthenticationPrincipal final User user,
         @RequestBody final EmbargoQuery query) {
         return service.findTestResults(query, user);
@@ -48,5 +48,12 @@ public class TestResultsController {
     @GetMapping("/filters")
     public TestResultAvailabilityOptions getFilters(@AuthenticationPrincipal final User user) {
         return service.getFilterOptions(user);
+    }
+
+    @PostMapping("/count")
+    public Integer countByQuery(
+        @AuthenticationPrincipal final User user,
+        @RequestBody final EmbargoQuery query) {
+        return service.countTestResults(query, user);
     }
 }

--- a/admin-service/src/main/resources/application.sql.yml
+++ b/admin-service/src/main/resources/application.sql.yml
@@ -108,8 +108,8 @@ sql:
                   y.year = ec.school_year and
                   d.id = ec.district_id and
                   s.id = ec.subject_id
-      WHERE ((ert.name = 'Individual' AND coalesce(individual, 0) IN (:statuses)) OR
-              (ert.name = 'Aggregate' AND coalesce(aggregate, 0) IN (:statuses)))
+      WHERE ((ert.name = 'Individual' AND coalesce(de.individual, 0) IN (:statuses)) OR
+              (ert.name = 'Aggregate' AND coalesce(de.aggregate, 0) IN (:statuses)))
               AND (:filter_by_year = 0 OR y.year = :year)
               AND (:filter_by_district = 0 OR d.id IN (:district_ids))
               AND (:filter_by_subject = 0 OR s.id = :subject_id)

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepositoryIT.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcEmbargoRepositoryIT.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.admin.repository.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional(transactionManager = "warehouseTxManager")
 public class JdbcEmbargoRepositoryIT {
 
-    // Default sort for TestResultsAvailabiility query
+    private static final int TotalRecordsInTestData = 60;
+
+    // Default sort for TestResultsAvailability query
     private static final Comparator<TestResultAvailability> DefaultSort =
        Comparator.comparingInt(TestResultAvailability::getSchoolYear).reversed()
            .thenComparing(TestResultAvailability::getDistrictName)
@@ -179,9 +180,11 @@ public class JdbcEmbargoRepositoryIT {
             .build();
 
         final List<TestResultAvailability> testResults = repository.findTestResultsAvailability(query);
-        assertThat(testResults).hasSize(60);
+        assertThat(testResults).hasSize(TotalRecordsInTestData);
         assertThat(testResults).isSortedAccordingTo(DefaultSort);
         assertThat(testResults.stream().allMatch(r -> r.getExamCount().equals(5))).isTrue();
+
+        assertThat(repository.countByQuery(query)).isEqualTo(TotalRecordsInTestData);
     }
 
     @Test
@@ -194,6 +197,9 @@ public class JdbcEmbargoRepositoryIT {
 
         final List<TestResultAvailability> testResults = repository.findTestResultsAvailability(query);
         assertThat(testResults).hasSize(10);
+
+        // Total count should be the name regardless of page size or offset
+        assertThat(repository.countByQuery(query)).isEqualTo(TotalRecordsInTestData);
     }
 
     @Test
@@ -205,6 +211,9 @@ public class JdbcEmbargoRepositoryIT {
             .build();
 
         final List<TestResultAvailability> testResults = repository.findTestResultsAvailability(query);
+
+        // Total count should be the name regardless of page size or offset
+        assertThat(repository.countByQuery(query)).isEqualTo(TotalRecordsInTestData);
 
         final EmbargoQuery query2 = query.copy().rowOffset(1).build();
         final List<TestResultAvailability> testResults2 = repository.findTestResultsAvailability(query2);
@@ -222,8 +231,10 @@ public class JdbcEmbargoRepositoryIT {
             .build();
 
         final List<TestResultAvailability> testResults = repository.findTestResultsAvailability(query);
-        assertThat(testResults).hasSize(12);
+        assertThat(testResults).hasSize(TotalRecordsInTestData/5); // Because filtering in one year out of the five
         assertThat(testResults.stream().allMatch(r -> r.getSchoolYear().equals(2017)));
+
+        assertThat(repository.countByQuery(query)).isEqualTo(TotalRecordsInTestData/5);
     }
 
     @Test
@@ -251,7 +262,7 @@ public class JdbcEmbargoRepositoryIT {
 
         final List<TestResultAvailability> testResults = repository.findTestResultsAvailability(query);
         assertThat(testResults).hasSize(30);
-        assertThat(testResults.stream().allMatch(r -> r.getSubjectId().equals(1)));
+        assertThat(testResults.stream().allMatch(r -> r.getSubjectId().equals(1L)));
     }
 
     @Test

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepositoryIT.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSchoolYearRepositoryIT.java
@@ -1,0 +1,32 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {
+    JdbcSchoolYearRepository.class
+})
+@Sql(config = @SqlConfig(dataSource = "warehouseDatasource", transactionManager = "warehouseTxManager"),
+    scripts = {"classpath:embargo-test-data.sql"}
+)
+@Transactional(transactionManager = "warehouseTxManager")
+public class JdbcSchoolYearRepositoryIT {
+    @Autowired
+    JdbcSchoolYearRepository repository;
+
+    @Test
+    public void itShouldFindAllSchoolYears() {
+        assertThat(repository.findAll()).hasSize(5);
+    }
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSubjectRepositoryIT.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcSubjectRepositoryIT.java
@@ -1,0 +1,32 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {
+    JdbcSubjectRepository.class
+})
+@Sql(config = @SqlConfig(dataSource = "warehouseDatasource", transactionManager = "warehouseTxManager"),
+    scripts = {"classpath:embargo-test-data.sql"}
+)
+@Transactional(transactionManager = "warehouseTxManager")
+public class JdbcSubjectRepositoryIT {
+    @Autowired
+    JdbcSubjectRepository repository;
+
+    @Test
+    public void itShouldFindAllSubjects() {
+        assertThat(repository.findAll()).hasSize(2);
+    }
+}

--- a/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultEmbargoServiceTest.java
+++ b/admin-service/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultEmbargoServiceTest.java
@@ -11,9 +11,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.opentestsystem.rdw.admin.model.Embargo;
 import org.opentestsystem.rdw.admin.model.EmbargoQuery;
 import org.opentestsystem.rdw.admin.model.TestResultsStatus;
+import org.opentestsystem.rdw.admin.repository.DistrictRepository;
 import org.opentestsystem.rdw.admin.repository.EmbargoAuditRepository;
 import org.opentestsystem.rdw.admin.repository.EmbargoRepository;
 import org.opentestsystem.rdw.admin.repository.ImportRepository;
+import org.opentestsystem.rdw.admin.repository.SchoolYearRepository;
+import org.opentestsystem.rdw.admin.repository.SubjectRepository;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemPropertiesImpl;
@@ -58,6 +61,12 @@ public class DefaultEmbargoServiceTest {
     @Mock
     private ImportRepository importRepository;
     @Mock
+    private SubjectRepository subjectRepository;
+    @Mock
+    private DistrictRepository districtRepository;
+    @Mock
+    private SchoolYearRepository groupRepository;
+    @Mock
     public User user;
 
     public EmbargoQuery query;
@@ -88,7 +97,14 @@ public class DefaultEmbargoServiceTest {
             .rowOffset(0)
             .build();
 
-        service = new DefaultEmbargoService(repository, auditRepository, organizationRepository, importRepository, systemSettings);
+        service = new DefaultEmbargoService(
+            repository,
+            auditRepository,
+            organizationRepository,
+            importRepository,
+            systemSettings,
+            subjectRepository,
+            groupRepository);
     }
 
     @Test

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/model/page-settings-type.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/model/page-settings-type.ts
@@ -1,0 +1,6 @@
+export interface PageSettingsType {
+  offset: number;
+  sortField: string;
+  descending: boolean;
+  pageSize: number;
+}

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/model/user-options.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/model/user-options.ts
@@ -2,5 +2,8 @@ export interface UserOptions {
   viewAudit: boolean;
   districtAdmin: boolean;
   districts: { label: string; value: number }[];
+  subjects: { label: string; value: number }[];
   statuses: { label: string; value: string }[];
+  schoolYears: { label: string; value: number }[];
+  reportTypes: { label: string; value: string }[];
 }

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/service/test-results-availability.service.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/service/test-results-availability.service.ts
@@ -13,6 +13,7 @@ import {
 import { UserOptions } from '../model/user-options';
 import { ResponseContentType } from '@angular/http';
 import { EmbargoQueryType } from '../model/embargo-query-type';
+import { PageSettingsType } from '../model/page-settings-type';
 
 const ResourceContext = `${AdminServiceRoute}/testResults`;
 const ServiceRoute = `${AdminServiceRoute}/embargoes`;
@@ -28,19 +29,19 @@ export class TestResultsAvailabilityService implements OnInit {
     @Inject(DATA_CONTEXT_URL) private contextUrl: string = '/api'
   ) {}
 
-  static readonly NoFiltersNumeric = -1;
-  static readonly NoFiltersText = 'All';
-
   static readonly FilterIncludeAll = {
     label: 'test-results-availability.all-text',
     value: null
   };
 
-  private testResultFilters: TestResultAvailabilityFilters = new TestResultAvailabilityFilters();
-  private defaultTestResultFilters = new TestResultAvailabilityFilters();
-
   successfulChange: boolean;
 
+  /**
+   * Converts an embargo record from the backend into a typescript object.
+   * @param source one record returned from the finder as json
+   *
+   * @return TestResultAvailability object.
+   */
   private static toTestResultAvailability(source: any): TestResultAvailability {
     return {
       schoolYear: { label: '' + source.schoolYear, value: source.schoolYear },
@@ -52,79 +53,130 @@ export class TestResultsAvailabilityService implements OnInit {
     };
   }
 
+  /**
+   * Converts the filter options returned by the backend for this user into a TypeScript object.
+   * @param source the data record returned by the backend as json
+   *
+   * @return a UserOptions object.
+   */
   private static toOptions(source: any): UserOptions {
+    const toSubjectKey = label => 'subject.' + label + '.name';
+    const toReportTypeKey = label =>
+      'test-results-availability.reportType.' + label;
+    const toStatusKey = label => 'test-results-availability.status.' + label;
+
     const statuses = source.statuses.map(stat => {
-      return { label: stat, value: stat };
+      return { label: toStatusKey(stat), value: stat };
     });
+    statuses.unshift(TestResultsAvailabilityService.FilterIncludeAll);
 
     const sourceDistricts = source.districts || [];
-    const districts = sourceDistricts.map(dist => {
-      return { label: dist.name, value: dist.id };
-    });
+    const districts = sourceDistricts
+      .map(dist => {
+        return { label: dist.name, value: dist.id };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    // Don't give an All option to district admins with only one district.
+    if (!(source.districtAdmin && source.districts.length === 1)) {
+      districts.unshift(TestResultsAvailabilityService.FilterIncludeAll);
+    }
+
+    const schoolYears = source.schoolYears
+      .map(year => {
+        return { label: year.toString(), value: year };
+      })
+      .sort((a, b) => b.value - a.value);
+    schoolYears.unshift(TestResultsAvailabilityService.FilterIncludeAll);
+
+    const subjects = source.subjects
+      .map(sub => {
+        return { label: toSubjectKey(sub.code), value: sub.id };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+    subjects.unshift(TestResultsAvailabilityService.FilterIncludeAll);
+
+    const reportTypes = source.reportTypes
+      .map(type => {
+        return { label: toReportTypeKey(type), value: type };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+    reportTypes.unshift(TestResultsAvailabilityService.FilterIncludeAll);
 
     return {
       viewAudit: source.viewAudit,
       districtAdmin: source.districtAdmin,
       districts: districts,
-      statuses: statuses
+      statuses: statuses,
+      subjects: subjects,
+      schoolYears: schoolYears,
+      reportTypes: reportTypes
     };
   }
 
-  private static matchesFilters(
-    testResult: TestResultAvailability,
-    testResultFilters: TestResultAvailabilityFilters
-  ) {
-    // may need to adjust order
-    return ['status', 'reportType', 'subject', 'district', 'schoolYear'].every(
-      field => {
-        return TestResultsAvailabilityService.isMatch(
-          field,
-          testResultFilters,
-          testResult
-        );
-      }
-    );
-  }
+  ngOnInit(): void {}
 
-  static isMatch(
-    field: string,
-    filters: TestResultAvailabilityFilters,
-    testResult: TestResultAvailability
-  ): boolean {
-    return (
-      filters[field] === TestResultsAvailabilityService.FilterIncludeAll ||
-      filters[field].value === testResult[field].value
-    );
-  }
+  // formatAsLocalDate(date: Date): string {
+  //   return this.datePipe.transform(date, 'yyyy-MM-dd');
+  // }
 
-  ngOnInit(): void {
-    this.setTestResultFilterDefaults();
-    this.testResultFilters = this.getTestResultAvailabilityFilterDefaults();
-  }
-
-  formatAsLocalDate(date: Date): string {
-    return this.datePipe.transform(date, 'yyyy-MM-dd');
-  }
-
-  // receive test results and apply filter's options
+  /**
+   * Gets one page of test results for the given page settings and filters.
+   *
+   * @param pageSettings filters, page size and offset, and sort.
+   * @param filters currently applied data filters
+   */
   getTestResults(
-    testResultFilters: TestResultAvailabilityFilters,
-    query: EmbargoQueryType
+    pageSettings: PageSettingsType,
+    filters: TestResultAvailabilityFilters
   ): Observable<TestResultAvailability[]> {
-    // Default Sort order from query:
-    // SchoolYear(D),District (by name) (A),Subject (by ID) (A), ReportType(A), Status(A)
-    console.log('Post to data service');
+    const query: EmbargoQueryType = {
+      pageSize: pageSettings.pageSize,
+      rowOffset: pageSettings.offset,
+      sortField: pageSettings.sortField,
+      descending: pageSettings.descending,
+      schoolYear: filters.schoolYear.value,
+      subjectId: filters.subject.value,
+      reportType: filters.reportType.value,
+      districtIds: filters.district.value ? [filters.district.value] : null,
+      statuses: filters.status.value ? [filters.status.value] : null
+    };
+
     return this.dataService.post(`${ResourceContext}`, query).pipe(
       map((sourceTestResults: any[]) => {
-        return sourceTestResults
-          .map(r => TestResultsAvailabilityService.toTestResultAvailability(r))
-          .filter(r =>
-            TestResultsAvailabilityService.matchesFilters(r, testResultFilters)
-          );
+        return sourceTestResults.map(r =>
+          TestResultsAvailabilityService.toTestResultAvailability(r)
+        );
       })
     );
   }
 
+  /**
+   * Gets total row count for the given filters.
+   *
+   * @param filters
+   */
+  getRowCount(filters: TestResultAvailabilityFilters): Observable<number> {
+    const query: EmbargoQueryType = {
+      pageSize: 0,
+      rowOffset: 0,
+      schoolYear: filters.schoolYear.value,
+      subjectId: filters.subject.value,
+      reportType: filters.reportType.value,
+      districtIds: filters.district.value ? [filters.district.value] : null,
+      statuses: filters.status.value ? [filters.status.value] : null
+    };
+
+    return this.dataService.post(`${ResourceContext}/count`, query).pipe(
+      map((source: number) => {
+        return source;
+      })
+    );
+  }
+
+  /**
+   * Gets the options for the filter dropdowns and some user permission settings.
+   */
   getUserOptions(): Observable<UserOptions> {
     return this.dataService.get(`${ResourceContext}/filters`).pipe(
       map((sourceUserSettings: any) => {
@@ -147,7 +199,6 @@ export class TestResultsAvailabilityService implements OnInit {
   ) {
     console.log('Change Request Log Info:', newStatus, testResultFilters);
     this.successfulChange = false;
-    this.testResultFilters.status = newStatus;
     this.logTestResults(testResultFilters, newStatus.value);
     this.successfulChange = true;
   }
@@ -172,18 +223,5 @@ export class TestResultsAvailabilityService implements OnInit {
       )
       .pipe()
       .subscribe();
-  }
-
-  setTestResultFilterDefaults() {
-    ['status', 'reportType', 'subject', 'district', 'schoolYear'].forEach(
-      field => {
-        this.defaultTestResultFilters[field] =
-          TestResultsAvailabilityService.FilterIncludeAll;
-      }
-    );
-  }
-
-  getTestResultAvailabilityFilterDefaults(): TestResultAvailabilityFilters {
-    return this.defaultTestResultFilters;
   }
 }

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability-change-status.modal.ts
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability-change-status.modal.ts
@@ -40,7 +40,8 @@ export class TestResultsAvailabilityChangeStatusModal implements OnInit {
   }
 
   ngOnInit(): void {
-    this.selectedFilters = this.service.getTestResultAvailabilityFilterDefaults();
+    // TODO: pass in filters from component
+    this.selectedFilters = null; // this.service.getTestResultAvailabilityFilterDefaults();
     this.showSandboxAlert = false;
     this.successfulChange = false;
   }

--- a/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.html
+++ b/webapp/src/main/webapp/src/app/admin/test-results-availability/test-results-availability.component.html
@@ -2,7 +2,11 @@
   <h1 class="h2" heading>
     {{ 'test-results-availability.title' | translate }}
   </h1>
-  <ul class="list-unstyled list-inline" controls *ngIf="(viewAudit$ | async)">
+  <ul
+    class="list-unstyled list-inline"
+    controls
+    *ngIf="userOptions && userOptions.viewAudit"
+  >
     <li>
       <a
         class="btn btn-default"
@@ -83,19 +87,21 @@
             </option>
           </select>
         </div>
+
         <!-- School Year Select -->
         <div class="col-md-2 test-left">
           <label for="select-schoolyear">{{
             'test-results-availability.filter-school-year' | translate
           }}</label>
           <select
+            *ngIf="userOptions"
             id="select-schoolyear"
             [(ngModel)]="testResultAvailabilityFilters.schoolYear"
             class="form-control"
             (ngModelChange)="onChangeSchoolYearFilter($event)"
           >
             <option
-              *ngFor="let schoolYear of (schoolYearOptions$ | async)"
+              *ngFor="let schoolYear of userOptions.schoolYears"
               [ngValue]="schoolYear"
             >
               {{ schoolYear.label | translate }}
@@ -105,21 +111,28 @@
 
         <!-- District Select  -->
         <div class="col-md-2 text-left">
-          <label for="select-district" *ngIf="(isDistrictAdmin$ | async)">
+          <label
+            for="select-district"
+            *ngIf="userOptions && userOptions.districtAdmin"
+          >
             {{ 'test-results-availability.district-admin' | translate }}
           </label>
-          <label for="select-district" *ngIf="!(isDistrictAdmin$ | async)">
+          <label
+            for="select-district"
+            *ngIf="!(userOptions && userOptions.districtAdmin)"
+          >
             {{ 'test-results-availability.filter-district' | translate }}
           </label>
           <select
+            *ngIf="userOptions"
             id="select-district"
             [(ngModel)]="testResultAvailabilityFilters.district"
             class="form-control"
             (ngModelChange)="onChangeDistrictFilter($event)"
-            [disabled]="((districtOptions$ | async) || []).length == 1"
+            [disabled]="userOptions.districts.length == 1"
           >
             <option
-              *ngFor="let district of (districtOptions$ | async)"
+              *ngFor="let district of userOptions.districts"
               [ngValue]="district"
             >
               {{ district.label | translate }}
@@ -128,18 +141,19 @@
         </div>
 
         <!-- Subject Select  -->
-        <div class="col-md-2">
+        <div *ngIf="userOptions" class="col-md-2">
           <label for="select-subject"
             >{{ 'test-results-availability.filter-subject' | translate }}
           </label>
           <select
+            *ngIf="userOptions"
             id="select-subject"
             [(ngModel)]="testResultAvailabilityFilters.subject"
             class="form-control"
             (ngModelChange)="onChangeSubjectFilter($event)"
           >
             <option
-              *ngFor="let subject of (subjectOptions$ | async)"
+              *ngFor="let subject of userOptions.subjects"
               [ngValue]="subject"
             >
               {{ subject.label | translate }}
@@ -161,13 +175,14 @@
             ></span>
           </label>
           <select
+            *ngIf="userOptions"
             id="select-report-type"
             [(ngModel)]="testResultAvailabilityFilters.reportType"
             class="form-control"
             (ngModelChange)="onChangeReportTypeFilter($event)"
           >
             <option
-              *ngFor="let reportType of (reportTypeOptions$ | async)"
+              *ngFor="let reportType of userOptions.reportTypes"
               [ngValue]="reportType"
             >
               {{ reportType.label | translate }}
@@ -189,13 +204,14 @@
             ></span
           ></label>
           <select
+            *ngIf="userOptions"
             id="select-status"
             [(ngModel)]="testResultAvailabilityFilters.status"
             class="form-control"
             (ngModelChange)="onChangeStatusFilter($event)"
           >
             <option
-              *ngFor="let status of (statusOptions$ | async)"
+              *ngFor="let status of userOptions.statuses"
               [ngValue]="status"
             >
               {{ status.label | translate }}
@@ -212,20 +228,22 @@
     <div class="well well-results">
       {{ 'test-results-availability.selected-title' | translate }}
 
-      <div class="table-list-container mt-sm">
+      <div
+        *ngIf="testResultAvailabilityFilters"
+        class="table-list-container mt-sm"
+      >
         <p-table
           [columns]="columns"
-          [value]="displayData$ | async"
+          [value]="displayData || []"
           [lazy]="true"
           (onLazyLoad)="resultsTablePageChange($event)"
           [paginator]="true"
-          [rows]="rowsPerPage"
-          sortField="name"
-          [autoLayout]="true"
-          [totalRecords]="totalRowCount"
+          [rows]="pageSettings.pageSize"
+          [totalRecords]="rowCount || 0"
           [loading]="loading"
-          [currentPageReportTemplate]="'{currentPage} of {totalPages}'"
-          [showCurrentPageReport]="true"
+          sortField="default"
+          [autoLayout]="true"
+          [showCurrentPageReport]="false"
         >
           <ng-template pTemplate="header" let-columns>
             <tr>
@@ -259,12 +277,7 @@
           >
             <tr [ngClass]="testResultsRowStyleClass(rowData)">
               <td *ngFor="let column of columns">
-                <span *ngIf="column.hasNameField">
-                  {{ group[column.field].name }}
-                </span>
-                <span *ngIf="!column.hasNameField">
-                  {{ group[column.field] }}
-                </span>
+                {{ group[column.field] }}
               </td>
             </tr>
           </ng-template>
@@ -280,7 +293,7 @@
       </div>
       <div class="modal-footer table-footer">
         <button
-          [disabled]="filteredResultsEmpty$ | async"
+          [disabled]="!rowCount || !testResultAvailabilityFilters.status.value"
           (click)="openChangeResultsModal()"
           class="btn btn-primary"
           type="button"


### PR DESCRIPTION
Test results availability data in now paged, so the filter options can't be derived from the results, so must be retrieved up front. Also, more careful consumption of the server data, since multiple subscriptions and pipes through async were causing the framework to rerun queries unnecessarily, significantly affecting performance.