### PR TITLE
Hotfix: default aggregate report add-ons sql being overwritten.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/sqlbuilder/QueryProvider.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,7 +53,9 @@ public class QueryProvider {
 
         // get the default addons, and replace any template-specific addons
         // this allows us to easily get the addons, preferring the report template while falling back to defaults
-        final Map<String, SqlTemplate> defaultAddons = sqlBuilderConfig.getTemplates().get(DefaultTemplateName).getAddons();
+        // (Note: shallow copy is enough to ensure map doesn't get corrupted by the overrides.)
+        final Map<String, SqlTemplate> defaultAddons =
+            new HashMap<>(sqlBuilderConfig.getTemplates().get(DefaultTemplateName).getAddons());
         if (template.getAddons() != null) {
             defaultAddons.putAll(template.getAddons());
         }


### PR DESCRIPTION
Bug caused add-on SQL fragments in default template to be overwritten by fragments from other report template, particularly the one for longitudinal reports. 