### PR TITLE
SRS-511: Target Reports running when minimum threshold not met

### DIFF
--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcTargetReportRepository.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/repository/impl/JdbcTargetReportRepository.java
@@ -52,9 +52,6 @@ public class JdbcTargetReportRepository
         extends AbstractReportRepository<TargetRow, TargetReportResult, TargetOrganizationQuery, TargetReportResult.Builder>
         implements TargetReportRepository {
 
-    @Value("${reporting.target-report.insufficient-data-cutoff}")
-    private Double insufficientDataCutoff;
-
     /**
      * Constructor
      */
@@ -123,7 +120,7 @@ public class JdbcTargetReportRepository
                                                         final Target target) {
 
         if (!target.isIncludeInReport()) return Excluded;
-        if (stdErr > insufficientDataCutoff) return InsufficientData;
+        if (stdErr > getInsufficientDataCutoff()) return InsufficientData;
         if (avgScore >= stdErr) return TargetReportingLevel.Above;
         if (avgScore <= (-1 * stdErr)) return TargetReportingLevel.Below;
         return TargetReportingLevel.Near;
@@ -178,5 +175,11 @@ public class JdbcTargetReportRepository
                 .build();
     }
 
+    private Double getInsufficientDataCutoff() {
+        if (reportingSystemProperties != null && reportingSystemProperties.getTargetReport() != null) {
+            return reportingSystemProperties.getTargetReport().getInsufficientDataCutoff();
+        }
 
+        return 0.0;
+    }
 }

--- a/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/TargetReportQueryHandler.java
+++ b/aggregate-service/src/main/java/org/opentestsystem/rdw/olap/service/impl/TargetReportQueryHandler.java
@@ -1,7 +1,6 @@
 package org.opentestsystem.rdw.olap.service.impl;
 
 import org.opentestsystem.rdw.common.model.AssessmentType;
-import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingProperties;
 import org.opentestsystem.rdw.olap.model.SubjectAssessment;
 import org.opentestsystem.rdw.olap.model.TargetOrganizationQuery;
 import org.opentestsystem.rdw.olap.model.TargetReportResult;
@@ -9,6 +8,8 @@ import org.opentestsystem.rdw.olap.model.TargetReportResult.Builder;
 import org.opentestsystem.rdw.olap.repository.TargetReportRepository;
 import org.opentestsystem.rdw.olap.service.AuthorizationService;
 import org.opentestsystem.rdw.olap.service.SubjectService;
+import org.opentestsystem.rdw.reporting.common.configuration.AggregateReportingProperties;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
 import org.opentestsystem.rdw.reporting.common.model.AggregateQuery;
 import org.opentestsystem.rdw.reporting.common.model.DimensionType;
 import org.opentestsystem.rdw.reporting.common.model.ReportQueryType;
@@ -16,7 +17,7 @@ import org.opentestsystem.rdw.reporting.common.model.TargetReportQuery;
 import org.opentestsystem.rdw.reporting.common.model.TargetRow;
 import org.opentestsystem.rdw.reporting.common.security.User;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
@@ -35,20 +36,21 @@ class TargetReportQueryHandler extends AbstractAggregateQueryHandler<TargetRow,
         TargetOrganizationQuery.Builder> {
 
     private final SubjectService subjectService;
-    private final int minNumberOfStudents;
+    private final ReportingSystemProperties reportingSystemProperties;
 
     @Autowired
     TargetReportQueryHandler(
-            final TargetReportRepository repository,
-            final AuthorizationService authorizationService,
-            final AggregateReportingProperties aggregateReportingProperties,
-            final TargetQueryConverter queryConverter,
-            final TaskExecutor threadPoolTaskExecutor,
-            final SubjectService subjectService,
-            @Value("${reporting.target-report.min-number-of-students}") final int minNumberOfStudents) {
+        final TargetReportRepository repository,
+        final AuthorizationService authorizationService,
+        final AggregateReportingProperties aggregateReportingProperties,
+        final TargetQueryConverter queryConverter,
+        final TaskExecutor threadPoolTaskExecutor,
+        final SubjectService subjectService,
+        final @Qualifier("reportingSystemPropertiesResolver") ReportingSystemProperties reportingSystemProperties) {
+
         super(repository, queryConverter, authorizationService, aggregateReportingProperties, threadPoolTaskExecutor);
         this.subjectService = subjectService;
-        this.minNumberOfStudents = minNumberOfStudents;
+        this.reportingSystemProperties = reportingSystemProperties;
     }
 
     /**
@@ -70,12 +72,22 @@ class TargetReportQueryHandler extends AbstractAggregateQueryHandler<TargetRow,
 
         for (final TargetRow row : reportResult.getPayload()) {
             if (row.getDimension().getType() == DimensionType.Overall) {
-                return (row.getMeasures().getStudentCount() >= minNumberOfStudents) ? reportResult
+                return (row.getMeasures().getStudentCount() >= getMinNumberOfStudents()) ? reportResult
                         : reportResult.copy().notEnoughResults(true).build();
             }
         }
 
         throw new IllegalStateException("missing row with Overall dimension");
+    }
+
+    protected int getMinNumberOfStudents() {
+        if (this.reportingSystemProperties != null &&
+            this.reportingSystemProperties.getTargetReport() != null &&
+            this.reportingSystemProperties.getTargetReport().getMinNumberOfStudents() != null) {
+            return this.reportingSystemProperties.getTargetReport().getMinNumberOfStudents();
+        }
+
+        return 0;
     }
 
     @Override

--- a/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/service/impl/TargetReportQueryHandlerTest.java
+++ b/aggregate-service/src/test/java/org/opentestsystem/rdw/olap/service/impl/TargetReportQueryHandlerTest.java
@@ -5,6 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
 import org.springframework.core.task.TaskExecutor;
 
 import org.opentestsystem.rdw.olap.model.AggregateReportQueryDescription;
@@ -59,11 +60,26 @@ public class TargetReportQueryHandlerTest extends AbstractAggregateQueryHandlerT
         queryConverter = mock(TargetQueryConverter.class);
         repository = mock(TargetReportRepository.class);
         subjectService = mock(SubjectService.class);
+
+
+
         when(subjectService.getSubjects()).thenReturn(newArrayList(
                 SubjectAssessment.builder().id(1).code("Math").assessmentType("sum").targetReport(true).build()
         ));
-        serviceUnderTest = new TargetReportQueryHandler(repository, authorizationService, aggregateReportingProperties, queryConverter, threadPoolTaskExecutor, subjectService, 0);
+        serviceUnderTest = new TargetReportQueryHandler(repository, authorizationService, aggregateReportingProperties,
+            queryConverter, threadPoolTaskExecutor, subjectService, mockReportingProperties(0));
         return serviceUnderTest;
+    }
+
+    private ReportingSystemProperties mockReportingProperties(final Integer minNumberOfStudents) {
+        final ReportingSystemProperties.TargetReportProperties targetReportProperties =
+            mock(ReportingSystemProperties.TargetReportProperties.class);
+        when(targetReportProperties.getMinNumberOfStudents()).thenReturn(minNumberOfStudents);
+
+        final ReportingSystemProperties reportingSystemProperties = mock(ReportingSystemProperties.class);
+        when(reportingSystemProperties.getTargetReport()).thenReturn(targetReportProperties);
+
+        return reportingSystemProperties;
     }
 
     @Override
@@ -247,7 +263,7 @@ public class TargetReportQueryHandlerTest extends AbstractAggregateQueryHandlerT
                 queryConverter,
                 queryPoolExecutor.threadPoolTaskExecutor(),
                 subjectService,
-                minNumberOfStudents);
+                mockReportingProperties(minNumberOfStudents));
 
         TargetReportResult reportResult = TargetReportResult.builder()
                 .row(AggregateTestUtils.targetRow(OrganizationType.School, -123L, Overall)

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemProperties.java
@@ -7,6 +7,9 @@ import org.opentestsystem.rdw.reporting.common.model.StudentFieldType;
 import java.util.List;
 import java.util.Map;
 
+import static org.opentestsystem.rdw.reporting.common.util.ObjectUtils.defaultIfNull;
+
+
 /**
  * Reporting configuration.
  */
@@ -166,6 +169,23 @@ public interface ReportingSystemProperties {
             this.code = code;
         }
 
+
+        /**
+         * Merge two objects using the values from this instance when non-null
+         * and otherwise the values from the other instance.
+         *
+         * @param other the other instance to merge to this one.
+         * @return a new instance containing the merged properties.
+         */
+        public StateProperties merge(final StateProperties other) {
+            StateProperties properties = new StateProperties();
+
+            properties.setCode(defaultIfNull(this.getCode(), other.getCode()));
+            properties.setName(defaultIfNull(this.getName(), other.getName()));
+
+            return properties;
+        }
+
         @Override
         public String toString() {
             return "StateProperties{" +
@@ -214,6 +234,24 @@ public interface ReportingSystemProperties {
 
         public void setMinNumberOfStudents(final Integer minNumberOfStudents) {
             this.minNumberOfStudents = minNumberOfStudents;
+        }
+
+        /**
+         * Merge two objects using the values from this instance when non-null
+         * and otherwise the values from the other instance.
+         *
+         * @param other the other instance to merge to this one.
+         * @return a new instance containing the merged properties.
+         */
+        public TargetReportProperties merge(TargetReportProperties other) {
+            TargetReportProperties properties = new TargetReportProperties();
+
+            properties.setMinNumberOfStudents(
+                defaultIfNull(this.getMinNumberOfStudents(), other.getMinNumberOfStudents()));
+            properties.setInsufficientDataCutoff(
+                defaultIfNull(this.getInsufficientDataCutoff(), other.getInsufficientDataCutoff()));
+
+            return properties;
         }
 
         @Override

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolver.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolver.java
@@ -7,6 +7,7 @@ import org.opentestsystem.rdw.reporting.common.model.StudentFieldType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,14 +20,14 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
     private final TenantKeyResolver tenantKeyResolver;
     private final ReportingSystemSettings reportingSystemSettings;
 
-    public ReportingSystemPropertiesResolver(TenantKeyResolver tenanKeyResolver,
+    public ReportingSystemPropertiesResolver(TenantKeyResolver tenantKeyResolver,
                                              ReportingSystemSettings reportingSystemSettings) {
-        this.tenantKeyResolver = tenanKeyResolver;
+        this.tenantKeyResolver = tenantKeyResolver;
         this.reportingSystemSettings = reportingSystemSettings;
         logger.debug("ReportingSystemSettings {}", reportingSystemSettings);
     }
 
-    private Optional<ReportingSystemProperties> getResolvedReportingSystemProperties() {
+    protected Optional<ReportingSystemProperties> getResolvedReportingSystemProperties() {
         return tenantKeyResolver.getTenantKey()
                 .flatMap(k -> Optional.ofNullable(reportingSystemSettings.getTenants().get(k)));
     }
@@ -113,7 +114,7 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
     @JsonView(ReportingSystemPropertiesJsonViews.Public.class)
     public StateProperties getState() {
         return getResolvedReportingSystemProperties()
-                .map(ReportingSystemProperties::getState)
+                .map(props -> props.getState().merge(reportingSystemSettings.getState()))
                 .orElse(reportingSystemSettings.getState());
     }
 
@@ -159,7 +160,7 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
     @JsonView(ReportingSystemPropertiesJsonViews.Public.class)
     public TargetReportProperties getTargetReport() {
         return getResolvedReportingSystemProperties()
-                .map(ReportingSystemProperties::getTargetReport)
+                .map(props -> props.getTargetReport().merge(reportingSystemSettings.getTargetReport()))
                 .orElse(reportingSystemSettings.getTargetReport());
     }
 
@@ -167,7 +168,7 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
     @JsonView(ReportingSystemPropertiesJsonViews.Public.class)
     public Map<StudentFieldType, SearchFieldPermissionLevel> getStudentFields() {
         return getResolvedReportingSystemProperties()
-                .map(ReportingSystemProperties::getStudentFields)
+                .map(props ->  mergeMap(props.getStudentFields(), reportingSystemSettings.getStudentFields()))
                 .orElse(reportingSystemSettings.getStudentFields());
     }
 
@@ -178,4 +179,18 @@ public class ReportingSystemPropertiesResolver implements ReportingSystemPropert
         return reportingSystemSettings.isTenantAdministrationDisabled();
     }
 
+    // Returned new map with base values, supplemented with defaults for any missing from base.
+    private <K, V> Map<K, V> mergeMap(Map<K, V> base, Map<K, V> defaults) {
+        if (base == null) {
+            return new HashMap<>(defaults);
+        } else if (defaults == null) {
+            return  new HashMap<>(base);
+        }
+
+        Map<K, V> merged = new HashMap<>(base);
+        defaults.forEach(
+            (key, value) -> merged.merge(key, value, (v1, v2) -> v1));
+
+        return merged;
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultUserStudentFieldService.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultUserStudentFieldService.java
@@ -31,20 +31,14 @@ public class DefaultUserStudentFieldService implements UserStudentFieldService {
             final SearchFieldPermissionLevel permissionLevel = reportingSystemProperties.getStudentFields().get(field);
 
             // Add the filter if
-            // 1. There is no entry in the reportingSystemProperties map
-            // (the default permission level is "everyone" except for ELAS)
+            // 1. There is no entry in the reportingSystemProperties map (the default permission level is "everyone")
             // 2. The permission level is explicitly set to enabled
             // 3. The permission level is set to admin and the user has individual PII read permission
-            // TODO - This hard-coded check of ELAS should be removed. It was added as a hotfix
-            // TODO   of a bug with how tenant configuration is saving student field overrides.
-            // TODO   Figure out what that issue is, resolve it, and revert this change.
-            if ((permissionLevel == null
-                    && !field.equals(StudentFieldType.EnglishLanguageAcquisitionStatus))
-            || permissionLevel == SearchFieldPermissionLevel.Enabled
-            || (
-                permissionLevel == SearchFieldPermissionLevel.Admin
-                && user.getPermissionsById().containsKey(ReportingPermission.IndividualPiiRead)
-            )) {
+            if (permissionLevel == null
+                || permissionLevel == SearchFieldPermissionLevel.Enabled
+                || ( permissionLevel == SearchFieldPermissionLevel.Admin
+                    && user.getPermissionsById().containsKey(ReportingPermission.IndividualPiiRead)
+                )) {
                 fields.add(field);
             }
         }

--- a/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/ObjectUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/reporting/common/util/ObjectUtils.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.reporting.common.util;
+
+/**
+ * ObjectUtils re-implements some methods of {@link org.apache.commons.lang.ObjectUtils} using generics.
+ */
+public class ObjectUtils {
+    public static <T> T defaultIfNull(T object, T defaultValue) {
+        return object != null ? object : defaultValue;
+    }
+
+    public static <T extends Comparable<T>> T min(T  c1, T  c2) {
+        return org.apache.commons.lang.ObjectUtils.compare(c1, c2, true) <= 0 ? c1 : c2;
+    }
+
+    public static <T extends Comparable<T>> T max(T c1, T c2) {
+        return org.apache.commons.lang.ObjectUtils.compare(c1, c2, false) >= 0 ? c1 : c2;
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolverTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/configuration/ReportingSystemPropertiesResolverTest.java
@@ -1,0 +1,154 @@
+package org.opentestsystem.rdw.reporting.common.configuration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.multitenant.TenantKeyResolver;
+import org.opentestsystem.rdw.reporting.common.model.SearchFieldPermissionLevel;
+import org.opentestsystem.rdw.reporting.common.model.StudentFieldType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *  Test for substructures of the reporting system properties. Only modified tenant properties are saved, so
+ *  retrieving the tenant properties for these substructures only populates the modified elements. The
+ *  properties resolver must explicitly merge the tenant properties with the system defaults in this case.
+ */
+public class ReportingSystemPropertiesResolverTest {
+    // Class under test.
+    private ReportingSystemPropertiesResolver reportingSystemPropertiesResolver;
+
+    private ReportingSystemSettings defaultProperties;
+    private ReportingSystemProperties tenantProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        TenantKeyResolver keyResolver = mock(TenantKeyResolver.class);
+        defaultProperties = mock(ReportingSystemSettings.class);
+        tenantProperties = mock(ReportingSystemProperties.class);
+
+        reportingSystemPropertiesResolver = new ReportingSystemPropertiesResolver(keyResolver, defaultProperties) {
+            @Override
+            protected Optional<ReportingSystemProperties> getResolvedReportingSystemProperties() {
+                return Optional.of(tenantProperties);
+            }
+        };
+    }
+
+    @Test
+    public void getState() {
+        ReportingSystemProperties.StateProperties results;
+
+        ReportingSystemProperties.StateProperties defaultTenant = new ReportingSystemProperties.StateProperties();
+        defaultTenant.setCode("CA");
+        defaultTenant.setName("California");
+
+        ReportingSystemProperties.StateProperties otherTenant = new ReportingSystemProperties.StateProperties();
+        otherTenant.setCode("NV");
+        otherTenant.setName("Nevada");
+
+        ReportingSystemProperties.StateProperties otherTenant2 = new ReportingSystemProperties.StateProperties();
+        otherTenant2.setCode("CA2");
+
+        when(defaultProperties.getState()).thenReturn(defaultTenant);
+
+        // When no tenant properties, expect defaults.
+        when(tenantProperties.getState()).thenReturn(new ReportingSystemProperties.StateProperties());
+        results = reportingSystemPropertiesResolver.getState();
+        assertThat(results.getCode()).isEqualTo(defaultTenant.getCode());
+        assertThat(results.getName()).isEqualTo(defaultTenant.getName());
+
+        // When complete set tenant properties, expect them.
+        when(tenantProperties.getState()).thenReturn(otherTenant);
+        results = reportingSystemPropertiesResolver.getState();
+        assertThat(results.getCode()).isEqualTo(otherTenant.getCode());
+        assertThat(results.getName()).isEqualTo(otherTenant.getName());
+
+        // When partial set of tenant properties, expect a blend.
+        when(tenantProperties.getState()).thenReturn(otherTenant2);
+        results = reportingSystemPropertiesResolver.getState();
+        assertThat(results.getCode()).isEqualTo(otherTenant2.getCode());
+        assertThat(results.getName()).isEqualTo(defaultTenant.getName());
+    }
+
+    @Test
+    public void getTargetReport() {
+        ReportingSystemProperties.TargetReportProperties results;
+
+        ReportingSystemProperties.TargetReportProperties defaultTenant =
+            new ReportingSystemProperties.TargetReportProperties();
+        defaultTenant.setInsufficientDataCutoff(0.2);
+        defaultTenant.setMinNumberOfStudents(20);
+
+        ReportingSystemProperties.TargetReportProperties otherTenant =
+            new ReportingSystemProperties.TargetReportProperties();
+        otherTenant.setInsufficientDataCutoff(0.1);
+        otherTenant.setMinNumberOfStudents(10);
+
+        ReportingSystemProperties.TargetReportProperties otherTenant2 =
+            new ReportingSystemProperties.TargetReportProperties();
+        otherTenant2.setMinNumberOfStudents(50);
+
+        when(defaultProperties.getTargetReport()).thenReturn(defaultTenant);
+
+        // When no tenant properties, expect defaults.
+        when(tenantProperties.getTargetReport()).thenReturn(new ReportingSystemProperties.TargetReportProperties());
+        results = reportingSystemPropertiesResolver.getTargetReport();
+        assertThat(results.getInsufficientDataCutoff()).isEqualTo(defaultTenant.getInsufficientDataCutoff());
+        assertThat(results.getMinNumberOfStudents()).isEqualTo(defaultTenant.getMinNumberOfStudents());
+
+        // When complete set tenant properties, expect them.
+        when(tenantProperties.getTargetReport()).thenReturn(otherTenant);
+        results = reportingSystemPropertiesResolver.getTargetReport();
+        assertThat(results.getInsufficientDataCutoff()).isEqualTo(otherTenant.getInsufficientDataCutoff());
+        assertThat(results.getMinNumberOfStudents()).isEqualTo(otherTenant.getMinNumberOfStudents());
+
+        // When partial set of tenant properties, expect a blend.
+        when(tenantProperties.getTargetReport()).thenReturn(otherTenant2);
+        results = reportingSystemPropertiesResolver.getTargetReport();
+        assertThat(results.getInsufficientDataCutoff()).isEqualTo(defaultTenant.getInsufficientDataCutoff());
+        assertThat(results.getMinNumberOfStudents()).isEqualTo(otherTenant2.getMinNumberOfStudents());
+    }
+
+    @Test
+    public void getStudentFields() {
+        Map<StudentFieldType, SearchFieldPermissionLevel> results;
+
+        Map<StudentFieldType, SearchFieldPermissionLevel> defaultTenant =
+            Arrays.stream(StudentFieldType.values())
+                .collect(toMap(type -> type, type -> SearchFieldPermissionLevel.Disabled));
+
+        List<StudentFieldType> enabledList = Arrays
+            .asList(StudentFieldType.EnglishLanguageAcquisitionStatus, StudentFieldType.Gender);
+
+        Map<StudentFieldType, SearchFieldPermissionLevel> otherTenant =
+            enabledList.stream()
+                .collect(toMap(type -> type, type -> SearchFieldPermissionLevel.Enabled));
+
+        when(defaultProperties.getStudentFields()).thenReturn(defaultTenant);
+
+        // When no tenant properties, expect defaults.
+        when(tenantProperties.getStudentFields()).thenReturn(Collections.emptyMap());
+        results = reportingSystemPropertiesResolver.getStudentFields();
+        for (StudentFieldType type : StudentFieldType.values()) {
+           assertThat(results.get(type)).isEqualTo(SearchFieldPermissionLevel.Disabled);
+        }
+
+        // When partial set of tenant properties, expect a blend.
+        when(tenantProperties.getStudentFields()).thenReturn(otherTenant);
+        results = reportingSystemPropertiesResolver.getStudentFields();
+        for (StudentFieldType type : StudentFieldType.values()) {
+            SearchFieldPermissionLevel expectedLevel = enabledList.contains(type) ?
+                SearchFieldPermissionLevel.Enabled : SearchFieldPermissionLevel.Disabled;
+            assertThat(results.get(type)).isEqualTo(expectedLevel);
+        }
+    }
+}

--- a/common/src/test/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultUserStudentFieldServiceTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/reporting/common/service/impl/DefaultUserStudentFieldServiceTest.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.reporting.common.model.StudentFieldType.EconomicDisadvantage;
+import static org.opentestsystem.rdw.reporting.common.model.StudentFieldType.EnglishLanguageAcquisitionStatus;
 import static org.opentestsystem.rdw.reporting.common.model.StudentFieldType.Ethnicity;
 import static org.opentestsystem.rdw.reporting.common.model.StudentFieldType.Gender;
 import static org.opentestsystem.rdw.reporting.common.model.StudentFieldType.IndividualEducationPlan;
@@ -69,7 +70,9 @@ public class DefaultUserStudentFieldServiceTest {
 
     @Before
     public void before() {
-        when(reportingSystemProperties.getStudentFields()).thenReturn(ImmutableMap.of());
+        // ELAS is disabled by default in system properties.
+        when(reportingSystemProperties.getStudentFields()).thenReturn(ImmutableMap.of(
+            EnglishLanguageAcquisitionStatus, SearchFieldPermissionLevel.Disabled));
 
         this.studentFieldTypes = ImmutableList.of(
                 EconomicDisadvantage,
@@ -111,6 +114,7 @@ public class DefaultUserStudentFieldServiceTest {
     @Test
     public void itShouldNotFilterOutAdminFieldsWhenSetToEnabled() {
         when(reportingSystemProperties.getStudentFields()).thenReturn(ImmutableMap.of(
+                EnglishLanguageAcquisitionStatus, SearchFieldPermissionLevel.Disabled,
                 Gender, SearchFieldPermissionLevel.Enabled
         ));
 
@@ -130,7 +134,8 @@ public class DefaultUserStudentFieldServiceTest {
     @Test
     public void itShouldFilterOutAdminFieldsForTeachers() {
         when(reportingSystemProperties.getStudentFields()).thenReturn(ImmutableMap.of(
-                Gender, SearchFieldPermissionLevel.Admin
+            EnglishLanguageAcquisitionStatus, SearchFieldPermissionLevel.Disabled,
+            Gender, SearchFieldPermissionLevel.Admin
         ));
 
         final List<StudentFieldType> expected = studentFieldTypes.stream()
@@ -153,7 +158,8 @@ public class DefaultUserStudentFieldServiceTest {
     @Test
     public void itShouldFilterOutDisabledFieldsForEveryone() {
         when(reportingSystemProperties.getStudentFields()).thenReturn(ImmutableMap.of(
-                Gender, SearchFieldPermissionLevel.Disabled
+            EnglishLanguageAcquisitionStatus, SearchFieldPermissionLevel.Disabled,
+            Gender, SearchFieldPermissionLevel.Disabled
         ));
 
         final List<StudentFieldType> expected = studentFieldTypes.stream()

--- a/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/reporting/web/ViewController.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.rdw.reporting.web;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.opentestsystem.rdw.reporting.common.configuration.ReportingSystemProperties;
+import org.opentestsystem.rdw.reporting.common.security.User;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import org.opentestsystem.rdw.reporting.common.security.User;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -14,15 +14,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class ViewController implements ErrorController {
 
     private static final String Index = "forward:/index.html";
+    private final ReportingSystemProperties reportingSystemProperties;
 
-    @Value("${reporting.access-denied-url:}")
-    private String accessDeniedUrl;
+    public ViewController(
+        @Qualifier("reportingSystemPropertiesResolver") final ReportingSystemProperties reportingSystemProperties) {
 
-    @Value("${reporting.landing-page-url:}")
-    private String landingPageUrl;
-
-    @Value("${reporting.logout-redirect-url:}")
-    private String logoutRedirectUrl;
+        this.reportingSystemProperties = reportingSystemProperties;
+    }
 
     /**
      * Public routes
@@ -39,8 +37,9 @@ public class ViewController implements ErrorController {
 
     @RequestMapping("/access-denied")
     public String accessDenied() {
-        if (!isBlank(this.accessDeniedUrl)) {
-            return this.accessDeniedUrl;
+        final String accessDeniedUrl = this.reportingSystemProperties.getAccessDeniedUrl();
+        if (!isBlank(accessDeniedUrl)) {
+            return accessDeniedUrl;
         }
         return Index;
     }
@@ -55,8 +54,9 @@ public class ViewController implements ErrorController {
 
     @RequestMapping("/")
     public String index(@AuthenticationPrincipal final User user) {
-        if (user == null && !isBlank(this.landingPageUrl)) {
-            return this.landingPageUrl;
+        final String landingPageUrl = this.reportingSystemProperties.getLandingPageUrl();
+        if (user == null && !isBlank(landingPageUrl)) {
+            return landingPageUrl;
         }
         return Index;
     }


### PR DESCRIPTION
Several flaws with loading tenant properties were uncovered and fixed. The target report threshold is one of them. See all SRS-171.